### PR TITLE
Add debug visualisation for segment tracker

### DIFF
--- a/lib/presentation/pages/map/segment_debugger.dart
+++ b/lib/presentation/pages/map/segment_debugger.dart
@@ -6,6 +6,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/core/spatial/segment_geometry.dart';
 import 'package:toll_cam_finder/features/segemnt_index_service.dart';
+import 'package:toll_cam_finder/services/segment_tracker.dart';
 
 /// Wraps the segment index to keep debugging logic out of the page widget.
 class SegmentDebugger {
@@ -16,11 +17,13 @@ class SegmentDebugger {
   bool _segmentsReady = false;
   List<SegmentGeometry> _debugCandidates = const [];
   List<LatLng> _debugQuerySquare = const [];
+  SegmentTrackerDebugSnapshot? _trackerSnapshot;
   DateTime? _lastLog;
 
   bool get isReady => _segmentsReady;
   List<SegmentGeometry> get candidates => _debugCandidates;
   List<LatLng> get querySquare => _debugQuerySquare;
+  SegmentTrackerDebugSnapshot? get trackerSnapshot => _trackerSnapshot;
 
   Future<bool> initialise({required String assetPath}) async {
     await _index.tryLoadFromDefaultAsset(assetPath: assetPath);
@@ -59,6 +62,10 @@ class SegmentDebugger {
       );
       _lastLog = now;
     }
+  }
+
+  void updateTrackerSnapshot(SegmentTrackerDebugSnapshot snapshot) {
+    _trackerSnapshot = snapshot;
   }
 
   List<LatLng> _computeQuerySquare(LatLng c, double radiusMeters) {

--- a/lib/presentation/pages/map/widgets/segment_debug_styles.dart
+++ b/lib/presentation/pages/map/widgets/segment_debug_styles.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:toll_cam_finder/services/segment_tracker.dart';
+
+class SegmentDebugStyles {
+  const SegmentDebugStyles._();
+
+  static Color colorForMatch(
+    SegmentTrackerDebugMatch match, {
+    required bool isActive,
+  }) {
+    if (isActive) {
+      return Colors.greenAccent;
+    }
+    if (match.isBestCandidate) {
+      return Colors.lightGreenAccent;
+    }
+    if (match.isOnSegment) {
+      if (match.geofenceHit && (!match.onPath || !match.directionOk)) {
+        return Colors.cyanAccent;
+      }
+      return Colors.blueAccent;
+    }
+    if (!match.onPath) {
+      return Colors.redAccent;
+    }
+    if (!match.directionOk) {
+      return Colors.orangeAccent;
+    }
+    return Colors.purpleAccent;
+  }
+
+  static double strokeWidthForMatch(
+    SegmentTrackerDebugMatch match, {
+    required bool isActive,
+  }) {
+    if (isActive) {
+      return 6.0;
+    }
+    if (match.isBestCandidate) {
+      return 5.0;
+    }
+    if (match.isOnSegment) {
+      return 4.0;
+    }
+    return 3.0;
+  }
+
+  static List<SegmentDebugFlag> flagsForMatch(
+    SegmentTrackerDebugMatch match,
+  ) {
+    final flags = <SegmentDebugFlag>[
+      SegmentDebugFlag(
+        match.onPath ? 'path✓' : 'path✗',
+        match.onPath ? Colors.greenAccent : Colors.redAccent,
+      ),
+    ];
+
+    if (match.directionDeltaDeg != null) {
+      flags.add(
+        SegmentDebugFlag(
+          match.directionOk ? 'bearing✓' : 'bearing✗',
+          match.directionOk ? Colors.greenAccent : Colors.orangeAccent,
+        ),
+      );
+    } else {
+      flags.add(
+        const SegmentDebugFlag('bearing–', Colors.blueGrey),
+      );
+    }
+
+    if (match.geofenceHit) {
+      flags.add(
+        const SegmentDebugFlag('geofence', Colors.cyanAccent),
+      );
+    }
+
+    if (match.isBestCandidate) {
+      flags.add(
+        const SegmentDebugFlag('best', Colors.amberAccent),
+      );
+    } else if (match.isOnSegment) {
+      flags.add(
+        const SegmentDebugFlag('eligible', Colors.lightBlueAccent),
+      );
+    }
+
+    return flags;
+  }
+}
+
+class SegmentDebugFlag {
+  final String label;
+  final Color color;
+
+  const SegmentDebugFlag(this.label, this.color);
+}

--- a/lib/presentation/pages/map/widgets/segment_overlays.dart
+++ b/lib/presentation/pages/map/widgets/segment_overlays.dart
@@ -2,7 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
+import 'package:toll_cam_finder/core/spatial/geo.dart';
 import 'package:toll_cam_finder/core/spatial/segment_geometry.dart';
+import 'package:toll_cam_finder/services/segment_tracker.dart';
+
+import 'segment_debug_styles.dart';
 
 class QuerySquareOverlay extends StatelessWidget {
   const QuerySquareOverlay({
@@ -57,5 +61,120 @@ class CandidateBoundsOverlay extends StatelessWidget {
     }).toList();
 
     return PolygonLayer(polygons: polygons);
+  }
+}
+
+class SegmentTrackerOverlay extends StatelessWidget {
+  const SegmentTrackerOverlay({
+    super.key,
+    required this.snapshot,
+    required this.startGeofenceRadiusMeters,
+  });
+
+  final SegmentTrackerDebugSnapshot snapshot;
+  final double startGeofenceRadiusMeters;
+
+  @override
+  Widget build(BuildContext context) {
+    final polylines = <Polyline>[];
+    final circles = <CircleMarker>[];
+
+    SegmentTrackerDebugMatch? bestMatch;
+    for (final match in snapshot.matches) {
+      final points = _toLatLng(match.segment.path);
+      if (points.length < 2) continue;
+      final isActive = snapshot.activeSegment?.id == match.segment.id;
+      final color = SegmentDebugStyles.colorForMatch(match, isActive: isActive);
+      final stroke = SegmentDebugStyles.strokeWidthForMatch(match, isActive: isActive);
+      polylines.add(
+        Polyline(
+          points: points,
+          strokeWidth: stroke,
+          color: color.withOpacity(isActive || match.isBestCandidate ? 0.95 : 0.6),
+          isDotted: !match.onPath && !match.geofenceHit,
+        ),
+      );
+      if (match.isBestCandidate) {
+        bestMatch = match;
+      }
+    }
+
+    final activeSegment = snapshot.activeSegment;
+    if (activeSegment != null &&
+        !snapshot.matches.any((m) => m.segment.id == activeSegment.id)) {
+      final points = _toLatLng(activeSegment.path);
+      if (points.length >= 2) {
+        polylines.add(
+          Polyline(
+            points: points,
+            strokeWidth: 6,
+            color: Colors.greenAccent.withOpacity(0.9),
+          ),
+        );
+      }
+    }
+
+    final exited = snapshot.exitedSegment;
+    if (exited != null) {
+      final points = _toLatLng(exited.path);
+      if (points.length >= 2) {
+        polylines.add(
+          Polyline(
+            points: points,
+            strokeWidth: 4,
+            isDotted: true,
+            color: Colors.redAccent.withOpacity(0.65),
+          ),
+        );
+      }
+    }
+
+    final drawnCircles = <String>{};
+    void addCircle(SegmentGeometry segment, Color color, double fillOpacity) {
+      if (drawnCircles.contains(segment.id)) return;
+      drawnCircles.add(segment.id);
+      final start = segment.path.first;
+      circles.add(
+        CircleMarker(
+          point: LatLng(start.lat, start.lon),
+          radius: startGeofenceRadiusMeters,
+          useRadiusInMeter: true,
+          color: color.withOpacity(fillOpacity),
+          borderColor: color.withOpacity(0.85),
+          borderStrokeWidth: 1.5,
+        ),
+      );
+    }
+
+    if (activeSegment != null) {
+      addCircle(activeSegment, Colors.greenAccent, 0.08);
+    }
+
+    if (bestMatch != null &&
+        (activeSegment == null || activeSegment.id != bestMatch.segment.id)) {
+      addCircle(bestMatch.segment, Colors.blueAccent, 0.08);
+    }
+
+    if (exited != null) {
+      addCircle(exited, Colors.redAccent, 0.05);
+    }
+
+    final layers = <Widget>[];
+    if (polylines.isNotEmpty) {
+      layers.add(PolylineLayer(polylines: polylines));
+    }
+    if (circles.isNotEmpty) {
+      layers.add(CircleLayer(circles: circles));
+    }
+
+    if (layers.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Stack(children: layers);
+  }
+
+  List<LatLng> _toLatLng(List<GeoPoint> path) {
+    return path.map((p) => LatLng(p.lat, p.lon)).toList(growable: false);
   }
 }

--- a/lib/presentation/pages/map/widgets/segment_tracker_debug_panel.dart
+++ b/lib/presentation/pages/map/widgets/segment_tracker_debug_panel.dart
@@ -1,0 +1,267 @@
+import 'package:flutter/material.dart';
+import 'package:toll_cam_finder/services/segment_tracker.dart';
+
+import 'segment_debug_styles.dart';
+
+class SegmentTrackerDebugPanel extends StatelessWidget {
+  const SegmentTrackerDebugPanel({
+    super.key,
+    required this.snapshot,
+    required this.distanceThresholdMeters,
+    required this.startGeofenceRadiusMeters,
+  });
+
+  final SegmentTrackerDebugSnapshot snapshot;
+  final double distanceThresholdMeters;
+  final double startGeofenceRadiusMeters;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final titleStyle = theme.textTheme.labelLarge?.copyWith(
+      color: Colors.white,
+      fontWeight: FontWeight.w600,
+    );
+    final infoStyle = theme.textTheme.bodySmall?.copyWith(
+      color: Colors.white70,
+    );
+
+    final matches = [...snapshot.matches]
+      ..sort((a, b) {
+        if (a.isBestCandidate != b.isBestCandidate) {
+          return a.isBestCandidate ? -1 : 1;
+        }
+        final activeId = snapshot.activeSegment?.id;
+        if (activeId != null) {
+          final aIsActive = a.segment.id == activeId;
+          final bIsActive = b.segment.id == activeId;
+          if (aIsActive != bIsActive) {
+            return aIsActive ? -1 : 1;
+          }
+        }
+        return a.distanceMeters.compareTo(b.distanceMeters);
+      });
+
+    final topMatches = matches.take(4).toList();
+
+    final entered = snapshot.enteredSegment;
+    final exited = snapshot.exitedSegment;
+
+    return Card(
+      color: Colors.black87.withOpacity(0.75),
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 320),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Segment tracker', style: titleStyle),
+              const SizedBox(height: 4),
+              _StatusLine(
+                label: 'Active',
+                value: snapshot.activeSegment?.id ?? 'none',
+                color: snapshot.activeSegment != null
+                    ? Colors.greenAccent
+                    : Colors.white54,
+              ),
+              if (entered != null)
+                _StatusLine(
+                  label: 'Entered',
+                  value: entered.id,
+                  color: Colors.greenAccent,
+                ),
+              if (exited != null)
+                _StatusLine(
+                  label: 'Exited',
+                  value: exited.id,
+                  color: Colors.redAccent,
+                ),
+              if (snapshot.distanceToActiveMeters != null)
+                Text(
+                  '⊥ distance: ${snapshot.distanceToActiveMeters!.toStringAsFixed(1)} m',
+                  style: infoStyle,
+                ),
+              if (snapshot.startDistanceToActiveMeters != null)
+                Text(
+                  'Start distance: ${snapshot.startDistanceToActiveMeters!.toStringAsFixed(1)} m',
+                  style: infoStyle,
+                ),
+              if (topMatches.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                Divider(color: Colors.white24, height: 1),
+                const SizedBox(height: 12),
+                for (var i = 0; i < topMatches.length; i++) ...[
+                  _MatchRow(
+                    match: topMatches[i],
+                    isActive:
+                        snapshot.activeSegment?.id == topMatches[i].segment.id,
+                  ),
+                  if (i != topMatches.length - 1) const SizedBox(height: 10),
+                ],
+              ] else ...[
+                const SizedBox(height: 12),
+                Text('No segment candidates in radius', style: infoStyle),
+              ],
+              const SizedBox(height: 8),
+              Text(
+                'distance≤${distanceThresholdMeters.toStringAsFixed(0)} m · '
+                'start≤${startGeofenceRadiusMeters.toStringAsFixed(0)} m',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: Colors.white38,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusLine extends StatelessWidget {
+  const _StatusLine({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: Colors.white70,
+        );
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 70,
+            child: Text('$label:', style: style),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: style?.copyWith(
+                color: color,
+                fontWeight: FontWeight.w600,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MatchRow extends StatelessWidget {
+  const _MatchRow({
+    required this.match,
+    required this.isActive,
+  });
+
+  final SegmentTrackerDebugMatch match;
+  final bool isActive;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = SegmentDebugStyles.colorForMatch(match, isActive: isActive);
+    final textStyle = theme.textTheme.bodySmall?.copyWith(
+      color: Colors.white,
+      fontWeight: isActive || match.isBestCandidate
+          ? FontWeight.w600
+          : FontWeight.w500,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Container(
+              width: 10,
+              height: 10,
+              decoration: BoxDecoration(
+                color: color,
+                borderRadius: BorderRadius.circular(3),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                match.segment.id,
+                style: textStyle,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            if (match.directionDeltaDeg != null) ...[
+              Text(
+                'Δ ${match.directionDeltaDeg!.toStringAsFixed(0)}°',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: match.directionOk
+                      ? Colors.white70
+                      : Colors.orangeAccent,
+                ),
+              ),
+              const SizedBox(width: 8),
+            ],
+            Text(
+              '${match.distanceMeters.toStringAsFixed(1)} m',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: Colors.white70,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Wrap(
+          spacing: 4,
+          runSpacing: 2,
+          children: [
+            for (final flag in SegmentDebugStyles.flagsForMatch(match))
+              _DebugChip(flag: flag),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _DebugChip extends StatelessWidget {
+  const _DebugChip({required this.flag});
+
+  final SegmentDebugFlag flag;
+
+  @override
+  Widget build(BuildContext context) {
+    final background = flag.color.withOpacity(0.18);
+    final border = flag.color.withOpacity(0.8);
+    final textColor = flag.color.computeLuminance() > 0.55
+        ? Colors.black87
+        : Colors.white;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: border, width: 0.8),
+      ),
+      child: Text(
+        flag.label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: textColor,
+              fontSize: 11,
+            ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/map_page.dart
+++ b/lib/presentation/pages/map_page.dart
@@ -25,6 +25,7 @@ import 'map/toll_camera_controller.dart';
 import 'map/widgets/map_controls_panel.dart';
 import 'map/widgets/map_fab_column.dart';
 import 'map/widgets/segment_overlays.dart';
+import 'map/widgets/segment_tracker_debug_panel.dart';
 
 class MapPage extends StatefulWidget {
   const MapPage({super.key});
@@ -65,6 +66,8 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
     candidateRadiusMeters: AppConstants.candidateRadiusMeters,
     onSegmentEntered: _onSegmentEntered,
     onSegmentExited: _onSegmentExited,
+    onDebugSnapshot:
+        kDebugMode ? _segmentDebugger.updateTrackerSnapshot : null,
   );
 
   double? _speedKmh;
@@ -348,6 +351,12 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
                 QuerySquareOverlay(points: _segmentDebugger.querySquare),
               if (kDebugMode && _segmentDebugger.candidates.isNotEmpty)
                 CandidateBoundsOverlay(candidates: _segmentDebugger.candidates),
+              if (kDebugMode && _segmentDebugger.trackerSnapshot != null)
+                SegmentTrackerOverlay(
+                  snapshot: _segmentDebugger.trackerSnapshot!,
+                  startGeofenceRadiusMeters:
+                      _segmentTracker.startGeofenceRadiusMeters,
+                ),
               TollCamerasOverlay(cameras: cameraState),
             ],
           ),
@@ -363,6 +372,20 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
               ),
             ),
           ),
+          if (kDebugMode && _segmentDebugger.trackerSnapshot != null)
+            Positioned(
+              top: 16,
+              right: 16,
+              child: SafeArea(
+                child: SegmentTrackerDebugPanel(
+                  snapshot: _segmentDebugger.trackerSnapshot!,
+                  distanceThresholdMeters:
+                      _segmentTracker.distanceThresholdMeters,
+                  startGeofenceRadiusMeters:
+                      _segmentTracker.startGeofenceRadiusMeters,
+                ),
+              ),
+            ),
         ],
       ),
 


### PR DESCRIPTION
## Summary
- capture segment tracker evaluation details and publish debug snapshots
- extend the map debugger to visualise active/best candidates and geofence ranges
- add an on-map overlay and debug panel (debug-only) to inspect segment matching decisions

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfb75a8ea4832d8d6363e11c7a41e0