### PR TITLE
Add segment index unit tests

### DIFF
--- a/lib/features/segemnt_index_service.dart
+++ b/lib/features/segemnt_index_service.dart
@@ -26,6 +26,11 @@ class SegmentIndexService {
     _index = SegmentSpatialIndex.build(segments);
   }
 
+  @visibleForTesting
+  void resetForTest() {
+    _index = null;
+  }
+
   /// Tries to load from [assetPath]:
   /// - If it's a JSON array: [{id, points:[{lat,lon},...], length_m?}, ...]
   /// - Else, if it's a GeoJSON FeatureCollection with LineString/MultiLineString.
@@ -193,4 +198,13 @@ class SegmentIndexService {
         .map((g) => g.id)
         .toList(growable: false);
   }
+
+  @visibleForTesting
+  List<SegmentGeometry> parsePlainArrayForTest(List list) => _parsePlainArray(list);
+
+  @visibleForTesting
+  List<SegmentGeometry> parseGeoJsonForTest(Map<String, dynamic> fc) => _parseGeoJson(fc);
+
+  @visibleForTesting
+  List<GeoPoint> toGeoPointsFromLonLatListForTest(List coords) => _toGeoPointsFromLonLatList(coords);
 }

--- a/test/core/spatial/segment_spatial_index_test.dart
+++ b/test/core/spatial/segment_spatial_index_test.dart
@@ -1,0 +1,91 @@
+import 'package:test/test.dart';
+import 'package:toll_cam_finder/core/spatial/geo.dart';
+import 'package:toll_cam_finder/core/spatial/segment_geometry.dart';
+import 'package:toll_cam_finder/core/spatial/segment_spatial_index.dart';
+
+void main() {
+  group('Geo utilities', () {
+    test('GeoBounds.around produces finite extents near the poles', () {
+      final bounds = GeoBounds.around(const GeoPoint(89.9999, 45), 1000);
+      expect(bounds.minLon.isFinite, isTrue, reason: 'Longitude range should be clamped to finite values.');
+      expect(bounds.maxLon.isFinite, isTrue);
+      expect(bounds.maxLat, greaterThan(bounds.minLat));
+      expect(bounds.maxLon, greaterThan(bounds.minLon));
+    });
+
+    test('SegmentGeometry.bounds returns tight bounding box for a path', () {
+      final geometry = SegmentGeometry(
+        id: 'segment',
+        path: const [
+          GeoPoint(10, 20),
+          GeoPoint(12, 25),
+          GeoPoint(9, 27),
+        ],
+      );
+
+      final bounds = geometry.bounds;
+      expect(bounds.minLat, 9);
+      expect(bounds.maxLat, 12);
+      expect(bounds.minLon, 20);
+      expect(bounds.maxLon, 27);
+    });
+  });
+
+  group('SegmentSpatialIndex', () {
+    test('candidatesNear returns segments with bounding boxes intersecting the search window', () {
+      final index = SegmentSpatialIndex.build([
+        SegmentGeometry(
+          id: 'north',
+          path: const [
+            GeoPoint(0.01, 0),
+            GeoPoint(0.02, 0),
+          ],
+        ),
+        SegmentGeometry(
+          id: 'east',
+          path: const [
+            GeoPoint(0, 0.015),
+            GeoPoint(0, 0.02),
+          ],
+        ),
+        SegmentGeometry(
+          id: 'far',
+          path: const [
+            GeoPoint(1, 1),
+            GeoPoint(1.1, 1.1),
+          ],
+        ),
+      ]);
+
+      final hits = index.candidatesNear(const GeoPoint(0, 0), radiusMeters: 2000);
+      final hitIds = hits.map((g) => g.id).toSet();
+
+      expect(hitIds, containsAll(<String>{'north', 'east'}));
+      expect(hitIds, isNot(contains('far')));
+    });
+
+    test('candidatesNear honours zero radius by matching only overlapping bounding boxes', () {
+      final boundaryPoint = const GeoPoint(0, 0.001);
+      final index = SegmentSpatialIndex.build([
+        SegmentGeometry(
+          id: 'touching',
+          path: const [
+            GeoPoint(0, 0.001),
+            GeoPoint(0, 0.0015),
+          ],
+        ),
+        SegmentGeometry(
+          id: 'disjoint',
+          path: const [
+            GeoPoint(0, 0.01),
+            GeoPoint(0, 0.02),
+          ],
+        ),
+      ]);
+
+      final hits = index.candidatesNear(boundaryPoint, radiusMeters: 0);
+      expect(hits.map((g) => g.id), contains('touching'));
+      expect(hits.map((g) => g.id), isNot(contains('disjoint')));
+    });
+  });
+}

--- a/test/features/segment_index_service_test.dart
+++ b/test/features/segment_index_service_test.dart
@@ -1,0 +1,172 @@
+import 'package:latlong2/latlong.dart';
+import 'package:test/test.dart';
+import 'package:toll_cam_finder/core/spatial/geo.dart';
+import 'package:toll_cam_finder/core/spatial/segment_geometry.dart';
+import 'package:toll_cam_finder/features/segemnt_index_service.dart';
+
+void main() {
+  final service = SegmentIndexService.instance;
+
+  setUp(() {
+    service.resetForTest();
+  });
+
+  group('SegmentIndexService parsing helpers', () {
+    test('parsePlainArrayForTest parses point arrays and start/end fallbacks', () {
+      final segments = service.parsePlainArrayForTest([
+        {
+          'id': 'with-points',
+          'points': [
+            {'lat': 10, 'lon': 20},
+            {'lat': 11, 'lng': 21},
+          ],
+          'length_m': 42.5,
+        },
+        {
+          'id': 'with-start-end',
+          'start': {'lat': 0, 'lon': 0},
+          'end': {'lat': 0.5, 'lng': 1},
+        },
+        {
+          'id': 'no-geometry',
+        },
+      ]);
+
+      expect(segments, hasLength(2), reason: 'Entries missing geometry should be skipped.');
+
+      final withPoints =
+          segments.firstWhere((seg) => seg.id == 'with-points', orElse: () => throw StateError('Segment not parsed.'));
+      expect(withPoints.path, hasLength(2), reason: 'Both coordinates should be preserved.');
+      expect(withPoints.path.first, predicate<GeoPoint>((p) => p.lat == 10 && p.lon == 20));
+      expect(withPoints.path.last, predicate<GeoPoint>((p) => p.lat == 11 && p.lon == 21),
+          reason: 'The parser must accept lng as an alias for lon.');
+      expect(withPoints.lengthMeters, closeTo(42.5, 1e-9));
+
+      final startEnd =
+          segments.firstWhere((seg) => seg.id == 'with-start-end', orElse: () => throw StateError('Segment not parsed.'));
+      expect(startEnd.path.first, predicate<GeoPoint>((p) => p.lat == 0 && p.lon == 0));
+      expect(startEnd.path.last, predicate<GeoPoint>((p) => p.lat == 0.5 && p.lon == 1));
+      expect(startEnd.lengthMeters, isNull, reason: 'Length is optional and defaults to null.');
+    });
+
+    test('parseGeoJsonForTest flattens MultiLineString and skips unsupported geometry', () {
+      final featureCollection = {
+        'type': 'FeatureCollection',
+        'features': [
+          {
+            'type': 'Feature',
+            'properties': {'segment_id': 'line-string', 'length_m': 123},
+            'geometry': {
+              'type': 'LineString',
+              'coordinates': [
+                [100.0, 0.0],
+                [100.001, 0.001],
+              ],
+            },
+          },
+          {
+            'type': 'Feature',
+            'properties': {'segment_id': 'multi'},
+            'geometry': {
+              'type': 'MultiLineString',
+              'coordinates': [
+                [
+                  [110.0, 1.0],
+                  [110.0005, 1.0005],
+                ],
+                [
+                  [110.001, 1.001],
+                  [110.0015, 1.0015],
+                ],
+              ],
+            },
+          },
+          {
+            'type': 'Feature',
+            'properties': {'segment_id': 'skip-me'},
+            'geometry': {
+              'type': 'Polygon',
+            },
+          },
+          {
+            'type': 'Feature',
+            'properties': {'segment_id': 'degenerate'},
+            'geometry': {
+              'type': 'LineString',
+              'coordinates': [
+                [0.0, 0.0],
+              ],
+            },
+          },
+        ],
+      };
+
+      final segments = service.parseGeoJsonForTest(featureCollection.cast<String, dynamic>());
+      expect(segments, hasLength(2), reason: 'Unsupported geometries and degenerate paths should be filtered out.');
+
+      final lineString =
+          segments.firstWhere((seg) => seg.id == 'line-string', orElse: () => throw StateError('LineString missing.'));
+      expect(lineString.path, hasLength(2));
+      expect(lineString.lengthMeters, 123);
+
+      final multi = segments.firstWhere((seg) => seg.id == 'multi', orElse: () => throw StateError('MultiLine missing.'));
+      expect(multi.path, hasLength(4), reason: 'All coordinates from each part must be flattened into one path.');
+    });
+
+    test('toGeoPointsFromLonLatListForTest ignores malformed coordinates', () {
+      final points = service.toGeoPointsFromLonLatListForTest([
+        [1, 2],
+        [3, 4, 5],
+        [6],
+        'bad',
+      ]);
+
+      expect(points, hasLength(3));
+      expect(points[0], predicate<GeoPoint>((p) => p.lat == 2 && p.lon == 1));
+      expect(points[1], predicate<GeoPoint>((p) => p.lat == 4 && p.lon == 3));
+      expect(points[2], predicate<GeoPoint>((p) => p.lat == 5 && p.lon == 6));
+    });
+  });
+
+  group('SegmentIndexService candidate queries', () {
+    test('candidateIdsNearLatLng returns empty list when index is not built', () {
+      final hits = service.candidateIdsNearLatLng(const LatLng(0, 0));
+      expect(hits, isEmpty, reason: 'Querying before building the index should not throw.');
+    });
+
+    test('candidateIdsNearLatLng finds segments whose bounding boxes touch the search radius', () async {
+      const radius = 150.0;
+      const metersPerDegree = 111320.0;
+      final boundaryLonDelta = radius / metersPerDegree;
+
+      await service.buildFromGeometries([
+        SegmentGeometry(
+          id: 'touching',
+          path: [
+            GeoPoint(0, boundaryLonDelta),
+            GeoPoint(0, boundaryLonDelta + 0.0001),
+          ],
+        ),
+        SegmentGeometry(
+          id: 'inside',
+          path: [
+            const GeoPoint(0.0005, 0.0005),
+            const GeoPoint(0.0006, 0.0006),
+          ],
+        ),
+        SegmentGeometry(
+          id: 'outside',
+          path: [
+            const GeoPoint(0.1, 0.1),
+            const GeoPoint(0.2, 0.2),
+          ],
+        ),
+      ]);
+
+      final hits = service.candidateIdsNearLatLng(const LatLng(0, 0), radiusMeters: radius);
+
+      expect(hits, containsAll(<String>{'touching', 'inside'}));
+      expect(hits, isNot(contains('outside')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- expose test-only helpers on `SegmentIndexService` so tests can reset state and invoke the parsers
- add unit coverage for parsing logic and candidate lookups in `SegmentIndexService`
- add spatial utility and R-tree query tests to confirm edge-case behaviour

## Testing
- flutter test *(fails: `flutter` command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe8dd0060832d964b5a84606aec9d