### PR TITLE
Add Supabase authentication flow and profile menu

### DIFF
--- a/lib/app/app_routes.dart
+++ b/lib/app/app_routes.dart
@@ -1,10 +1,22 @@
 import 'package:flutter/material.dart';
+import '../presentation/pages/auth/auth_prompt_page.dart';
+import '../presentation/pages/auth/login_page.dart';
+import '../presentation/pages/auth/profile_page.dart';
+import '../presentation/pages/auth/sign_up_page.dart';
 import '../presentation/pages/map_page.dart';
 
 class AppRoutes {
   static const String map = '/';
+  static const String authPrompt = '/auth';
+  static const String login = '/login';
+  static const String signUp = '/sign-up';
+  static const String profile = '/profile';
 
   static Map<String, WidgetBuilder> get routes => {
         map: (_) => const MapPage(),
+        authPrompt: (_) => const AuthPromptPage(),
+        login: (_) => const LoginPage(),
+        signUp: (_) => const SignUpPage(),
+        profile: (_) => const ProfilePage(),
       };
 }

--- a/lib/core/config/supabase_config.dart
+++ b/lib/core/config/supabase_config.dart
@@ -1,0 +1,17 @@
+/// Configuration holder for Supabase credentials.
+///
+/// Provide values via `--dart-define` or by editing the constants directly
+/// before running the app.
+class SupabaseConfig {
+  const SupabaseConfig._();
+
+  static const String url = String.fromEnvironment(
+    'SUPABASE_URL',
+    defaultValue: '',
+  );
+
+  static const String anonKey = String.fromEnvironment(
+    'SUPABASE_ANON_KEY',
+    defaultValue: '',
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:toll_cam_finder/services/average_speed_est.dart';
-import 'app/app.dart';
 
-void main() {
+import 'app/app.dart';
+import 'services/supabase_service.dart';
+
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await SupabaseService.initialize();
+
   runApp(
     ChangeNotifierProvider(
       create: (_) => AverageSpeedController(),

--- a/lib/presentation/pages/auth/auth_prompt_page.dart
+++ b/lib/presentation/pages/auth/auth_prompt_page.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/app_routes.dart';
+import '../../../services/supabase_service.dart';
+
+class AuthPromptPage extends StatelessWidget {
+  const AuthPromptPage({super.key});
+
+  void _goToLogin(BuildContext context) {
+    Navigator.of(context).pushNamed(AppRoutes.login);
+  }
+
+  void _goToSignUp(BuildContext context) {
+    Navigator.of(context).pushNamed(AppRoutes.signUp);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!SupabaseService.isConfigured) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Profile'),
+        ),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              'Supabase credentials are missing. Add your project details to '
+              'enable authentication.',
+              style: Theme.of(context).textTheme.bodyLarge,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Profile'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'Access your profile',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Log in to view your profile or create a new account to get started.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 32),
+            FilledButton(
+              onPressed: () => _goToLogin(context),
+              child: const Text('Log in'),
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton(
+              onPressed: () => _goToSignUp(context),
+              child: const Text('Create an account'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/auth/login_page.dart
+++ b/lib/presentation/pages/auth/login_page.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../app/app_routes.dart';
+import '../../../services/supabase_service.dart';
+
+class LoginPageArgs {
+  const LoginPageArgs({this.email, this.showAccountCreated = false});
+
+  final String? email;
+  final bool showAccountCreated;
+}
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  bool _isLoading = false;
+  bool _initializedArgs = false;
+  String? _errorMessage;
+  bool _hasShownAccountCreatedMessage = false;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initializedArgs) return;
+    final args = ModalRoute.of(context)?.settings.arguments;
+    if (args is LoginPageArgs && args.email != null) {
+      _emailController.text = args.email!;
+    }
+    if (args is LoginPageArgs &&
+        args.showAccountCreated &&
+        !_hasShownAccountCreatedMessage) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Account created. Please log in.'),
+          ),
+        );
+      });
+      _hasShownAccountCreatedMessage = true;
+    }
+    _initializedArgs = true;
+  }
+
+  Future<void> _login() async {
+    final formState = _formKey.currentState;
+    if (formState == null || !formState.validate()) {
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    final client = SupabaseService.clientOrNull;
+    if (client == null) {
+      setState(() {
+        _errorMessage =
+            'Authentication is not available. Configure Supabase first.';
+        _isLoading = false;
+      });
+      return;
+    }
+
+    try {
+      await client.auth.signInWithPassword(
+        email: _emailController.text.trim(),
+        password: _passwordController.text,
+      );
+
+      if (!mounted) return;
+
+      Navigator.of(context).pushNamedAndRemoveUntil(
+        AppRoutes.profile,
+        (route) => route.settings.name == AppRoutes.map,
+      );
+    } on AuthException catch (error) {
+      setState(() {
+        _errorMessage = error.message;
+      });
+    } catch (error) {
+      setState(() {
+        _errorMessage = 'Unexpected error: $error';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!SupabaseService.isConfigured) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Log in'),
+        ),
+        body: _buildConfigurationWarning(context),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Log in'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Welcome back',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(
+                  labelText: 'Email',
+                ),
+                keyboardType: TextInputType.emailAddress,
+                autofillHints: const [AutofillHints.email],
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter your email.';
+                  }
+                  if (!value.contains('@')) {
+                    return 'Please enter a valid email address.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(
+                  labelText: 'Password',
+                ),
+                obscureText: true,
+                autofillHints: const [AutofillHints.password],
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter your password.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              if (_errorMessage != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: Text(
+                    _errorMessage!,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                ),
+              FilledButton(
+                onPressed: _isLoading ? null : _login,
+                child: _isLoading
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Log in'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildConfigurationWarning(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          'Supabase credentials are missing. Add your project details to '
+          'enable authentication.',
+          style: Theme.of(context).textTheme.bodyLarge,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/auth/profile_page.dart
+++ b/lib/presentation/pages/auth/profile_page.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../app/app_routes.dart';
+import '../../../services/supabase_service.dart';
+
+class ProfilePage extends StatefulWidget {
+  const ProfilePage({super.key});
+
+  @override
+  State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage> {
+  User? _user;
+  StreamSubscription<AuthState>? _authSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    final client = SupabaseService.clientOrNull;
+    if (client == null) {
+      return;
+    }
+    _user = client.auth.currentUser;
+    _authSubscription = client.auth.onAuthStateChange.listen((authState) {
+      if (!mounted) return;
+      setState(() {
+        _user = authState.session?.user;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _authSubscription?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _signOut() async {
+    final client = SupabaseService.clientOrNull;
+    if (client == null) {
+      return;
+    }
+    await client.auth.signOut();
+    if (!mounted) return;
+    Navigator.of(context).pushNamedAndRemoveUntil(
+      AppRoutes.map,
+      (route) => false,
+    );
+  }
+
+  void _goToAuthPrompt() {
+    Navigator.of(context).pushNamedAndRemoveUntil(
+      AppRoutes.authPrompt,
+      (route) => route.settings.name == AppRoutes.map,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!SupabaseService.isConfigured) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Profile'),
+        ),
+        body: _buildConfigurationWarning(context),
+      );
+    }
+
+    final user = _user;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Profile'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: user == null
+            ? Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'You are not logged in',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Log in or create an account to view your profile.',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    onPressed: _goToAuthPrompt,
+                    child: const Text('Go to authentication'),
+                  ),
+                ],
+              )
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'Welcome!',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                  const SizedBox(height: 24),
+                  Card(
+                    child: ListTile(
+                      leading: const Icon(Icons.person_outline),
+                      title: Text(user.email ?? 'Unknown user'),
+                      subtitle: const Text('Email'),
+                    ),
+                  ),
+                  const Spacer(),
+                  FilledButton.tonal(
+                    onPressed: _signOut,
+                    child: const Text('Sign out'),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+
+  Widget _buildConfigurationWarning(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          'Supabase credentials are missing. Add your project details to '
+          'enable authentication.',
+          style: Theme.of(context).textTheme.bodyLarge,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/auth/sign_up_page.dart
+++ b/lib/presentation/pages/auth/sign_up_page.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../app/app_routes.dart';
+import '../../../services/supabase_service.dart';
+import 'login_page.dart';
+
+class SignUpPage extends StatefulWidget {
+  const SignUpPage({super.key});
+
+  @override
+  State<SignUpPage> createState() => _SignUpPageState();
+}
+
+class _SignUpPageState extends State<SignUpPage> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _confirmPasswordController =
+      TextEditingController();
+
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _signUp() async {
+    final formState = _formKey.currentState;
+    if (formState == null || !formState.validate()) {
+      return;
+    }
+
+    final client = SupabaseService.clientOrNull;
+    if (client == null) {
+      setState(() {
+        _errorMessage =
+            'Authentication is not available. Configure Supabase first.';
+      });
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    final email = _emailController.text.trim();
+    final password = _passwordController.text;
+
+    try {
+      await client.auth.signUp(
+        email: email,
+        password: password,
+      );
+
+      if (!mounted) return;
+
+      Navigator.of(context).pushNamedAndRemoveUntil(
+        AppRoutes.login,
+        (route) => route.settings.name == AppRoutes.map,
+        arguments: LoginPageArgs(
+          email: email,
+          showAccountCreated: true,
+        ),
+      );
+    } on AuthException catch (error) {
+      setState(() {
+        _errorMessage = error.message;
+      });
+    } catch (error) {
+      setState(() {
+        _errorMessage = 'Unexpected error: $error';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!SupabaseService.isConfigured) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Create account'),
+        ),
+        body: _buildConfigurationWarning(context),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create account'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Join TollCam',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(
+                  labelText: 'Email',
+                ),
+                keyboardType: TextInputType.emailAddress,
+                autofillHints: const [AutofillHints.email],
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter your email.';
+                  }
+                  if (!value.contains('@')) {
+                    return 'Please enter a valid email address.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(
+                  labelText: 'Password',
+                ),
+                obscureText: true,
+                autofillHints: const [AutofillHints.newPassword],
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter a password.';
+                  }
+                  if (value.length < 6) {
+                    return 'Password must be at least 6 characters long.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _confirmPasswordController,
+                decoration: const InputDecoration(
+                  labelText: 'Confirm password',
+                ),
+                obscureText: true,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please confirm your password.';
+                  }
+                  if (value != _passwordController.text) {
+                    return 'Passwords do not match.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              if (_errorMessage != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: Text(
+                    _errorMessage!,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                ),
+              FilledButton(
+                onPressed: _isLoading ? null : _signUp,
+                child: _isLoading
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Create account'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildConfigurationWarning(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          'Supabase credentials are missing. Add your project details to '
+          'enable authentication.',
+          style: Theme.of(context).textTheme.bodyLarge,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/map_page.dart
+++ b/lib/presentation/pages/map_page.dart
@@ -16,8 +16,10 @@ import 'package:toll_cam_finder/services/average_speed_est.dart';
 import 'package:toll_cam_finder/services/speed_smoother.dart';
 import 'package:toll_cam_finder/services/segment_tracker.dart';
 
+import '../../app/app_routes.dart';
 import '../../services/location_service.dart';
 import '../../services/permission_service.dart';
+import '../../services/supabase_service.dart';
 import 'map/blue_dot_animator.dart';
 import 'map/toll_camera_controller.dart';
 import 'map/widgets/map_controls_panel.dart';
@@ -67,6 +69,44 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
   double? _speedKmh;
   double? _compassHeading;
   String? _segmentProgressLabel;
+
+  void _openProfile(BuildContext context) {
+    final navigator = Navigator.of(context);
+    navigator.pop();
+
+    if (!SupabaseService.isConfigured) {
+      navigator.pushNamed(AppRoutes.authPrompt);
+      return;
+    }
+
+    final session = SupabaseService.clientOrNull?.auth.currentSession;
+    final route = session == null ? AppRoutes.authPrompt : AppRoutes.profile;
+
+    navigator.pushNamed(route);
+  }
+
+  Drawer _buildEndDrawer(BuildContext context) {
+    return Drawer(
+      child: SafeArea(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            const ListTile(
+              title: Text(
+                'Options',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.person_outline),
+              title: const Text('Profile'),
+              onTap: () => _openProfile(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 
   @override
   void initState() {
@@ -433,6 +473,24 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
               ),
             ),
           ),
+          SafeArea(
+            child: Align(
+              alignment: Alignment.topRight,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 16, right: 16),
+                child: Builder(
+                  builder: (context) => Material(
+                    color: Colors.transparent,
+                    child: IconButton(
+                      icon: const Icon(Icons.menu),
+                      tooltip: 'Open options',
+                      onPressed: () => Scaffold.of(context).openEndDrawer(),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
         ],
       ),
 
@@ -441,6 +499,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
         onResetView: _onResetView,
         avgController: _avgCtrl,
       ),
+      endDrawer: _buildEndDrawer(context),
     );
   }
 }

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../core/config/supabase_config.dart';
+
+class SupabaseService {
+  const SupabaseService._();
+
+  static bool _initialized = false;
+  static bool _isConfigured = false;
+
+  static bool get isConfigured => _isConfigured;
+
+  static SupabaseClient? get clientOrNull =>
+      _isConfigured ? Supabase.instance.client : null;
+
+  static Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+
+    final url = SupabaseConfig.url;
+    final anonKey = SupabaseConfig.anonKey;
+
+    if (url.isEmpty || anonKey.isEmpty) {
+      debugPrint(
+        'Supabase credentials are not configured. Authentication features '
+        'will be disabled.',
+      );
+      _initialized = true;
+      _isConfigured = false;
+      return;
+    }
+
+    await Supabase.initialize(
+      url: url,
+      anonKey: anonKey,
+      authFlowType: AuthFlowType.pkce,
+    );
+    _initialized = true;
+    _isConfigured = true;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   http: ^1.5.0
   test: ^1.26.2
   csv: ^6.0.0
+  supabase_flutter: ^2.3.4
+  shared_preferences: ^2.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a Supabase service and configuration hook to initialize authentication
- create auth prompt, login, sign-up, and profile pages wired into the router
- expose a top-right options button on the map that opens a drawer leading to the profile flow
- declare the shared_preferences plugin dependency so Android builds include the generated registrant

## Testing
- flutter pub get *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8eeff6794832d9037cdfebed92085