### PR TITLE
Add UI scaffolding for authentication navigation

### DIFF
--- a/lib/app/app_routes.dart
+++ b/lib/app/app_routes.dart
@@ -1,10 +1,19 @@
 import 'package:flutter/material.dart';
+import '../presentation/pages/auth/login_page.dart';
+import '../presentation/pages/auth/profile_page.dart';
+import '../presentation/pages/auth/sign_up_page.dart';
 import '../presentation/pages/map_page.dart';
 
 class AppRoutes {
   static const String map = '/';
+  static const String login = '/login';
+  static const String signUp = '/sign-up';
+  static const String profile = '/profile';
 
   static Map<String, WidgetBuilder> get routes => {
         map: (_) => const MapPage(),
+        login: (_) => const LoginPage(),
+        signUp: (_) => const SignUpPage(),
+        profile: (_) => const ProfilePage(),
       };
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:toll_cam_finder/services/average_speed_est.dart';
+
 import 'app/app.dart';
+import 'services/auth_controller.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   runApp(
-    ChangeNotifierProvider(
-      create: (_) => AverageSpeedController(),
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) => AverageSpeedController(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => AuthController(),
+        ),
+      ],
       child: const TollCamApp(),
     ),
   );

--- a/lib/presentation/pages/auth/login_page.dart
+++ b/lib/presentation/pages/auth/login_page.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../app/app_routes.dart';
+import '../../../services/auth_controller.dart';
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _initializedEmail = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initializedEmail) return;
+    final pendingEmail = context.read<AuthController>().pendingEmail;
+    if (pendingEmail != null) {
+      _emailController.text = pendingEmail;
+    }
+    _initializedEmail = true;
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    final auth = context.read<AuthController>();
+    await auth.logIn(
+      email: _emailController.text.trim(),
+      password: _passwordController.text,
+    );
+
+    if (!mounted) return;
+    Navigator.of(context).pushNamedAndRemoveUntil(
+      AppRoutes.profile,
+      ModalRoute.withName(AppRoutes.map),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Log in'),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: 32),
+                Text(
+                  'Welcome back',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 24),
+                TextFormField(
+                  controller: _emailController,
+                  keyboardType: TextInputType.emailAddress,
+                  decoration: const InputDecoration(
+                    labelText: 'Email',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Please enter your email';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _passwordController,
+                  obscureText: true,
+                  decoration: const InputDecoration(
+                    labelText: 'Password',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter your password';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: _submit,
+                  child: const Text('Continue'),
+                ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pushReplacementNamed(AppRoutes.signUp);
+                  },
+                  child: const Text('Create a new account'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/auth/profile_page.dart
+++ b/lib/presentation/pages/auth/profile_page.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../app/app_routes.dart';
+import '../../../services/auth_controller.dart';
+
+class ProfilePage extends StatelessWidget {
+  const ProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = context.watch<AuthController>();
+    final email = auth.currentEmail ?? 'Unknown user';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Your profile'),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const CircleAvatar(
+                radius: 40,
+                child: Icon(Icons.person, size: 40),
+              ),
+              const SizedBox(height: 24),
+              Text(
+                email,
+                style: Theme.of(context).textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Manage your TollCam account and preferences.',
+                style: Theme.of(context).textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+              const Spacer(),
+              ElevatedButton(
+                onPressed: () async {
+                  await context.read<AuthController>().logOut();
+                  Navigator.of(context).popUntil(
+                    ModalRoute.withName(AppRoutes.map),
+                  );
+                },
+                child: const Text('Log out'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/auth/sign_up_page.dart
+++ b/lib/presentation/pages/auth/sign_up_page.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../app/app_routes.dart';
+import '../../../services/auth_controller.dart';
+
+class SignUpPage extends StatefulWidget {
+  const SignUpPage({super.key});
+
+  @override
+  State<SignUpPage> createState() => _SignUpPageState();
+}
+
+class _SignUpPageState extends State<SignUpPage> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _confirmPasswordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    final auth = context.read<AuthController>();
+    await auth.register(email: _emailController.text.trim());
+
+    if (!mounted) return;
+    Navigator.of(context).pushReplacementNamed(AppRoutes.login);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create account'),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: 32),
+                Text(
+                  'Join TollCam',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 24),
+                TextFormField(
+                  controller: _nameController,
+                  textCapitalization: TextCapitalization.words,
+                  decoration: const InputDecoration(
+                    labelText: 'Full name',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Please enter your name';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _emailController,
+                  keyboardType: TextInputType.emailAddress,
+                  decoration: const InputDecoration(
+                    labelText: 'Email',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Please enter your email';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _passwordController,
+                  obscureText: true,
+                  decoration: const InputDecoration(
+                    labelText: 'Password',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please create a password';
+                    }
+                    if (value.length < 6) {
+                      return 'Password must be at least 6 characters';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _confirmPasswordController,
+                  obscureText: true,
+                  decoration: const InputDecoration(
+                    labelText: 'Confirm password',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please confirm your password';
+                    }
+                    if (value != _passwordController.text) {
+                      return 'Passwords do not match';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: _submit,
+                  child: const Text('Create account'),
+                ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pushReplacementNamed(AppRoutes.login);
+                  },
+                  child: const Text('Already have an account? Log in'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/map_page.dart
+++ b/lib/presentation/pages/map_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_compass/flutter_compass.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:provider/provider.dart';
 
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/features/segemnt_index_service.dart';
@@ -16,6 +17,8 @@ import 'package:toll_cam_finder/services/average_speed_est.dart';
 import 'package:toll_cam_finder/services/speed_smoother.dart';
 import 'package:toll_cam_finder/services/segment_tracker.dart';
 
+import '../../app/app_routes.dart';
+import '../../services/auth_controller.dart';
 import '../../services/location_service.dart';
 import '../../services/permission_service.dart';
 import 'map/blue_dot_animator.dart';
@@ -389,6 +392,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
     final cameraState = _cameraController.state;
 
     return Scaffold(
+      endDrawer: _buildOptionsDrawer(),
       body: Stack(
         children: [
           FlutterMap(
@@ -433,6 +437,27 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
               ),
             ),
           ),
+          SafeArea(
+            child: Align(
+              alignment: Alignment.topRight,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 16, right: 16),
+                child: Builder(
+                  builder: (context) {
+                    return Material(
+                      color: Colors.black54,
+                      shape: const CircleBorder(),
+                      child: IconButton(
+                        onPressed: () => Scaffold.of(context).openEndDrawer(),
+                        icon: const Icon(Icons.menu, color: Colors.white),
+                        tooltip: 'Open menu',
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
         ],
       ),
 
@@ -441,6 +466,65 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
         onResetView: _onResetView,
         avgController: _avgCtrl,
       ),
+    );
+  }
+
+  Drawer _buildOptionsDrawer() {
+    return Drawer(
+      child: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          children: [
+            ListTile(
+              leading: const Icon(Icons.person_outline),
+              title: const Text('Profile'),
+              onTap: () {
+                Navigator.of(context).pop();
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (!mounted) return;
+                  _onProfileSelected();
+                });
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _onProfileSelected() {
+    final auth = context.read<AuthController>();
+    if (auth.isLoggedIn) {
+      Navigator.of(context).pushNamed(AppRoutes.profile);
+      return;
+    }
+
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Wrap(
+            children: [
+              ListTile(
+                leading: const Icon(Icons.login),
+                title: const Text('Log in'),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  Navigator.of(context).pushNamed(AppRoutes.login);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.person_add_alt),
+                title: const Text('Create an account'),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  Navigator.of(context).pushNamed(AppRoutes.signUp);
+                },
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/services/auth_controller.dart
+++ b/lib/services/auth_controller.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+
+/// Lightweight controller that tracks the authenticated user state.
+///
+/// This implementation intentionally avoids any actual authentication logic
+/// so the real flows can be plugged in later.
+class AuthController extends ChangeNotifier {
+  bool _isLoggedIn = false;
+  String? _currentEmail;
+  String? _pendingEmail;
+
+  bool get isLoggedIn => _isLoggedIn;
+  String? get currentEmail => _currentEmail;
+  String? get pendingEmail => _pendingEmail;
+
+  /// Placeholder login flow. Replace with real implementation.
+  Future<void> logIn({required String email, required String password}) async {
+    _currentEmail = email;
+    _isLoggedIn = true;
+    _pendingEmail = null;
+    notifyListeners();
+  }
+
+  /// Placeholder account creation hook. Replace with real implementation.
+  Future<void> register({required String email}) async {
+    _pendingEmail = email;
+    _isLoggedIn = false;
+    notifyListeners();
+  }
+
+  Future<void> logOut() async {
+    _isLoggedIn = false;
+    _currentEmail = null;
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- register a lightweight authentication controller alongside the existing providers
- add profile, login, and sign-up screens to scaffold future authentication flows
- introduce a top-right options menu on the map that routes users through the appropriate auth experience

## Testing
- flutter analyze *(fails: Flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f8642fa4832db50d5f2f43fa802a