### PR TITLE
Refactor segment picker map widgets

### DIFF
--- a/lib/presentation/pages/create_segment_page.dart
+++ b/lib/presentation/pages/create_segment_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:toll_cam_finder/presentation/widgets/segment_picker_map.dart';
+import 'package:toll_cam_finder/presentation/widgets/segment_picker/segment_picker_map.dart';
 
 class CreateSegmentPage extends StatefulWidget {
   const CreateSegmentPage({super.key});

--- a/lib/presentation/widgets/segment_picker/map_icon_button.dart
+++ b/lib/presentation/widgets/segment_picker/map_icon_button.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class MapIconButton extends StatelessWidget {
+  const MapIconButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: theme.colorScheme.surface.withOpacity(0.9),
+      shape: const CircleBorder(),
+      elevation: 2,
+      child: IconButton(
+        icon: Icon(icon, color: theme.colorScheme.onSurface),
+        onPressed: onPressed,
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/segment_picker/segment_picker_map.dart
+++ b/lib/presentation/widgets/segment_picker/segment_picker_map.dart
@@ -6,6 +6,10 @@ import 'package:latlong2/latlong.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/core/spatial/geo.dart';
 import 'package:toll_cam_finder/presentation/widgets/base_tile_layer.dart';
+import 'package:toll_cam_finder/presentation/widgets/segment_picker/map_icon_button.dart';
+import 'package:toll_cam_finder/presentation/widgets/segment_picker/segment_picker_map_full_screen_page.dart';
+import 'package:toll_cam_finder/presentation/widgets/segment_picker/segment_picker_map_hint_card.dart';
+import 'package:toll_cam_finder/presentation/widgets/segment_picker/segment_point_marker.dart';
 import 'package:toll_cam_finder/services/osrm_path_fetcher.dart';
 
 class SegmentPickerMap extends StatefulWidget {
@@ -22,6 +26,12 @@ class SegmentPickerMap extends StatefulWidget {
 
   @override
   State<SegmentPickerMap> createState() => _SegmentPickerMapState();
+}
+
+enum _SegmentPoint { start, end }
+
+extension on _SegmentPoint {
+  String get label => this == _SegmentPoint.start ? 'A' : 'B';
 }
 
 class _SegmentPickerMapState extends State<SegmentPickerMap> {
@@ -64,32 +74,8 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
 
   @override
   Widget build(BuildContext context) {
-    final markers = <Marker>[];
     final theme = Theme.of(context);
-
-    if (_start != null) {
-      markers.add(
-        Marker(
-          point: _start!,
-          width: 44,
-          height: 44,
-          alignment: Alignment.center,
-          child: _SegmentMarker(label: 'A', color: theme.colorScheme.primary),
-        ),
-      );
-    }
-
-    if (_end != null) {
-      markers.add(
-        Marker(
-          point: _end!,
-          width: 44,
-          height: 44,
-          alignment: Alignment.center,
-          child: _SegmentMarker(label: 'B', color: theme.colorScheme.primary),
-        ),
-      );
-    }
+    final markers = _buildMarkers(theme);
 
     final routePoints = _routePoints ??
         (_start != null && _end != null ? <LatLng>[_start!, _end!] : null);
@@ -125,7 +111,7 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
           left: 16,
           right: 72,
           top: 16,
-          child: _MapHintCard(
+          child: SegmentPickerMapHintCard(
             hasStart: _start != null,
             hasEnd: _end != null,
           ),
@@ -136,12 +122,12 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              _ZoomButton(
+              MapIconButton(
                 icon: Icons.add,
                 onPressed: () => _zoomBy(_zoomStep),
               ),
               const SizedBox(height: 12),
-              _ZoomButton(
+              MapIconButton(
                 icon: Icons.remove,
                 onPressed: () => _zoomBy(-_zoomStep),
               ),
@@ -151,8 +137,8 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
         Positioned(
           top: 16,
           right: 16,
-          child: _FullScreenButton(
-            isFullScreen: widget.isFullScreen,
+          child: MapIconButton(
+            icon: widget.isFullScreen ? Icons.fullscreen_exit : Icons.fullscreen,
             onPressed: widget.isFullScreen ? _exitFullScreen : _openFullScreen,
           ),
         ),
@@ -193,58 +179,50 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
   void _handleMapTap(TapPosition tapPosition, LatLng latLng) {
     if (!_mapReady) return;
 
-    if (_start == null) {
-      _updateStart(latLng);
-    } else if (_end == null) {
-      _updateEnd(latLng);
+    final start = _start;
+    final end = _end;
+
+    if (start == null) {
+      _updatePoint(_SegmentPoint.start, latLng);
+    } else if (end == null) {
+      _updatePoint(_SegmentPoint.end, latLng);
     } else {
-      final double distToStart = _distance(_start!, latLng);
-      final double distToEnd = _distance(_end!, latLng);
-      if (distToStart <= distToEnd) {
-        _updateStart(latLng);
-      } else {
-        _updateEnd(latLng);
-      }
+      final double distToStart = _distance(start, latLng);
+      final double distToEnd = _distance(end, latLng);
+      final target =
+          distToStart <= distToEnd ? _SegmentPoint.start : _SegmentPoint.end;
+      _updatePoint(target, latLng);
     }
 
     _fitCamera();
   }
 
   void _handleStartTextChanged() {
-    if (_updatingControllers || _suspendUpdates) return;
-    final parsed = _parseLatLng(widget.startController.text);
-    if (_positionsEqual(_start, parsed)) return;
-    setState(() {
-      _start = parsed;
-    });
-    _refreshRoute();
-    _fitCamera();
+    _handleControllerChanged(_SegmentPoint.start);
   }
 
   void _handleEndTextChanged() {
+    _handleControllerChanged(_SegmentPoint.end);
+  }
+
+  void _handleControllerChanged(_SegmentPoint point) {
     if (_updatingControllers || _suspendUpdates) return;
-    final parsed = _parseLatLng(widget.endController.text);
-    if (_positionsEqual(_end, parsed)) return;
+    final controller = _controllerFor(point);
+    final parsed = _parseLatLng(controller.text);
+    final current = _positionFor(point);
+    if (_positionsEqual(current, parsed)) return;
     setState(() {
-      _end = parsed;
+      _setPosition(point, parsed);
     });
     _refreshRoute();
     _fitCamera();
   }
 
-  void _updateStart(LatLng latLng) {
+  void _updatePoint(_SegmentPoint point, LatLng latLng) {
     setState(() {
-      _start = latLng;
+      _setPosition(point, latLng);
     });
-    _writeToController(widget.startController, latLng);
-    _refreshRoute();
-  }
-
-  void _updateEnd(LatLng latLng) {
-    setState(() {
-      _end = latLng;
-    });
-    _writeToController(widget.endController, latLng);
+    _writeToController(_controllerFor(point), latLng);
     _refreshRoute();
   }
 
@@ -266,8 +244,11 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
     await Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (context) => SegmentPickerMapFullScreenPage(
-          startController: widget.startController,
-          endController: widget.endController,
+          mapBuilder: (context) => SegmentPickerMap(
+            startController: widget.startController,
+            endController: widget.endController,
+            isFullScreen: true,
+          ),
         ),
       ),
     );
@@ -282,11 +263,15 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
   }
 
   void _syncFromControllers() {
-    final parsedStart = _parseLatLng(widget.startController.text);
-    final parsedEnd = _parseLatLng(widget.endController.text);
     setState(() {
-      _start = parsedStart;
-      _end = parsedEnd;
+      _setPosition(
+        _SegmentPoint.start,
+        _parseLatLng(widget.startController.text),
+      );
+      _setPosition(
+        _SegmentPoint.end,
+        _parseLatLng(widget.endController.text),
+      );
     });
     _refreshRoute();
     _fitCamera();
@@ -379,156 +364,43 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
   String _formatLatLng(LatLng value) {
     return '${value.latitude.toStringAsFixed(6)}, ${value.longitude.toStringAsFixed(6)}';
   }
-}
 
-class _SegmentMarker extends StatelessWidget {
-  const _SegmentMarker({required this.label, required this.color});
-
-  final String label;
-  final Color color;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: color,
-        shape: BoxShape.circle,
-        boxShadow: const [
-          BoxShadow(
-            color: Colors.black26,
-            blurRadius: 6,
-            offset: Offset(0, 4),
-          ),
-        ],
-      ),
-      child: SizedBox(
-        width: 36,
-        height: 36,
-        child: Center(
-          child: Text(
-            label,
-            style: theme.textTheme.titleMedium?.copyWith(
-              color: Colors.white,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        ),
-      ),
-    );
+  TextEditingController _controllerFor(_SegmentPoint point) {
+    return point == _SegmentPoint.start
+        ? widget.startController
+        : widget.endController;
   }
-}
 
-class _ZoomButton extends StatelessWidget {
-  const _ZoomButton({
-    required this.icon,
-    required this.onPressed,
-  });
-
-  final IconData icon;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Material(
-      color: theme.colorScheme.surface.withOpacity(0.9),
-      shape: const CircleBorder(),
-      elevation: 2,
-      child: IconButton(
-        icon: Icon(icon, color: theme.colorScheme.onSurface),
-        onPressed: onPressed,
-      ),
-    );
+  LatLng? _positionFor(_SegmentPoint point) {
+    return point == _SegmentPoint.start ? _start : _end;
   }
-}
 
-class _FullScreenButton extends StatelessWidget {
-  const _FullScreenButton({
-    required this.isFullScreen,
-    required this.onPressed,
-  });
-
-  final bool isFullScreen;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Material(
-      color: theme.colorScheme.surface.withOpacity(0.9),
-      shape: const CircleBorder(),
-      elevation: 2,
-      child: IconButton(
-        icon: Icon(
-          isFullScreen ? Icons.fullscreen_exit : Icons.fullscreen,
-          color: theme.colorScheme.onSurface,
-        ),
-        onPressed: onPressed,
-      ),
-    );
-  }
-}
-
-class SegmentPickerMapFullScreenPage extends StatelessWidget {
-  const SegmentPickerMapFullScreenPage({
-    super.key,
-    required this.startController,
-    required this.endController,
-  });
-
-  final TextEditingController startController;
-  final TextEditingController endController;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: SafeArea(
-        child: SegmentPickerMap(
-          startController: startController,
-          endController: endController,
-          isFullScreen: true,
-        ),
-      ),
-    );
-  }
-}
-
-class _MapHintCard extends StatelessWidget {
-  const _MapHintCard({required this.hasStart, required this.hasEnd});
-
-  final bool hasStart;
-  final bool hasEnd;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    String message;
-    if (!hasStart && !hasEnd) {
-      message = 'Tap anywhere on the map to place point A.';
-    } else if (hasStart && !hasEnd) {
-      message = 'Tap a second location to place point B.';
+  void _setPosition(_SegmentPoint point, LatLng? value) {
+    if (point == _SegmentPoint.start) {
+      _start = value;
     } else {
-      message = 'Tap near A or B to reposition that point.';
+      _end = value;
     }
+  }
 
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surface.withOpacity(0.9),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: theme.colorScheme.outlineVariant),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        child: Text(
-          message,
-          style: theme.textTheme.bodyMedium?.copyWith(
-            color: theme.colorScheme.onSurface,
-          ),
-          textAlign: TextAlign.center,
-        ),
-      ),
-    );
+  List<Marker> _buildMarkers(ThemeData theme) {
+    final color = theme.colorScheme.primary;
+    return _SegmentPoint.values
+        .map((point) {
+          final position = _positionFor(point);
+          if (position == null) return null;
+          return Marker(
+            point: position,
+            width: 44,
+            height: 44,
+            alignment: Alignment.center,
+            child: SegmentPointMarker(
+              label: point.label,
+              color: color,
+            ),
+          );
+        })
+        .whereType<Marker>()
+        .toList(growable: false);
   }
 }

--- a/lib/presentation/widgets/segment_picker/segment_picker_map_full_screen_page.dart
+++ b/lib/presentation/widgets/segment_picker/segment_picker_map_full_screen_page.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class SegmentPickerMapFullScreenPage extends StatelessWidget {
+  const SegmentPickerMapFullScreenPage({
+    super.key,
+    required this.mapBuilder,
+  });
+
+  final WidgetBuilder mapBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: SafeArea(
+        child: Builder(builder: mapBuilder),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/segment_picker/segment_picker_map_hint_card.dart
+++ b/lib/presentation/widgets/segment_picker/segment_picker_map_hint_card.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class SegmentPickerMapHintCard extends StatelessWidget {
+  const SegmentPickerMapHintCard({
+    super.key,
+    required this.hasStart,
+    required this.hasEnd,
+  });
+
+  final bool hasStart;
+  final bool hasEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    String message;
+    if (!hasStart && !hasEnd) {
+      message = 'Tap anywhere on the map to place point A.';
+    } else if (hasStart && !hasEnd) {
+      message = 'Tap a second location to place point B.';
+    } else {
+      message = 'Tap near A or B to reposition that point.';
+    }
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface.withOpacity(0.9),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Text(
+          message,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurface,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/segment_picker/segment_point_marker.dart
+++ b/lib/presentation/widgets/segment_picker/segment_point_marker.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class SegmentPointMarker extends StatelessWidget {
+  const SegmentPointMarker({
+    super.key,
+    required this.label,
+    required this.color,
+  });
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+        boxShadow: const [
+          BoxShadow(
+            color: Colors.black26,
+            blurRadius: 6,
+            offset: Offset(0, 4),
+          ),
+        ],
+      ),
+      child: SizedBox(
+        width: 36,
+        height: 36,
+        child: Center(
+          child: Text(
+            label,
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- restructure the segment picker map widget to reduce duplication when managing start and end points
- extract reusable UI pieces (map icon button, marker, hint card, fullscreen wrapper) into dedicated widgets under presentation/widgets/segment_picker
- update imports to point at the new widget locations

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dff0aa83a0832dbbef552b458ed51d