### PR TITLE
Add local segment saving and preserve through sync

### DIFF
--- a/lib/presentation/pages/segments_page.dart
+++ b/lib/presentation/pages/segments_page.dart
@@ -66,8 +66,19 @@ class _SegmentsPageState extends State<SegmentsPage> {
     );
   }
 
-  void _onCreateSegmentPressed() {
-    Navigator.of(context).pushNamed(AppRoutes.createSegment);
+  Future<void> _onCreateSegmentPressed() async {
+    final result = await Navigator.of(context).pushNamed(AppRoutes.createSegment);
+    if (!mounted || result != true) {
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Segment saved locally.')),
+    );
+
+    setState(() {
+      _segmentsFuture = _repository.loadSegments();
+    });
   }
 }
 
@@ -85,7 +96,21 @@ class _SegmentCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Segment ${segment.id}', style: theme.textTheme.labelMedium),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Expanded(
+                  child: Text(
+                    'Segment ${segment.displayId}',
+                    style: theme.textTheme.labelMedium,
+                  ),
+                ),
+                if (segment.isLocalOnly) ...[
+                  const SizedBox(width: 8),
+                  const _LocalBadge(),
+                ],
+              ],
+            ),
             const SizedBox(height: 4),
             Text(segment.name, style: theme.textTheme.titleMedium),
             const SizedBox(height: 16),
@@ -102,6 +127,28 @@ class _SegmentCard extends StatelessWidget {
               ],
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LocalBadge extends StatelessWidget {
+  const _LocalBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        'Local',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSecondaryContainer,
         ),
       ),
     );

--- a/lib/services/local_segments_service.dart
+++ b/lib/services/local_segments_service.dart
@@ -1,0 +1,137 @@
+import 'dart:math';
+
+import 'package:csv/csv.dart';
+import 'package:flutter/foundation.dart';
+
+import 'toll_segments_csv_constants.dart';
+import 'toll_segments_file_system.dart';
+import 'toll_segments_file_system_stub.dart'
+    if (dart.library.io) 'toll_segments_file_system_io.dart' as fs_impl;
+import 'toll_segments_paths.dart';
+
+/// Persists user-created segments to the local toll segments CSV.
+class LocalSegmentsService {
+  LocalSegmentsService({
+    TollSegmentsFileSystem? fileSystem,
+    TollSegmentsPathResolver? pathResolver,
+  })  : _fileSystem = fileSystem ?? fs_impl.createFileSystem(),
+        _pathResolver = pathResolver;
+
+  final TollSegmentsFileSystem _fileSystem;
+  final TollSegmentsPathResolver? _pathResolver;
+
+  /// Stores a user-created segment on disk. The resulting row is marked with a
+  /// local identifier so that it survives future synchronisation runs.
+  Future<void> saveLocalSegment({
+    required String name,
+    required String startCoordinates,
+    required String endCoordinates,
+  }) async {
+    if (kIsWeb) {
+      throw const LocalSegmentsServiceException(
+        'Saving local segments is not supported on the web.',
+      );
+    }
+
+    final normalizedName = name.trim().isEmpty ? 'Personal segment' : name.trim();
+    final normalizedStart = _normalizeCoordinates(startCoordinates);
+    final normalizedEnd = _normalizeCoordinates(endCoordinates);
+
+    final csvPath = await resolveTollSegmentsDataPath(
+      overrideResolver: _pathResolver,
+    );
+    await _fileSystem.ensureParentDirectory(csvPath);
+
+    final rows = await _readExistingRows(csvPath);
+    if (rows.isEmpty) {
+      rows.add(TollSegmentsCsvSchema.header);
+    } else if (!_isHeaderRow(rows.first)) {
+      rows.insert(0, TollSegmentsCsvSchema.header);
+    }
+
+    final newRow = <String>[
+      _generateLocalId(),
+      normalizedName,
+      '$normalizedName start',
+      '$normalizedName end',
+      normalizedStart,
+      normalizedEnd,
+    ];
+
+    rows.add(newRow);
+
+    final csv = const ListToCsvConverter(
+      fieldDelimiter: ';',
+      textDelimiter: '"',
+      textEndDelimiter: '"',
+    ).convert(rows);
+
+    await _fileSystem.writeAsString(csvPath, '$csv\n');
+  }
+
+  Future<List<List<String>>> _readExistingRows(String path) async {
+    if (!await _fileSystem.exists(path)) {
+      return <List<String>>[];
+    }
+
+    final contents = await _fileSystem.readAsString(path);
+    if (contents.trim().isEmpty) {
+      return <List<String>>[];
+    }
+
+    final parsed = const CsvToListConverter(
+      fieldDelimiter: ';',
+      shouldParseNumbers: false,
+    ).convert(contents);
+
+    return parsed
+        .map((row) => row.map((cell) => cell.toString()).toList(growable: false))
+        .toList(growable: true);
+  }
+
+  bool _isHeaderRow(List<String> row) {
+    if (row.length != TollSegmentsCsvSchema.header.length) {
+      return false;
+    }
+    for (var i = 0; i < row.length; i++) {
+      if (row[i].trim() != TollSegmentsCsvSchema.header[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  String _generateLocalId() {
+    final timestamp = DateTime.now().microsecondsSinceEpoch;
+    final random = Random().nextInt(0xFFFFFF);
+    return '${TollSegmentsCsvSchema.localSegmentIdPrefix}$timestamp-$random';
+  }
+
+  String _normalizeCoordinates(String input) {
+    final parts = input.split(',');
+    if (parts.length < 2) {
+      throw const LocalSegmentsServiceException(
+        'Coordinates must be provided in the format "lat, lon".',
+      );
+    }
+
+    final lat = double.tryParse(parts[0].trim());
+    final lon = double.tryParse(parts[1].trim());
+    if (lat == null || lon == null) {
+      throw const LocalSegmentsServiceException(
+        'Coordinates must be valid decimal numbers.',
+      );
+    }
+
+    return '${lat.toStringAsFixed(6)}, ${lon.toStringAsFixed(6)}';
+  }
+}
+
+class LocalSegmentsServiceException implements Exception {
+  const LocalSegmentsServiceException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'LocalSegmentsServiceException: $message';
+}

--- a/lib/services/toll_segments_csv_constants.dart
+++ b/lib/services/toll_segments_csv_constants.dart
@@ -1,0 +1,22 @@
+/// Canonical header for the toll segments CSV files used across the app.
+///
+/// The order of these columns matches the schema produced by the Supabase
+/// export and expected by the sync service.
+class TollSegmentsCsvSchema {
+  const TollSegmentsCsvSchema._();
+
+  /// List of column headers in the order they should appear in the CSV.
+  static const List<String> header = <String>[
+    'ID',
+    'road',
+    'Start name',
+    'End name',
+    'Start',
+    'End',
+  ];
+
+  /// Prefix applied to identifiers of user-created segments that only exist on
+  /// the local device. These rows must be preserved during cloud synchronisation
+  /// to avoid losing user data.
+  static const String localSegmentIdPrefix = 'LOCAL:';
+}


### PR DESCRIPTION
## Summary
- allow create-segment flow to persist private segments locally with validation
- refresh the segments list after returning and highlight local-only segments in the UI
- reuse a shared CSV schema to keep local rows and keep them out of Supabase sync deletions

## Testing
- not run (flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e0bd09a6e0832da2b1b54014b3845b