### PR TITLE
Add local segment management and numeric ordering

### DIFF
--- a/lib/app/app_routes.dart
+++ b/lib/app/app_routes.dart
@@ -12,6 +12,7 @@ class AppRoutes {
   static const String signUp = '/sign-up';
   static const String profile = '/profile';
   static const String segments = '/segments';
+  static const String localSegments = '/segments/local';
   static const String createSegment = '/segments/create';
 
   static Map<String, WidgetBuilder> get routes => {
@@ -20,6 +21,7 @@ class AppRoutes {
     signUp: (_) => const SignUpPage(),
     profile: (_) => const ProfilePage(),
     segments: (_) => const SegmentsPage(),
+    localSegments: (_) => const LocalSegmentsPage(),
     createSegment: (_) => const CreateSegmentPage(),
   };
 }

--- a/lib/presentation/pages/segments_page.dart
+++ b/lib/presentation/pages/segments_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:toll_cam_finder/services/local_segments_service.dart';
 import 'package:toll_cam_finder/services/segments_repository.dart';
 
 import '../../app/app_routes.dart';
@@ -11,8 +12,11 @@ class SegmentsPage extends StatefulWidget {
   State<SegmentsPage> createState() => _SegmentsPageState();
 }
 
+enum _SegmentAction { delete }
+
 class _SegmentsPageState extends State<SegmentsPage> {
   final SegmentsRepository _repository = SegmentsRepository();
+  final LocalSegmentsService _localSegmentsService = LocalSegmentsService();
   late Future<List<SegmentInfo>> _segmentsFuture;
   bool _segmentsUpdated = false;
 
@@ -30,7 +34,16 @@ class _SegmentsPageState extends State<SegmentsPage> {
         return false;
       },
       child: Scaffold(
-        appBar: AppBar(title: const Text('Segments')),
+        appBar: AppBar(
+          title: const Text('Segments'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.folder_special_outlined),
+              tooltip: 'Local segments',
+              onPressed: _onShowLocalSegmentsPressed,
+            ),
+          ],
+        ),
         body: FutureBuilder<List<SegmentInfo>>(
           future: _segmentsFuture,
           builder: (context, snapshot) {
@@ -59,7 +72,10 @@ class _SegmentsPageState extends State<SegmentsPage> {
               separatorBuilder: (context, index) => const SizedBox(height: 12),
               itemBuilder: (context, index) {
                 final segment = segments[index];
-                return _SegmentCard(segment: segment);
+                return _SegmentCard(
+                  segment: segment,
+                  onLongPress: () => _onSegmentLongPress(segment),
+                );
               },
             );
           },
@@ -71,6 +87,18 @@ class _SegmentsPageState extends State<SegmentsPage> {
         ),
       ),
     );
+  }
+
+  Future<void> _onShowLocalSegmentsPressed() async {
+    final result = await Navigator.of(context).pushNamed(AppRoutes.localSegments);
+    if (!mounted || result != true) {
+      return;
+    }
+
+    _segmentsUpdated = true;
+    setState(() {
+      _segmentsFuture = _repository.loadSegments();
+    });
   }
 
   Future<void> _onCreateSegmentPressed() async {
@@ -88,53 +116,120 @@ class _SegmentsPageState extends State<SegmentsPage> {
       _segmentsFuture = _repository.loadSegments();
     });
   }
+
+  Future<void> _onSegmentLongPress(SegmentInfo segment) async {
+    final action = await _showSegmentActionsSheet(context, segment);
+    if (!mounted || action != _SegmentAction.delete) {
+      return;
+    }
+
+    await _confirmAndDeleteSegment(segment);
+  }
+
+  Future<void> _confirmAndDeleteSegment(SegmentInfo segment) async {
+    final confirmed = await _showDeleteConfirmationDialog(context, segment);
+    if (!mounted || !confirmed) {
+      return;
+    }
+
+    await _deleteSegment(segment);
+  }
+
+  Future<void> _deleteSegment(SegmentInfo segment) async {
+    final messenger = ScaffoldMessenger.of(context);
+
+    try {
+      final deleted = await _localSegmentsService.deleteLocalSegment(segment.id);
+      if (!mounted) {
+        return;
+      }
+
+      if (!deleted) {
+        messenger.showSnackBar(
+          const SnackBar(content: Text('Failed to delete the segment.')),
+        );
+        return;
+      }
+
+      messenger.showSnackBar(
+        SnackBar(content: Text('Segment ${segment.displayId} deleted.')),
+      );
+      _segmentsUpdated = true;
+      setState(() {
+        _segmentsFuture = _repository.loadSegments();
+      });
+    } on LocalSegmentsServiceException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        SnackBar(content: Text(error.message)),
+      );
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Failed to delete the segment.')),
+      );
+    }
+  }
 }
 
 class _SegmentCard extends StatelessWidget {
-  const _SegmentCard({required this.segment});
+  const _SegmentCard({
+    required this.segment,
+    this.onLongPress,
+  });
 
   final SegmentInfo segment;
+  final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Expanded(
-                  child: Text(
-                    'Segment ${segment.displayId}',
-                    style: theme.textTheme.labelMedium,
+      child: InkWell(
+        onLongPress: onLongPress,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Segment ${segment.displayId}',
+                      style: theme.textTheme.labelMedium,
+                    ),
                   ),
-                ),
-                if (segment.isLocalOnly) ...[
-                  const SizedBox(width: 8),
-                  const _LocalBadge(),
+                  if (segment.isLocalOnly) ...[
+                    const SizedBox(width: 8),
+                    const _LocalBadge(),
+                  ],
                 ],
-              ],
-            ),
-            const SizedBox(height: 4),
-            Text(segment.name, style: theme.textTheme.titleMedium),
-            const SizedBox(height: 16),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(
-                  child: _SegmentLocation(label: 'Start', value: segment.start),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: _SegmentLocation(label: 'End', value: segment.end),
-                ),
-              ],
-            ),
-          ],
+              ),
+              const SizedBox(height: 4),
+              Text(segment.name, style: theme.textTheme.titleMedium),
+              const SizedBox(height: 16),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child:
+                        _SegmentLocation(label: 'Start', value: segment.start),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: _SegmentLocation(label: 'End', value: segment.end),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -183,12 +278,170 @@ class _SegmentLocation extends StatelessWidget {
   }
 }
 
+class LocalSegmentsPage extends StatefulWidget {
+  const LocalSegmentsPage({super.key});
+
+  @override
+  State<LocalSegmentsPage> createState() => _LocalSegmentsPageState();
+}
+
+class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
+  final SegmentsRepository _repository = SegmentsRepository();
+  final LocalSegmentsService _localSegmentsService = LocalSegmentsService();
+  late Future<List<SegmentInfo>> _segmentsFuture;
+  bool _segmentsUpdated = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _segmentsFuture = _repository.loadSegments(onlyLocal: true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async {
+        Navigator.of(context).pop(_segmentsUpdated);
+        return false;
+      },
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Local segments')),
+        body: FutureBuilder<List<SegmentInfo>>(
+          future: _segmentsFuture,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            if (snapshot.hasError) {
+              return _ErrorView(
+                onRetry: () {
+                  setState(() {
+                    _segmentsFuture = _repository.loadSegments(onlyLocal: true);
+                  });
+                },
+              );
+            }
+
+            final segments = snapshot.data ?? const <SegmentInfo>[];
+            if (segments.isEmpty) {
+              return const _EmptyLocalSegmentsView();
+            }
+
+            return ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: segments.length,
+              separatorBuilder: (context, index) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                final segment = segments[index];
+                return _SegmentCard(
+                  segment: segment,
+                  onLongPress: () => _onSegmentLongPress(segment),
+                );
+              },
+            );
+          },
+        ),
+        floatingActionButton: FloatingActionButton.extended(
+          onPressed: _onCreateSegmentPressed,
+          icon: const Icon(Icons.add),
+          label: const Text('Create segment'),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _onCreateSegmentPressed() async {
+    final result = await Navigator.of(context).pushNamed(AppRoutes.createSegment);
+    if (!mounted || result != true) {
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Segment saved locally.')),
+    );
+
+    _segmentsUpdated = true;
+    setState(() {
+      _segmentsFuture = _repository.loadSegments(onlyLocal: true);
+    });
+  }
+
+  Future<void> _onSegmentLongPress(SegmentInfo segment) async {
+    final action = await _showSegmentActionsSheet(context, segment);
+    if (!mounted || action != _SegmentAction.delete) {
+      return;
+    }
+
+    await _confirmAndDeleteSegment(segment);
+  }
+
+  Future<void> _confirmAndDeleteSegment(SegmentInfo segment) async {
+    final confirmed = await _showDeleteConfirmationDialog(context, segment);
+    if (!mounted || !confirmed) {
+      return;
+    }
+
+    await _deleteSegment(segment);
+  }
+
+  Future<void> _deleteSegment(SegmentInfo segment) async {
+    final messenger = ScaffoldMessenger.of(context);
+
+    try {
+      final deleted = await _localSegmentsService.deleteLocalSegment(segment.id);
+      if (!mounted) {
+        return;
+      }
+
+      if (!deleted) {
+        messenger.showSnackBar(
+          const SnackBar(content: Text('Failed to delete the segment.')),
+        );
+        return;
+      }
+
+      messenger.showSnackBar(
+        SnackBar(content: Text('Segment ${segment.displayId} deleted.')),
+      );
+      _segmentsUpdated = true;
+      setState(() {
+        _segmentsFuture = _repository.loadSegments(onlyLocal: true);
+      });
+    } on LocalSegmentsServiceException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        SnackBar(content: Text(error.message)),
+      );
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Failed to delete the segment.')),
+      );
+    }
+  }
+}
+
+
 class _EmptySegmentsView extends StatelessWidget {
   const _EmptySegmentsView();
 
   @override
   Widget build(BuildContext context) {
     return const Center(child: Text('No segments available.'));
+  }
+}
+
+class _EmptyLocalSegmentsView extends StatelessWidget {
+  const _EmptyLocalSegmentsView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('No local segments saved yet.'));
   }
 }
 
@@ -210,4 +463,61 @@ class _ErrorView extends StatelessWidget {
       ),
     );
   }
+}
+
+Future<_SegmentAction?> _showSegmentActionsSheet(
+  BuildContext context,
+  SegmentInfo segment,
+) {
+  final canDelete = segment.isLocalOnly;
+  return showModalBottomSheet<_SegmentAction>(
+    context: context,
+    builder: (context) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.delete_outline),
+              title: const Text('Delete segment'),
+              subtitle: canDelete
+                  ? null
+                  : const Text('Only local segments can be deleted.'),
+              enabled: canDelete,
+              onTap: canDelete
+                  ? () => Navigator.of(context).pop(_SegmentAction.delete)
+                  : null,
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+Future<bool> _showDeleteConfirmationDialog(
+  BuildContext context,
+  SegmentInfo segment,
+) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        title: const Text('Delete segment'),
+        content: Text('Are you sure you want to delete segment ${segment.displayId}?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      );
+    },
+  );
+
+  return result ?? false;
 }


### PR DESCRIPTION
## Summary
- sort segment listings by numeric identifier when possible to avoid lexical ordering issues
- add long-press actions that allow deleting locally stored segments and refresh the lists
- create a dedicated local segments page and route for reviewing device-only entries

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0ca1c10f8832db2609abd2e6fee25