### PR TITLE
Fix Supabase coordinate column casing

### DIFF
--- a/lib/services/remote_segments_service.dart
+++ b/lib/services/remote_segments_service.dart
@@ -1,0 +1,61 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'local_segments_service.dart';
+
+/// Handles submitting user-created segments to Supabase for moderation.
+class RemoteSegmentsService {
+  RemoteSegmentsService({
+    SupabaseClient? client,
+    this.tableName = 'Toll_Segments',
+  }) : _client = client;
+
+  final SupabaseClient? _client;
+  final String tableName;
+
+  static const String _moderationStatusColumn = 'moderation_status';
+  static const String _pendingStatus = 'pending';
+
+  /// Uploads the supplied [draft] to Supabase, marking it as pending moderation.
+  Future<void> submitForModeration(SegmentDraft draft) async {
+    final client = _client;
+    if (client == null) {
+      throw const RemoteSegmentsServiceException(
+        'Supabase is not configured. Unable to submit the segment for moderation.',
+      );
+    }
+
+    try {
+      await client.from(tableName).insert(<String, dynamic>{
+        'road': draft.name,
+        'start_name': draft.startDisplayName,
+        'end_name': draft.endDisplayName,
+        'Start': draft.startCoordinates,
+        'End': draft.endCoordinates,
+        _moderationStatusColumn: _pendingStatus,
+      });
+    } on PostgrestException catch (error) {
+      throw RemoteSegmentsServiceException(
+        'Failed to submit the segment for moderation: ${error.message}',
+        cause: error,
+      );
+    } catch (error, stackTrace) {
+      throw RemoteSegmentsServiceException(
+        'Unexpected error while submitting the segment for moderation.',
+        cause: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+}
+
+/// Error raised when submitting a segment for moderation fails.
+class RemoteSegmentsServiceException implements Exception {
+  const RemoteSegmentsServiceException(this.message, {this.cause, this.stackTrace});
+
+  final String message;
+  final Object? cause;
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() => 'RemoteSegmentsServiceException: $message';
+}


### PR DESCRIPTION
## Summary
- expose `SegmentDraft` creation in the local segments service and reuse it when persisting user-created rows
- add a remote segments service and wire the create segment page to submit pending entries for moderation while rolling back local state on failure
- filter Supabase sync to download only segments whose moderation status is approved
- ensure Supabase submissions use the capitalized `Start`/`End` columns to match the table schema

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e0d1afe744832d840ac07a2e488ad8