### PR TITLE
Generate unique identifiers for public segment submissions

### DIFF
--- a/lib/services/local_segments_service.dart
+++ b/lib/services/local_segments_service.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:csv/csv.dart';
 import 'package:flutter/foundation.dart';
 
@@ -8,6 +6,7 @@ import 'toll_segments_file_system.dart';
 import 'toll_segments_file_system_stub.dart'
     if (dart.library.io) 'toll_segments_file_system_io.dart' as fs_impl;
 import 'toll_segments_paths.dart';
+import 'segment_id_generator.dart';
 
 /// Persists user-created segments to the local toll segments CSV.
 class LocalSegmentsService {
@@ -76,7 +75,7 @@ class LocalSegmentsService {
       rows.insert(0, TollSegmentsCsvSchema.header);
     }
 
-    final localId = _generateLocalId();
+    final localId = SegmentIdGenerator.generateLocalId();
     final newRow = <String>[
       localId,
       draft.name,
@@ -190,12 +189,6 @@ class LocalSegmentsService {
       }
     }
     return true;
-  }
-
-  String _generateLocalId() {
-    final timestamp = DateTime.now().microsecondsSinceEpoch;
-    final random = Random().nextInt(0xFFFFFF);
-    return '${TollSegmentsCsvSchema.localSegmentIdPrefix}$timestamp-$random';
   }
 
   String _normalizeCoordinates(String input) {

--- a/lib/services/remote_segments_service.dart
+++ b/lib/services/remote_segments_service.dart
@@ -1,6 +1,7 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'local_segments_service.dart';
+import 'segment_id_generator.dart';
 
 /// Handles submitting user-created segments to Supabase for moderation.
 class RemoteSegmentsService {
@@ -24,8 +25,11 @@ class RemoteSegmentsService {
       );
     }
 
+    final pendingId = SegmentIdGenerator.generateRemoteId();
+
     try {
       await client.from(tableName).insert(<String, dynamic>{
+        'id': pendingId,
         'road': draft.name,
         'Start name': draft.startDisplayName,
         'End name': draft.endDisplayName,

--- a/lib/services/segment_id_generator.dart
+++ b/lib/services/segment_id_generator.dart
@@ -1,0 +1,27 @@
+import 'package:uuid/uuid.dart';
+
+import 'toll_segments_csv_constants.dart';
+
+/// Generates unique identifiers for user-created segments.
+class SegmentIdGenerator {
+  SegmentIdGenerator._();
+
+  static const String _remotePrefix = 'REMOTE:';
+  static const Uuid _uuid = Uuid();
+
+  /// Generates an identifier suitable for storing local-only segments.
+  static String generateLocalId() {
+    return '${TollSegmentsCsvSchema.localSegmentIdPrefix}${_generateSuffix()}';
+  }
+
+  /// Generates an identifier suitable for submitting segments to the backend.
+  static String generateRemoteId() {
+    return '$_remotePrefix${_generateSuffix()}';
+  }
+
+  static String _generateSuffix() {
+    final timestamp = DateTime.now().toUtc().microsecondsSinceEpoch.toRadixString(36);
+    final uniqueComponent = _uuid.v7().replaceAll('-', '');
+    return '$timestamp-$uniqueComponent';
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -982,13 +982,13 @@ packages:
     source: hosted
     version: "3.1.4"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
-      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      sha256: 814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.1"
+    version: "4.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   test: ^1.26.2
   csv: ^6.0.0
   supabase_flutter: ^2.10.1
+  uuid: ^4.4.0
 
 dev_dependencies:
   flutter_test:

--- a/test/services/segment_id_generator_test.dart
+++ b/test/services/segment_id_generator_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:toll_cam_finder/services/segment_id_generator.dart';
+import 'package:toll_cam_finder/services/toll_segments_csv_constants.dart';
+
+void main() {
+  test('generateLocalId returns unique values with expected prefix', () {
+    final prefix = TollSegmentsCsvSchema.localSegmentIdPrefix;
+    final generated = <String>{};
+
+    for (var i = 0; i < 500; i++) {
+      final id = SegmentIdGenerator.generateLocalId();
+      expect(id.startsWith(prefix), isTrue, reason: 'Local ID should start with prefix.');
+      expect(generated.add(id), isTrue, reason: 'Local IDs must be unique.');
+    }
+  });
+
+  test('generateRemoteId returns unique values with remote prefix', () {
+    const remotePrefix = 'REMOTE:';
+    final generated = <String>{};
+
+    for (var i = 0; i < 500; i++) {
+      final id = SegmentIdGenerator.generateRemoteId();
+      expect(id.startsWith(remotePrefix), isTrue, reason: 'Remote ID should start with remote prefix.');
+      expect(generated.add(id), isTrue, reason: 'Remote IDs must be unique.');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add a dedicated SegmentIdGenerator that produces timestamped UUID-based IDs
- use the generator for local drafts and include generated IDs when inserting into Supabase
- depend on the uuid package and cover the generator with unit tests

## Testing
- Not run (Flutter SDK not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0ded295a8832db27c8ddf9237c78b