### PR TITLE
Require authentication for public segment submissions

### DIFF
--- a/lib/services/auth_controller.dart
+++ b/lib/services/auth_controller.dart
@@ -23,10 +23,12 @@ class AuthController extends ChangeNotifier {
   bool _isLoggedIn = false;
   String? _currentEmail;
   String? _pendingEmail;
+  String? _currentUserId;
 
   bool get isLoggedIn => _isLoggedIn;
   String? get currentEmail => _currentEmail;
   String? get pendingEmail => _pendingEmail;
+  String? get currentUserId => _currentUserId;
   bool get isConfigured => _client != null;
   SupabaseClient? get client => _client;
   
@@ -106,7 +108,7 @@ class AuthController extends ChangeNotifier {
   }
 
   Future<void> logOut() async {
-   if (_client == null) {
+    if (_client == null) {
       _applySession(null);
       return;
     }
@@ -125,9 +127,13 @@ class AuthController extends ChangeNotifier {
   void _applySession(Session? session) {
     final user = session?.user;
     _currentEmail = user?.email;
+    _currentUserId = user?.id;
     _isLoggedIn = user != null;
     if (user != null) {
       _pendingEmail = null;
+    }
+    if (user == null) {
+      _currentUserId = null;
     }
     notifyListeners();
   }

--- a/lib/services/remote_segments_service.dart
+++ b/lib/services/remote_segments_service.dart
@@ -17,13 +17,23 @@ class RemoteSegmentsService {
   static const String _approvedStatus = 'approved';
   static const String _idColumn = 'id';
   static const int _smallIntMax = 32767;
+  static const String _addedByUserColumn = 'added_by_user';
 
   /// Uploads the supplied [draft] to Supabase, marking it as pending moderation.
-  Future<void> submitForModeration(SegmentDraft draft) async {
+  Future<void> submitForModeration(
+    SegmentDraft draft, {
+    required String addedByUserId,
+  }) async {
     final client = _client;
     if (client == null) {
       throw const RemoteSegmentsServiceException(
         'Supabase is not configured. Unable to submit the segment for moderation.',
+      );
+    }
+
+    if (addedByUserId.trim().isEmpty) {
+      throw const RemoteSegmentsServiceException(
+        'A logged in user is required to submit a public segment for moderation.',
       );
     }
 
@@ -38,6 +48,7 @@ class RemoteSegmentsService {
         'Start': draft.startCoordinates,
         'End': draft.endCoordinates,
         _moderationStatusColumn: _pendingStatus,
+        _addedByUserColumn: addedByUserId,
       });
     } on PostgrestException catch (error) {
       throw RemoteSegmentsServiceException(

--- a/lib/services/toll_segments_sync_service.dart
+++ b/lib/services/toll_segments_sync_service.dart
@@ -29,6 +29,7 @@ class TollSegmentsSyncService {
 
   static const String _moderationStatusColumn = 'moderation_status';
   static const String _approvedStatus = 'approved';
+  static const String _addedByUserColumn = 'added_by_user';
 
   /// Performs the synchronization flow.
   ///
@@ -139,7 +140,12 @@ class TollSegmentsSyncService {
           .select('*')
           .eq(_moderationStatusColumn, _approvedStatus);
 
-      return response.cast<Map<String, dynamic>>();
+      return response
+          .cast<Map<String, dynamic>>()
+          .map((record) => Map<String, dynamic>.from(record)
+            ..removeWhere((key, value) =>
+                _normalize(key) == _normalize(_addedByUserColumn)))
+          .toList(growable: false);
     } on PostgrestException catch (error) {
       if (_isMissingColumnError(error, _moderationStatusColumn)) {
         throw TollSegmentsSyncException(


### PR DESCRIPTION
## Summary
- require users to be logged in before submitting a public segment and surface helpful error messaging
- include the authenticated user's id when uploading public segment drafts for moderation
- exclude the new added_by_user column from synced segment data to avoid exposing it to other users

## Testing
- not run (flutter tooling unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68e1045cfdb8832db8523260280774dd