### PR TITLE
Persist create segment drafts and return after login

### DIFF
--- a/lib/presentation/pages/auth/login_page.dart
+++ b/lib/presentation/pages/auth/login_page.dart
@@ -44,18 +44,24 @@ class _LoginPageState extends State<LoginPage> {
     });
    
     final auth = context.read<AuthController>();
-    
-     try {
+    final shouldPopOnSuccess =
+        ModalRoute.of(context)?.settings.arguments == true;
+
+    try {
       await auth.logIn(
         email: _emailController.text.trim(),
         password: _passwordController.text,
       );
 
-    if (!mounted) return;
-      Navigator.of(context).pushNamedAndRemoveUntil(
-        AppRoutes.profile,
-        ModalRoute.withName(AppRoutes.map),
-      );
+      if (!mounted) return;
+      if (shouldPopOnSuccess) {
+        Navigator.of(context).pop(true);
+      } else {
+        Navigator.of(context).pushNamedAndRemoveUntil(
+          AppRoutes.profile,
+          ModalRoute.withName(AppRoutes.map),
+        );
+      }
     } on AuthFailure catch (error) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -130,7 +136,7 @@ class _LoginPageState extends State<LoginPage> {
                 ),
                 const SizedBox(height: 24),
                 ElevatedButton(
-                 onPressed: _isSubmitting ? null : _submit,
+                  onPressed: _isSubmitting ? null : _submit,
                   child: _isSubmitting
                       ? const SizedBox(
                           height: 20,

--- a/lib/presentation/widgets/segment_picker/segment_picker_map.dart
+++ b/lib/presentation/widgets/segment_picker/segment_picker_map.dart
@@ -141,6 +141,11 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
                 icon: Icons.remove,
                 onPressed: () => _zoomBy(-AppConstants.segmentPickerZoomStep),
               ),
+              const SizedBox(height: AppConstants.segmentPickerZoomButtonSpacing),
+              MapActionButton(
+                icon: Icons.clear,
+                onPressed: _clearEndpoints,
+              ),
             ],
           ),
         ),
@@ -270,6 +275,23 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
     }
   }
 
+  void _clearEndpoints() {
+    if (_start == null && _end == null) {
+      return;
+    }
+    setState(() {
+      _start = null;
+      _end = null;
+      _routePoints = null;
+      _lastRouteStart = null;
+      _lastRouteEnd = null;
+      _routeRequestToken = null;
+    });
+    _clearController(widget.startController);
+    _clearController(widget.endController);
+    _mapController.move(AppConstants.initialCenter, AppConstants.initialZoom);
+  }
+
   void _zoomBy(double delta) {
     final camera = _mapController.camera;
     final targetZoom = (camera.zoom + delta)
@@ -278,8 +300,16 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
   }
 
   void _writeToController(TextEditingController controller, LatLng latLng) {
+    _setControllerText(controller, _formatLatLng(latLng));
+  }
+
+  void _clearController(TextEditingController controller) {
+    _setControllerText(controller, '');
+  }
+
+  void _setControllerText(TextEditingController controller, String value) {
     _updatingControllers = true;
-    controller.text = _formatLatLng(latLng);
+    controller.text = value;
     _updatingControllers = false;
   }
 


### PR DESCRIPTION
## Summary
- add login route import to the create segment page
- replace the snackbar shown when unauthenticated users publish segments with a dialog offering login or local save
- return users to the create segment screen after a successful login initiated from the publish dialog
- persist create segment form fields between visits and add a map action to clear both endpoints

## Testing
- not run (flutter is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e108770914832db7837e97114345d0