### PR TITLE
Track public submission state for local segments

### DIFF
--- a/lib/presentation/pages/create_segment_page.dart
+++ b/lib/presentation/pages/create_segment_page.dart
@@ -275,7 +275,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
       return;
     }
 
-    final localId = await _saveDraftLocally(draft);
+    final localId = await _saveDraftLocally(draft, isPublic: true);
     if (localId == null) {
       return;
     }
@@ -327,9 +327,15 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     }
   }
 
-  Future<String?> _saveDraftLocally(SegmentDraft draft) async {
+  Future<String?> _saveDraftLocally(
+    SegmentDraft draft, {
+    bool isPublic = false,
+  }) async {
     try {
-      return await _localSegmentsService.saveDraft(draft);
+      return await _localSegmentsService.saveDraft(
+        draft,
+        isPublic: isPublic,
+      );
     } on LocalSegmentsServiceException catch (error) {
       _showSnackBar(error.message);
     } catch (_) {

--- a/lib/presentation/pages/segments_page.dart
+++ b/lib/presentation/pages/segments_page.dart
@@ -144,48 +144,57 @@ class _SegmentsPageState extends State<SegmentsPage> {
   }
 
   Future<bool> _handleRemoteSubmissionCancellation(SegmentInfo segment) async {
+    if (!segment.submittedForReview) {
+      return true;
+    }
+
+    final shouldWithdraw =
+        await _showCancelRemoteSubmissionDialog(context, segment);
+    if (!mounted) {
+      return false;
+    }
+
+    if (shouldWithdraw != true) {
+      return true;
+    }
+
+    final messenger = ScaffoldMessenger.of(context);
+
     AuthController auth;
     try {
       auth = context.read<AuthController>();
     } catch (_) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('You must be logged in to withdraw the public submission.'),
+        ),
+      );
+      return false;
     }
 
     if (!auth.isLoggedIn || !auth.isConfigured) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('You must be logged in to withdraw the public submission.'),
+        ),
+      );
+      return false;
     }
 
     final userId = auth.currentUserId;
     final client = auth.client;
     if (userId == null || userId.isEmpty || client == null) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Unable to withdraw the public submission for this segment.'),
+        ),
+      );
+      return false;
     }
 
-    final messenger = ScaffoldMessenger.of(context);
     final remoteService = RemoteSegmentsService(client: client);
 
     try {
-      final hasPending = await remoteService.hasPendingSubmission(
-        addedByUserId: userId,
-        name: segment.name,
-        startCoordinates: segment.start,
-        endCoordinates: segment.end,
-      );
-
-      if (!hasPending) {
-        return true;
-      }
-
-      final shouldCancel =
-          await _showCancelRemoteSubmissionDialog(context, segment);
-      if (!mounted) {
-        return false;
-      }
-
-      if (shouldCancel != true) {
-        return true;
-      }
-
       final deleted = await remoteService.deletePendingSubmission(
         addedByUserId: userId,
         name: segment.name,
@@ -204,8 +213,9 @@ class _SegmentsPageState extends State<SegmentsPage> {
       } else {
         messenger.showSnackBar(
           const SnackBar(
-            content:
-                Text('The public review request for this segment was already processed.'),
+            content: Text(
+              'The public review request for this segment was already processed.',
+            ),
           ),
         );
       }
@@ -480,48 +490,57 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
   }
 
   Future<bool> _handleRemoteSubmissionCancellation(SegmentInfo segment) async {
+    if (!segment.submittedForReview) {
+      return true;
+    }
+
+    final shouldWithdraw =
+        await _showCancelRemoteSubmissionDialog(context, segment);
+    if (!mounted) {
+      return false;
+    }
+
+    if (shouldWithdraw != true) {
+      return true;
+    }
+
+    final messenger = ScaffoldMessenger.of(context);
+
     AuthController auth;
     try {
       auth = context.read<AuthController>();
     } catch (_) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('You must be logged in to withdraw the public submission.'),
+        ),
+      );
+      return false;
     }
 
     if (!auth.isLoggedIn || !auth.isConfigured) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('You must be logged in to withdraw the public submission.'),
+        ),
+      );
+      return false;
     }
 
     final userId = auth.currentUserId;
     final client = auth.client;
     if (userId == null || userId.isEmpty || client == null) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Unable to withdraw the public submission for this segment.'),
+        ),
+      );
+      return false;
     }
 
-    final messenger = ScaffoldMessenger.of(context);
     final remoteService = RemoteSegmentsService(client: client);
 
     try {
-      final hasPending = await remoteService.hasPendingSubmission(
-        addedByUserId: userId,
-        name: segment.name,
-        startCoordinates: segment.start,
-        endCoordinates: segment.end,
-      );
-
-      if (!hasPending) {
-        return true;
-      }
-
-      final shouldCancel =
-          await _showCancelRemoteSubmissionDialog(context, segment);
-      if (!mounted) {
-        return false;
-      }
-
-      if (shouldCancel != true) {
-        return true;
-      }
-
       final deleted = await remoteService.deletePendingSubmission(
         addedByUserId: userId,
         name: segment.name,
@@ -540,8 +559,9 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
       } else {
         messenger.showSnackBar(
           const SnackBar(
-            content:
-                Text('The public review request for this segment was already processed.'),
+            content: Text(
+              'The public review request for this segment was already processed.',
+            ),
           ),
         );
       }
@@ -705,20 +725,18 @@ Future<bool> _showCancelRemoteSubmissionDialog(
     context: context,
     builder: (context) {
       return AlertDialog(
-        title: const Text('Cancel public submission?'),
-        content: Text(
-          'Segment ${segment.displayId} was submitted for public review. '
-          'Cancelling the public submission will prevent it from being published. '
-          'Do you want to cancel the public submission as well?',
+        title: const Text('Withdraw public submission?'),
+        content: const Text(
+          'u have submitted this segment for review, do you want to withdraw the submition',
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Keep submission'),
+            child: const Text('No'),
           ),
           FilledButton(
             onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Cancel submission'),
+            child: const Text('Yes'),
           ),
         ],
       );

--- a/lib/services/toll_segments_paths.dart
+++ b/lib/services/toll_segments_paths.dart
@@ -8,6 +8,9 @@ const String kTollSegmentsAssetPath = 'assets/data/toll_segments.csv';
 /// Default file name used when storing the synced toll segments data on disk.
 const String kTollSegmentsFileName = 'toll_segments.csv';
 
+/// Default file name used to persist metadata about locally created segments.
+const String kTollSegmentsMetadataFileName = 'toll_segments_public.json';
+
 /// Function signature for providing a custom on-disk location for the synced
 /// toll segments CSV. Useful for tests.
 typedef TollSegmentsPathResolver = Future<String> Function();
@@ -33,4 +36,24 @@ Future<String> resolveTollSegmentsDataPath({
 
   final directory = await getApplicationSupportDirectory();
   return p.join(directory.path, kTollSegmentsFileName);
+}
+
+/// Resolves the absolute path where metadata for locally created segments
+/// should be stored. The metadata file lives alongside the CSV that stores the
+/// segment records.
+Future<String> resolveTollSegmentsMetadataPath({
+  TollSegmentsPathResolver? overrideResolver,
+}) async {
+  final csvPath = await resolveTollSegmentsDataPath(
+    overrideResolver: overrideResolver,
+  );
+
+  if (kIsWeb) {
+    // Web builds cannot persist to disk. A synthetic asset-like path is
+    // returned for consistency, even though it will not be used.
+    return p.setExtension(csvPath, '.public.json');
+  }
+
+  final directory = p.dirname(csvPath);
+  return p.join(directory, kTollSegmentsMetadataFileName);
 }


### PR DESCRIPTION
## Summary
- add a lightweight metadata file so LocalSegmentsService can remember which local segments were submitted for public review
- extend SegmentInfo and the segments page workflow to respect the stored flag and let users withdraw the remote submission when deleting
- mark public drafts during creation and expose a helper to resolve the metadata path alongside the CSV storage

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e13eeb4488832db34de87d15ded0e0