### PR TITLE
Check Supabase before offering withdrawal dialog

### DIFF
--- a/lib/presentation/pages/create_segment_page.dart
+++ b/lib/presentation/pages/create_segment_page.dart
@@ -275,7 +275,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
       return;
     }
 
-    final localId = await _saveDraftLocally(draft, isPublic: true);
+    final localId = await _saveDraftLocally(draft);
     if (localId == null) {
       return;
     }
@@ -328,14 +328,10 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
   }
 
   Future<String?> _saveDraftLocally(
-    SegmentDraft draft, {
-    bool isPublic = false,
-  }) async {
+    SegmentDraft draft,
+  ) async {
     try {
-      return await _localSegmentsService.saveDraft(
-        draft,
-        isPublic: isPublic,
-      );
+      return await _localSegmentsService.saveDraft(draft);
     } on LocalSegmentsServiceException catch (error) {
       _showSnackBar(error.message);
     } catch (_) {

--- a/lib/presentation/pages/segments_page.dart
+++ b/lib/presentation/pages/segments_page.dart
@@ -144,8 +144,48 @@ class _SegmentsPageState extends State<SegmentsPage> {
   }
 
   Future<bool> _handleRemoteSubmissionCancellation(SegmentInfo segment) async {
-    if (!segment.submittedForReview) {
+    final messenger = ScaffoldMessenger.of(context);
+
+    AuthController? auth;
+    try {
+      auth = context.read<AuthController>();
+    } catch (_) {
+      auth = null;
+    }
+
+    if (auth == null || !auth.isLoggedIn || !auth.isConfigured) {
       return true;
+    }
+
+    final userId = auth.currentUserId;
+    final client = auth.client;
+    if (userId == null || userId.isEmpty || client == null) {
+      return true;
+    }
+
+    final remoteService = RemoteSegmentsService(client: client);
+
+    try {
+      final hasPending = await remoteService.hasPendingSubmission(
+        addedByUserId: userId,
+        name: segment.name,
+        startCoordinates: segment.start,
+        endCoordinates: segment.end,
+      );
+
+      if (!hasPending) {
+        return true;
+      }
+    } on RemoteSegmentsServiceException catch (error) {
+      messenger.showSnackBar(SnackBar(content: Text(error.message)));
+      return false;
+    } catch (_) {
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Failed to check the public submission status.'),
+        ),
+      );
+      return false;
     }
 
     final shouldWithdraw =
@@ -157,42 +197,6 @@ class _SegmentsPageState extends State<SegmentsPage> {
     if (shouldWithdraw != true) {
       return true;
     }
-
-    final messenger = ScaffoldMessenger.of(context);
-
-    AuthController auth;
-    try {
-      auth = context.read<AuthController>();
-    } catch (_) {
-      messenger.showSnackBar(
-        const SnackBar(
-          content: Text('You must be logged in to withdraw the public submission.'),
-        ),
-      );
-      return false;
-    }
-
-    if (!auth.isLoggedIn || !auth.isConfigured) {
-      messenger.showSnackBar(
-        const SnackBar(
-          content: Text('You must be logged in to withdraw the public submission.'),
-        ),
-      );
-      return false;
-    }
-
-    final userId = auth.currentUserId;
-    final client = auth.client;
-    if (userId == null || userId.isEmpty || client == null) {
-      messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Unable to withdraw the public submission for this segment.'),
-        ),
-      );
-      return false;
-    }
-
-    final remoteService = RemoteSegmentsService(client: client);
 
     try {
       final deleted = await remoteService.deletePendingSubmission(
@@ -490,8 +494,48 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
   }
 
   Future<bool> _handleRemoteSubmissionCancellation(SegmentInfo segment) async {
-    if (!segment.submittedForReview) {
+    final messenger = ScaffoldMessenger.of(context);
+
+    AuthController? auth;
+    try {
+      auth = context.read<AuthController>();
+    } catch (_) {
+      auth = null;
+    }
+
+    if (auth == null || !auth.isLoggedIn || !auth.isConfigured) {
       return true;
+    }
+
+    final userId = auth.currentUserId;
+    final client = auth.client;
+    if (userId == null || userId.isEmpty || client == null) {
+      return true;
+    }
+
+    final remoteService = RemoteSegmentsService(client: client);
+
+    try {
+      final hasPending = await remoteService.hasPendingSubmission(
+        addedByUserId: userId,
+        name: segment.name,
+        startCoordinates: segment.start,
+        endCoordinates: segment.end,
+      );
+
+      if (!hasPending) {
+        return true;
+      }
+    } on RemoteSegmentsServiceException catch (error) {
+      messenger.showSnackBar(SnackBar(content: Text(error.message)));
+      return false;
+    } catch (_) {
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Failed to check the public submission status.'),
+        ),
+      );
+      return false;
     }
 
     final shouldWithdraw =
@@ -503,42 +547,6 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
     if (shouldWithdraw != true) {
       return true;
     }
-
-    final messenger = ScaffoldMessenger.of(context);
-
-    AuthController auth;
-    try {
-      auth = context.read<AuthController>();
-    } catch (_) {
-      messenger.showSnackBar(
-        const SnackBar(
-          content: Text('You must be logged in to withdraw the public submission.'),
-        ),
-      );
-      return false;
-    }
-
-    if (!auth.isLoggedIn || !auth.isConfigured) {
-      messenger.showSnackBar(
-        const SnackBar(
-          content: Text('You must be logged in to withdraw the public submission.'),
-        ),
-      );
-      return false;
-    }
-
-    final userId = auth.currentUserId;
-    final client = auth.client;
-    if (userId == null || userId.isEmpty || client == null) {
-      messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Unable to withdraw the public submission for this segment.'),
-        ),
-      );
-      return false;
-    }
-
-    final remoteService = RemoteSegmentsService(client: client);
 
     try {
       final deleted = await remoteService.deletePendingSubmission(

--- a/lib/services/segments_repository.dart
+++ b/lib/services/segments_repository.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:csv/csv.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
@@ -18,7 +16,6 @@ class SegmentInfo {
     required this.start,
     required this.end,
     this.isLocalOnly = false,
-    this.submittedForReview = false,
   });
 
   final String id;
@@ -26,7 +23,6 @@ class SegmentInfo {
   final String start;
   final String end;
   final bool isLocalOnly;
-  final bool submittedForReview;
 
   String get displayId {
     if (!isLocalOnly) {
@@ -67,10 +63,6 @@ class SegmentsRepository {
       return const [];
     }
 
-    final submittedIds = (!kIsWeb && assetPath == kTollSegmentsAssetPath)
-        ? await _loadSubmittedSegmentIds()
-        : <String>{};
-
     final segments = <SegmentInfo>[];
     for (final row in rows.skip(1)) {
       if (row.length <= idIndex ||
@@ -100,7 +92,6 @@ class SegmentsRepository {
           start: start,
           end: end,
           isLocalOnly: isLocalOnly,
-          submittedForReview: submittedIds.contains(id),
         ),
       );
     }
@@ -180,28 +171,5 @@ class SegmentsRepository {
     }
 
     return rootBundle.loadString(assetPath);
-  }
-
-  Future<Set<String>> _loadSubmittedSegmentIds() async {
-    try {
-      final metadataPath = await resolveTollSegmentsMetadataPath();
-      if (!await _fileSystem.exists(metadataPath)) {
-        return <String>{};
-      }
-
-      final contents = await _fileSystem.readAsString(metadataPath);
-      if (contents.trim().isEmpty) {
-        return <String>{};
-      }
-
-      final decoded = jsonDecode(contents);
-      if (decoded is List) {
-        return decoded.map((entry) => '$entry').toSet();
-      }
-    } catch (_) {
-      // Ignore metadata parsing failures; treat as if there is no metadata.
-    }
-
-    return <String>{};
   }
 }


### PR DESCRIPTION
## Summary
- remove the local metadata tracking for submitted segments so the repository only reflects CSV contents
- simplify the local draft persistence API now that submission metadata is gone
- check Supabase for pending submissions before showing the withdrawal dialog and delete the remote request only when needed

## Testing
- not run (flutter is not installed in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e14c801a90832da82008458866ead4