### PR TITLE
Ensure withdrawing segments removes Supabase submission

### DIFF
--- a/lib/presentation/pages/create_segment_page.dart
+++ b/lib/presentation/pages/create_segment_page.dart
@@ -182,7 +182,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
   }
 
   Future<void> _handlePrivateSegmentSaved() async {
-    final draft = _buildDraft();
+    final draft = _buildDraft(isPublic: false);
     if (draft == null) {
       return;
     }
@@ -270,7 +270,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
       return;
     }
 
-    final draft = _buildDraft();
+    final draft = _buildDraft(isPublic: true);
     if (draft == null) {
       return;
     }
@@ -308,7 +308,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     Navigator.of(context).pop(true);
   }
 
-  SegmentDraft? _buildDraft() {
+  SegmentDraft? _buildDraft({required bool isPublic}) {
     if (_startController.text.trim().isEmpty ||
         _endController.text.trim().isEmpty) {
       _showSnackBar('Start and end coordinates are required.');
@@ -320,6 +320,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
         name: _nameController.text,
         startCoordinates: _startController.text,
         endCoordinates: _endController.text,
+        isPublic: isPublic,
       );
     } on LocalSegmentsServiceException catch (error) {
       _showSnackBar(error.message);

--- a/lib/presentation/pages/segments_page.dart
+++ b/lib/presentation/pages/segments_page.dart
@@ -144,49 +144,58 @@ class _SegmentsPageState extends State<SegmentsPage> {
   }
 
   Future<bool> _handleRemoteSubmissionCancellation(SegmentInfo segment) async {
+    if (!segment.isMarkedPublic) {
+      return true;
+    }
+
+    final shouldWithdraw =
+        await _showCancelRemoteSubmissionDialog(context, segment);
+    if (!mounted) {
+      return false;
+    }
+
+    if (shouldWithdraw != true) {
+      return true;
+    }
+
+    final messenger = ScaffoldMessenger.of(context);
+
     AuthController auth;
     try {
       auth = context.read<AuthController>();
     } catch (_) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Unable to withdraw the public submission.'),
+        ),
+      );
+      return false;
     }
 
     if (!auth.isLoggedIn || !auth.isConfigured) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Please sign in to withdraw the public submission.'),
+        ),
+      );
+      return false;
     }
 
     final userId = auth.currentUserId;
     final client = auth.client;
     if (userId == null || userId.isEmpty || client == null) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Unable to withdraw the public submission.'),
+        ),
+      );
+      return false;
     }
 
-    final messenger = ScaffoldMessenger.of(context);
     final remoteService = RemoteSegmentsService(client: client);
 
     try {
-      final hasPending = await remoteService.hasPendingSubmission(
-        addedByUserId: userId,
-        name: segment.name,
-        startCoordinates: segment.start,
-        endCoordinates: segment.end,
-      );
-
-      if (!hasPending) {
-        return true;
-      }
-
-      final shouldCancel =
-          await _showCancelRemoteSubmissionDialog(context, segment);
-      if (!mounted) {
-        return false;
-      }
-
-      if (shouldCancel != true) {
-        return true;
-      }
-
-      final deleted = await remoteService.deletePendingSubmission(
+      final deleted = await remoteService.deleteSubmission(
         addedByUserId: userId,
         name: segment.name,
         startCoordinates: segment.start,
@@ -199,13 +208,6 @@ class _SegmentsPageState extends State<SegmentsPage> {
             content: Text(
               'Segment ${segment.displayId} will no longer be reviewed for public release.',
             ),
-          ),
-        );
-      } else {
-        messenger.showSnackBar(
-          const SnackBar(
-            content:
-                Text('The public review request for this segment was already processed.'),
           ),
         );
       }
@@ -480,49 +482,58 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
   }
 
   Future<bool> _handleRemoteSubmissionCancellation(SegmentInfo segment) async {
+    if (!segment.isMarkedPublic) {
+      return true;
+    }
+
+    final shouldWithdraw =
+        await _showCancelRemoteSubmissionDialog(context, segment);
+    if (!mounted) {
+      return false;
+    }
+
+    if (shouldWithdraw != true) {
+      return true;
+    }
+
+    final messenger = ScaffoldMessenger.of(context);
+
     AuthController auth;
     try {
       auth = context.read<AuthController>();
     } catch (_) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Unable to withdraw the public submission.'),
+        ),
+      );
+      return false;
     }
 
     if (!auth.isLoggedIn || !auth.isConfigured) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Please sign in to withdraw the public submission.'),
+        ),
+      );
+      return false;
     }
 
     final userId = auth.currentUserId;
     final client = auth.client;
     if (userId == null || userId.isEmpty || client == null) {
-      return true;
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Unable to withdraw the public submission.'),
+        ),
+      );
+      return false;
     }
 
-    final messenger = ScaffoldMessenger.of(context);
     final remoteService = RemoteSegmentsService(client: client);
 
     try {
-      final hasPending = await remoteService.hasPendingSubmission(
-        addedByUserId: userId,
-        name: segment.name,
-        startCoordinates: segment.start,
-        endCoordinates: segment.end,
-      );
-
-      if (!hasPending) {
-        return true;
-      }
-
-      final shouldCancel =
-          await _showCancelRemoteSubmissionDialog(context, segment);
-      if (!mounted) {
-        return false;
-      }
-
-      if (shouldCancel != true) {
-        return true;
-      }
-
-      final deleted = await remoteService.deletePendingSubmission(
+      final deleted = await remoteService.deleteSubmission(
         addedByUserId: userId,
         name: segment.name,
         startCoordinates: segment.start,
@@ -535,13 +546,6 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
             content: Text(
               'Segment ${segment.displayId} will no longer be reviewed for public release.',
             ),
-          ),
-        );
-      } else {
-        messenger.showSnackBar(
-          const SnackBar(
-            content:
-                Text('The public review request for this segment was already processed.'),
           ),
         );
       }
@@ -705,20 +709,19 @@ Future<bool> _showCancelRemoteSubmissionDialog(
     context: context,
     builder: (context) {
       return AlertDialog(
-        title: const Text('Cancel public submission?'),
-        content: Text(
-          'Segment ${segment.displayId} was submitted for public review. '
-          'Cancelling the public submission will prevent it from being published. '
-          'Do you want to cancel the public submission as well?',
+        title: const Text('Withdraw public submission?'),
+        content: const Text(
+          'You have submitted this segment for review. '
+          'Do you want to withdraw the submission?',
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Keep submission'),
+            child: const Text('No'),
           ),
           FilledButton(
             onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Cancel submission'),
+            child: const Text('Yes'),
           ),
         ],
       );

--- a/lib/services/remote_segments_service.dart
+++ b/lib/services/remote_segments_service.dart
@@ -109,9 +109,10 @@ class RemoteSegmentsService {
     }
   }
 
-  /// Deletes the pending moderation request that matches the provided segment
-  /// for the supplied user. Returns `true` if a submission was deleted.
-  Future<bool> deletePendingSubmission({
+  /// Deletes the moderation request that matches the provided segment for the
+  /// supplied user, regardless of the current moderation status. Returns
+  /// `true` if a submission was deleted.
+  Future<bool> deleteSubmission({
     required String addedByUserId,
     required String name,
     required String startCoordinates,
@@ -129,7 +130,6 @@ class RemoteSegmentsService {
           .from(tableName)
           .delete()
           .match(<String, Object>{
-        _moderationStatusColumn: _pendingStatus,
         _addedByUserColumn: addedByUserId,
         _roadColumn: name,
         _startColumn: startCoordinates,

--- a/lib/services/toll_segments_paths.dart
+++ b/lib/services/toll_segments_paths.dart
@@ -8,6 +8,9 @@ const String kTollSegmentsAssetPath = 'assets/data/toll_segments.csv';
 /// Default file name used when storing the synced toll segments data on disk.
 const String kTollSegmentsFileName = 'toll_segments.csv';
 
+/// Suffix appended to the toll segments CSV path to store local metadata.
+const String kTollSegmentsMetadataSuffix = '_metadata.json';
+
 /// Function signature for providing a custom on-disk location for the synced
 /// toll segments CSV. Useful for tests.
 typedef TollSegmentsPathResolver = Future<String> Function();
@@ -34,3 +37,15 @@ Future<String> resolveTollSegmentsDataPath({
   final directory = await getApplicationSupportDirectory();
   return p.join(directory.path, kTollSegmentsFileName);
 }
+
+/// Resolves the path where metadata related to the toll segments CSV should be
+/// stored.
+Future<String> resolveTollSegmentsMetadataPath({
+  TollSegmentsPathResolver? overrideResolver,
+}) async {
+  final csvPath = await resolveTollSegmentsDataPath(
+    overrideResolver: overrideResolver,
+  );
+  return '$csvPath$kTollSegmentsMetadataSuffix';
+}
+


### PR DESCRIPTION
## Summary
- delete Supabase submissions for withdrawn segments regardless of moderation status
- avoid warning users that the public review request was already processed when withdrawing

## Testing
- Not run (flutter command unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e14ef95c90832d8a286ac2cef4caf2