### PR TITLE
Add road metadata when creating segments

### DIFF
--- a/lib/presentation/pages/create_segment_page.dart
+++ b/lib/presentation/pages/create_segment_page.dart
@@ -16,12 +16,14 @@ class CreateSegmentPage extends StatefulWidget {
 
 class _CreateSegmentPageState extends State<CreateSegmentPage> {
   static String? _cachedName;
+  static String? _cachedRoadName;
   static String? _cachedStartDisplayName;
   static String? _cachedEndDisplayName;
   static String? _cachedStartCoordinates;
   static String? _cachedEndCoordinates;
 
   final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _roadController = TextEditingController();
   final TextEditingController _startNameController = TextEditingController();
   final TextEditingController _endNameController = TextEditingController();
   final TextEditingController _startController = TextEditingController();
@@ -35,6 +37,9 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     super.initState();
     if (_cachedName != null) {
       _nameController.text = _cachedName!;
+    }
+    if (_cachedRoadName != null) {
+      _roadController.text = _cachedRoadName!;
     }
     if (_cachedStartDisplayName != null) {
       _startNameController.text = _cachedStartDisplayName!;
@@ -54,18 +59,21 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
   void dispose() {
     if (_persistDraftOnDispose) {
       _cachedName = _nameController.text;
+      _cachedRoadName = _roadController.text;
       _cachedStartDisplayName = _startNameController.text;
       _cachedEndDisplayName = _endNameController.text;
       _cachedStartCoordinates = _startController.text;
       _cachedEndCoordinates = _endController.text;
     } else {
       _cachedName = null;
+      _cachedRoadName = null;
       _cachedStartDisplayName = null;
       _cachedEndDisplayName = null;
       _cachedStartCoordinates = null;
       _cachedEndCoordinates = null;
     }
     _nameController.dispose();
+    _roadController.dispose();
     _startNameController.dispose();
     _endNameController.dispose();
     _startController.dispose();
@@ -91,6 +99,12 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
                 controller: _nameController,
                 label: 'Segment name',
                 hintText: 'Segment name',
+              ),
+              const SizedBox(height: 16),
+              _LabeledTextField(
+                controller: _roadController,
+                label: 'Road name',
+                hintText: 'Road name',
               ),
               const SizedBox(height: 16),
               _LabeledTextField(
@@ -346,6 +360,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     try {
       return _localSegmentsService.prepareDraft(
         name: _nameController.text,
+        roadName: _roadController.text,
         startDisplayName: _startNameController.text,
         endDisplayName: _endNameController.text,
         startCoordinates: _startController.text,
@@ -386,6 +401,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
   void _resetDraftState() {
     _persistDraftOnDispose = false;
     _cachedName = null;
+    _cachedRoadName = null;
     _cachedStartDisplayName = null;
     _cachedEndDisplayName = null;
     _cachedStartCoordinates = null;
@@ -394,6 +410,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
 
   void _cacheDraftInputs() {
     _cachedName = _nameController.text;
+    _cachedRoadName = _roadController.text;
     _cachedStartDisplayName = _startNameController.text;
     _cachedEndDisplayName = _endNameController.text;
     _cachedStartCoordinates = _startController.text;

--- a/lib/services/remote_segments_service.dart
+++ b/lib/services/remote_segments_service.dart
@@ -19,6 +19,7 @@ class RemoteSegmentsService {
   static const int _smallIntMax = 32767;
   static const String _addedByUserColumn = 'added_by_user';
   static const String _roadColumn = 'road';
+  static const String _nameColumn = 'name';
   static const String _startColumn = 'Start';
   static const String _endColumn = 'End';
 
@@ -45,7 +46,8 @@ class RemoteSegmentsService {
     try {
       await client.from(tableName).insert(<String, dynamic>{
         'id': pendingId,
-        'road': draft.name,
+        _nameColumn: draft.name,
+        _roadColumn: draft.roadName,
         'Start name': draft.startDisplayName,
         'End name': draft.endDisplayName,
         'Start': draft.startCoordinates,
@@ -72,6 +74,7 @@ class RemoteSegmentsService {
   Future<bool> hasPendingSubmission({
     required String addedByUserId,
     required String name,
+    required String roadName,
     required String startCoordinates,
     required String endCoordinates,
   }) async {
@@ -89,7 +92,8 @@ class RemoteSegmentsService {
           .match(<String, Object>{
         _moderationStatusColumn: _pendingStatus,
         _addedByUserColumn: addedByUserId,
-        _roadColumn: name,
+        _nameColumn: name,
+        _roadColumn: roadName,
         _startColumn: startCoordinates,
         _endColumn: endCoordinates,
       }).limit(1);
@@ -115,6 +119,7 @@ class RemoteSegmentsService {
   Future<bool> deleteSubmission({
     required String addedByUserId,
     required String name,
+    required String roadName,
     required String startCoordinates,
     required String endCoordinates,
   }) async {
@@ -131,7 +136,8 @@ class RemoteSegmentsService {
           .delete()
           .match(<String, Object>{
         _addedByUserColumn: addedByUserId,
-        _roadColumn: name,
+        _nameColumn: name,
+        _roadColumn: roadName,
         _startColumn: startCoordinates,
         _endColumn: endCoordinates,
       }).select('$_idColumn');

--- a/lib/services/toll_segments_csv_constants.dart
+++ b/lib/services/toll_segments_csv_constants.dart
@@ -8,6 +8,17 @@ class TollSegmentsCsvSchema {
   /// List of column headers in the order they should appear in the CSV.
   static const List<String> header = <String>[
     'ID',
+    'name',
+    'road',
+    'Start name',
+    'End name',
+    'Start',
+    'End',
+  ];
+
+  /// Legacy header used before the dedicated `name` column was introduced.
+  static const List<String> legacyHeader = <String>[
+    'ID',
     'road',
     'Start name',
     'End name',

--- a/lib/services/toll_segments_sync_service.dart
+++ b/lib/services/toll_segments_sync_service.dart
@@ -425,6 +425,7 @@ class TollSegmentsSyncService {
   static const Map<String, List<String>> _columnAliases =
       <String, List<String>>{
         'ID': <String>['id'],
+        'name': <String>['segment_name', 'road'],
         'road': <String>['road_name'],
         'Start name': <String>['start_name', 'startname'],
         'End name': <String>['end_name', 'endname'],


### PR DESCRIPTION
## Summary
- add a road name field to the create segment page and retain cached values when navigating away
- persist segment names to the dedicated CSV column, upgrade legacy files, and store road names separately
- update Supabase submission and sync logic to handle the new name and road columns

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e22c6c2408832d987d9b66acbd0f5f