### PR TITLE
Refactor segment pages into reusable widgets

### DIFF
--- a/lib/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart
+++ b/lib/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class SegmentLabeledTextField extends StatelessWidget {
+  const SegmentLabeledTextField({
+    super.key,
+    required this.controller,
+    required this.label,
+    this.hintText,
+  });
+
+  final TextEditingController controller;
+  final String label;
+  final String? hintText;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: label,
+        hintText: hintText,
+        border: const OutlineInputBorder(),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/create_segment_page.dart
+++ b/lib/presentation/pages/create_segment_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:toll_cam_finder/app/app_routes.dart';
+import 'package:toll_cam_finder/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart';
 import 'package:toll_cam_finder/presentation/widgets/segment_picker/segment_picker_map.dart';
 import 'package:toll_cam_finder/services/auth_controller.dart';
 import 'package:toll_cam_finder/services/local_segments_service.dart';
@@ -189,12 +190,12 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
                               ),
                               const SizedBox(height: 24),
                               buildFieldPair(
-                                _LabeledTextField(
+                                SegmentLabeledTextField(
                                   controller: _nameController,
                                   label: 'Segment name',
                                   hintText: 'Segment name',
                                 ),
-                                _LabeledTextField(
+                                SegmentLabeledTextField(
                                   controller: _roadNameController,
                                   label: 'Road name',
                                   hintText: 'Road name',
@@ -202,12 +203,12 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
                               ),
                               const SizedBox(height: 20),
                               buildFieldPair(
-                                _LabeledTextField(
+                                SegmentLabeledTextField(
                                   controller: _startNameController,
                                   label: 'Start',
                                   hintText: 'Start name',
                                 ),
-                                _LabeledTextField(
+                                SegmentLabeledTextField(
                                   controller: _endNameController,
                                   label: 'End',
                                   hintText: 'End name',
@@ -215,12 +216,12 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
                               ),
                               const SizedBox(height: 20),
                               buildFieldPair(
-                                _LabeledTextField(
+                                SegmentLabeledTextField(
                                   controller: _startController,
                                   label: 'Start coordinates',
                                   hintText: '41.8626802,26.0873785',
                                 ),
-                                _LabeledTextField(
+                                SegmentLabeledTextField(
                                   controller: _endController,
                                   label: 'End point',
                                   hintText: '41.8322163,26.1404669',
@@ -512,30 +513,6 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     _cachedEndDisplayName = _endNameController.text;
     _cachedStartCoordinates = _startController.text;
     _cachedEndCoordinates = _endController.text;
-  }
-}
-
-class _LabeledTextField extends StatelessWidget {
-  const _LabeledTextField({
-    required this.controller,
-    required this.label,
-    this.hintText,
-  });
-
-  final TextEditingController controller;
-  final String label;
-  final String? hintText;
-
-  @override
-  Widget build(BuildContext context) {
-    return TextField(
-      controller: controller,
-      decoration: InputDecoration(
-        labelText: label,
-        hintText: hintText,
-        border: const OutlineInputBorder(),
-      ),
-    );
   }
 }
 

--- a/lib/presentation/pages/segments/widgets/empty_segments_views.dart
+++ b/lib/presentation/pages/segments/widgets/empty_segments_views.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class EmptySegmentsView extends StatelessWidget {
+  const EmptySegmentsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('No segments available.'));
+  }
+}
+
+class EmptyLocalSegmentsView extends StatelessWidget {
+  const EmptyLocalSegmentsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('No local segments saved yet.'));
+  }
+}

--- a/lib/presentation/pages/segments/widgets/segment_action_dialogs.dart
+++ b/lib/presentation/pages/segments/widgets/segment_action_dialogs.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+import 'package:toll_cam_finder/services/segments_repository.dart';
+
+enum SegmentAction { delete }
+
+Future<SegmentAction?> showSegmentActionsSheet(
+  BuildContext context,
+  SegmentInfo segment,
+) {
+  final canDelete = segment.isLocalOnly;
+  return showModalBottomSheet<SegmentAction>(
+    context: context,
+    builder: (context) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.delete_outline),
+              title: const Text('Delete segment'),
+              subtitle: canDelete
+                  ? null
+                  : const Text('Only local segments can be deleted.'),
+              enabled: canDelete,
+              onTap: canDelete
+                  ? () => Navigator.of(context).pop(SegmentAction.delete)
+                  : null,
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+Future<bool> showDeleteConfirmationDialog(
+  BuildContext context,
+  SegmentInfo segment,
+) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        title: const Text('Delete segment'),
+        content: Text(
+          'Are you sure you want to delete segment ${segment.displayId}?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      );
+    },
+  );
+
+  return result ?? false;
+}
+
+Future<bool> showCancelRemoteSubmissionDialog(
+  BuildContext context,
+  SegmentInfo segment,
+) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        title: const Text('Withdraw public submission?'),
+        content: const Text(
+          'You have submitted this segment for review. '
+          'Do you want to withdraw the submission?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('No'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Yes'),
+          ),
+        ],
+      );
+    },
+  );
+
+  return result ?? false;
+}

--- a/lib/presentation/pages/segments/widgets/segment_card.dart
+++ b/lib/presentation/pages/segments/widgets/segment_card.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+import 'package:toll_cam_finder/services/segments_repository.dart';
+
+class SegmentCard extends StatelessWidget {
+  const SegmentCard({
+    super.key,
+    required this.segment,
+    this.onLongPress,
+  });
+
+  final SegmentInfo segment;
+  final VoidCallback? onLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      child: InkWell(
+        onLongPress: onLongPress,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: Text(
+                      segment.name,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ),
+                  if (segment.isLocalOnly) ...[
+                    const SizedBox(width: 8),
+                    const _LocalBadge(),
+                  ],
+                ],
+              ),
+              const SizedBox(height: 16),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: _SegmentLocation(
+                      value: segment.startDisplayName,
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: _SegmentLocation(
+                      value: segment.endDisplayName,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LocalBadge extends StatelessWidget {
+  const _LocalBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        'Local',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSecondaryContainer,
+        ),
+      ),
+    );
+  }
+}
+
+class _SegmentLocation extends StatelessWidget {
+  const _SegmentLocation({required this.value});
+
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final trimmedValue = value.trim();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          trimmedValue.isEmpty ? '—' : trimmedValue,
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 4),
+        Text(value, style: theme.textTheme.bodyMedium),
+      ],
+    );
+  }
+}

--- a/lib/presentation/pages/segments/widgets/segments_error_view.dart
+++ b/lib/presentation/pages/segments/widgets/segments_error_view.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class SegmentsErrorView extends StatelessWidget {
+  const SegmentsErrorView({
+    super.key,
+    required this.onRetry,
+  });
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('Failed to load segments.'),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/segments_page.dart
+++ b/lib/presentation/pages/segments_page.dart
@@ -7,6 +7,10 @@ import 'package:toll_cam_finder/services/remote_segments_service.dart';
 import 'package:toll_cam_finder/services/segments_repository.dart';
 
 import '../../app/app_routes.dart';
+import 'segments/widgets/empty_segments_views.dart';
+import 'segments/widgets/segment_action_dialogs.dart';
+import 'segments/widgets/segment_card.dart';
+import 'segments/widgets/segments_error_view.dart';
 
 class SegmentsPage extends StatefulWidget {
   const SegmentsPage({super.key});
@@ -14,8 +18,6 @@ class SegmentsPage extends StatefulWidget {
   @override
   State<SegmentsPage> createState() => _SegmentsPageState();
 }
-
-enum _SegmentAction { delete }
 
 class _SegmentsPageState extends State<SegmentsPage> {
   final SegmentsRepository _repository = SegmentsRepository();
@@ -55,7 +57,7 @@ class _SegmentsPageState extends State<SegmentsPage> {
             }
 
             if (snapshot.hasError) {
-              return _ErrorView(
+              return SegmentsErrorView(
                 onRetry: () {
                   setState(() {
                     _segmentsFuture = _repository.loadSegments();
@@ -66,7 +68,7 @@ class _SegmentsPageState extends State<SegmentsPage> {
 
             final segments = snapshot.data ?? const <SegmentInfo>[];
             if (segments.isEmpty) {
-              return const _EmptySegmentsView();
+              return const EmptySegmentsView();
             }
 
             return ListView.separated(
@@ -75,7 +77,7 @@ class _SegmentsPageState extends State<SegmentsPage> {
               separatorBuilder: (context, index) => const SizedBox(height: 12),
               itemBuilder: (context, index) {
                 final segment = segments[index];
-                return _SegmentCard(
+                return SegmentCard(
                   segment: segment,
                   onLongPress: () => _onSegmentLongPress(segment),
                 );
@@ -125,8 +127,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
   }
 
   Future<void> _onSegmentLongPress(SegmentInfo segment) async {
-    final action = await _showSegmentActionsSheet(context, segment);
-    if (!mounted || action != _SegmentAction.delete) {
+    final action = await showSegmentActionsSheet(context, segment);
+    if (!mounted || action != SegmentAction.delete) {
       return;
     }
 
@@ -134,7 +136,7 @@ class _SegmentsPageState extends State<SegmentsPage> {
   }
 
   Future<void> _confirmAndDeleteSegment(SegmentInfo segment) async {
-    final confirmed = await _showDeleteConfirmationDialog(context, segment);
+    final confirmed = await showDeleteConfirmationDialog(context, segment);
     if (!mounted || !confirmed) {
       return;
     }
@@ -152,7 +154,7 @@ class _SegmentsPageState extends State<SegmentsPage> {
       return true;
     }
 
-    final shouldWithdraw = await _showCancelRemoteSubmissionDialog(
+    final shouldWithdraw = await showCancelRemoteSubmissionDialog(
       context,
       segment,
     );
@@ -273,112 +275,6 @@ class _SegmentsPageState extends State<SegmentsPage> {
   }
 }
 
-class _SegmentCard extends StatelessWidget {
-  const _SegmentCard({required this.segment, this.onLongPress});
-
-  final SegmentInfo segment;
-  final VoidCallback? onLongPress;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Card(
-      child: InkWell(
-        onLongPress: onLongPress,
-        borderRadius: BorderRadius.circular(12),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Expanded(
-                    child: Text(
-                      segment.name,
-                      style: theme.textTheme.titleMedium,
-                    ),
-                  ),
-                  if (segment.isLocalOnly) ...[
-                    const SizedBox(width: 8),
-                    const _LocalBadge(),
-                  ],
-                ],
-              ),
-              const SizedBox(height: 16),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: _SegmentLocation(
-                      label: 'Start',
-                      value: segment.startDisplayName,
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: _SegmentLocation(
-                      label: 'End',
-                      value: segment.endDisplayName,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _LocalBadge extends StatelessWidget {
-  const _LocalBadge();
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.secondaryContainer,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Text(
-        'Local',
-        style: theme.textTheme.labelSmall?.copyWith(
-          color: theme.colorScheme.onSecondaryContainer,
-        ),
-      ),
-    );
-  }
-}
-
-class _SegmentLocation extends StatelessWidget {
-  const _SegmentLocation({required this.label, required this.value});
-
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final trimmedValue = value.trim();
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          trimmedValue.isEmpty ? '—' : trimmedValue,
-          style: theme.textTheme.bodyMedium,
-        ),
-        const SizedBox(height: 4),
-        Text(value, style: theme.textTheme.bodyMedium),
-      ],
-    );
-  }
-}
-
 class LocalSegmentsPage extends StatefulWidget {
   const LocalSegmentsPage({super.key});
 
@@ -415,7 +311,7 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
             }
 
             if (snapshot.hasError) {
-              return _ErrorView(
+              return SegmentsErrorView(
                 onRetry: () {
                   setState(() {
                     _segmentsFuture = _repository.loadSegments(onlyLocal: true);
@@ -426,7 +322,7 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
 
             final segments = snapshot.data ?? const <SegmentInfo>[];
             if (segments.isEmpty) {
-              return const _EmptyLocalSegmentsView();
+              return const EmptyLocalSegmentsView();
             }
 
             return ListView.separated(
@@ -435,7 +331,7 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
               separatorBuilder: (context, index) => const SizedBox(height: 12),
               itemBuilder: (context, index) {
                 final segment = segments[index];
-                return _SegmentCard(
+                return SegmentCard(
                   segment: segment,
                   onLongPress: () => _onSegmentLongPress(segment),
                 );
@@ -471,8 +367,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
   }
 
   Future<void> _onSegmentLongPress(SegmentInfo segment) async {
-    final action = await _showSegmentActionsSheet(context, segment);
-    if (!mounted || action != _SegmentAction.delete) {
+    final action = await showSegmentActionsSheet(context, segment);
+    if (!mounted || action != SegmentAction.delete) {
       return;
     }
 
@@ -480,7 +376,7 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
   }
 
   Future<void> _confirmAndDeleteSegment(SegmentInfo segment) async {
-    final confirmed = await _showDeleteConfirmationDialog(context, segment);
+    final confirmed = await showDeleteConfirmationDialog(context, segment);
     if (!mounted || !confirmed) {
       return;
     }
@@ -498,7 +394,7 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
       return true;
     }
 
-    final shouldWithdraw = await _showCancelRemoteSubmissionDialog(
+    final shouldWithdraw = await showCancelRemoteSubmissionDialog(
       context,
       segment,
     );
@@ -619,129 +515,3 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
   }
 }
 
-class _EmptySegmentsView extends StatelessWidget {
-  const _EmptySegmentsView();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(child: Text('No segments available.'));
-  }
-}
-
-class _EmptyLocalSegmentsView extends StatelessWidget {
-  const _EmptyLocalSegmentsView();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(child: Text('No local segments saved yet.'));
-  }
-}
-
-class _ErrorView extends StatelessWidget {
-  const _ErrorView({required this.onRetry});
-
-  final VoidCallback onRetry;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Text('Failed to load segments.'),
-          const SizedBox(height: 12),
-          ElevatedButton(onPressed: onRetry, child: const Text('Retry')),
-        ],
-      ),
-    );
-  }
-}
-
-Future<_SegmentAction?> _showSegmentActionsSheet(
-  BuildContext context,
-  SegmentInfo segment,
-) {
-  final canDelete = segment.isLocalOnly;
-  return showModalBottomSheet<_SegmentAction>(
-    context: context,
-    builder: (context) {
-      return SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.delete_outline),
-              title: const Text('Delete segment'),
-              subtitle: canDelete
-                  ? null
-                  : const Text('Only local segments can be deleted.'),
-              enabled: canDelete,
-              onTap: canDelete
-                  ? () => Navigator.of(context).pop(_SegmentAction.delete)
-                  : null,
-            ),
-          ],
-        ),
-      );
-    },
-  );
-}
-
-Future<bool> _showDeleteConfirmationDialog(
-  BuildContext context,
-  SegmentInfo segment,
-) async {
-  final result = await showDialog<bool>(
-    context: context,
-    builder: (context) {
-      return AlertDialog(
-        title: const Text('Delete segment'),
-        content: Text(
-          'Are you sure you want to delete segment ${segment.displayId}?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Delete'),
-          ),
-        ],
-      );
-    },
-  );
-
-  return result ?? false;
-}
-
-Future<bool> _showCancelRemoteSubmissionDialog(
-  BuildContext context,
-  SegmentInfo segment,
-) async {
-  final result = await showDialog<bool>(
-    context: context,
-    builder: (context) {
-      return AlertDialog(
-        title: const Text('Withdraw public submission?'),
-        content: const Text(
-          'You have submitted this segment for review. '
-          'Do you want to withdraw the submission?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('No'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Yes'),
-          ),
-        ],
-      );
-    },
-  );
-
-  return result ?? false;
-}


### PR DESCRIPTION
## Summary
- extract the reusable labeled text field from `CreateSegmentPage` into its own widget
- factor the segment list cards, empty/error views, and action dialogs into a widgets folder
- update the segment screens to import and use the new widgets for better readability

## Testing
- Not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2363b7e40832d9746f69a20e27707