### PR TITLE
Add segment deactivation support for segments and map overlays

### DIFF
--- a/lib/presentation/pages/map/toll_camera_controller.dart
+++ b/lib/presentation/pages/map/toll_camera_controller.dart
@@ -17,8 +17,14 @@ class TollCameraController {
         visibleCameras: _cameras.visibleCameras,
       );
 
-  Future<void> loadFromAsset(String assetPath) async {
-    await _cameras.loadFromAsset(assetPath);
+  Future<void> loadFromAsset(
+    String assetPath, {
+    Set<String> excludedSegmentIds = const <String>{},
+  }) async {
+    await _cameras.loadFromAsset(
+      assetPath,
+      excludedSegmentIds: excludedSegmentIds,
+    );
   }
 
   void updateVisible({LatLngBounds? bounds}) {

--- a/lib/presentation/pages/segments_page.dart
+++ b/lib/presentation/pages/segments_page.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:toll_cam_finder/services/auth_controller.dart';
 import 'package:toll_cam_finder/services/local_segments_service.dart';
 import 'package:toll_cam_finder/services/remote_segments_service.dart';
+import 'package:toll_cam_finder/services/segments_metadata_service.dart';
 import 'package:toll_cam_finder/services/segments_repository.dart';
 
 import '../../app/app_routes.dart';
@@ -24,6 +25,7 @@ class SegmentsPage extends StatefulWidget {
 class _SegmentsPageState extends State<SegmentsPage> {
   final SegmentsRepository _repository = SegmentsRepository();
   final LocalSegmentsService _localSegmentsService = LocalSegmentsService();
+  final SegmentsMetadataService _metadataService = SegmentsMetadataService();
   late Future<List<SegmentInfo>> _segmentsFuture;
   bool _segmentsUpdated = false;
 
@@ -130,11 +132,49 @@ class _SegmentsPageState extends State<SegmentsPage> {
 
   Future<void> _onSegmentLongPress(SegmentInfo segment) async {
     final action = await showSegmentActionsSheet(context, segment);
-    if (!mounted || action != SegmentAction.delete) {
+    if (!mounted || action == null) {
       return;
     }
 
-    await _confirmAndDeleteSegment(segment);
+    switch (action) {
+      case SegmentAction.delete:
+        await _confirmAndDeleteSegment(segment);
+        break;
+      case SegmentAction.deactivate:
+        await _setSegmentDeactivated(segment, true);
+        break;
+      case SegmentAction.activate:
+        await _setSegmentDeactivated(segment, false);
+        break;
+    }
+  }
+
+  Future<void> _setSegmentDeactivated(
+    SegmentInfo segment,
+    bool deactivate,
+  ) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await _metadataService.setSegmentDeactivated(segment.id, deactivate);
+      if (!mounted) return;
+
+      final message = deactivate
+          ? 'Segment ${segment.displayId} hidden. Cameras and warnings are disabled.'
+          : 'Segment ${segment.displayId} is visible again. Cameras and warnings restored.';
+      messenger.showSnackBar(SnackBar(content: Text(message)));
+      _segmentsUpdated = true;
+      setState(() {
+        _segmentsFuture = _repository.loadSegments();
+      });
+    } on SegmentsMetadataException catch (error) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            'Failed to update segment ${segment.displayId}: ${error.message}',
+          ),
+        ),
+      );
+    }
   }
 
   Future<void> _confirmAndDeleteSegment(SegmentInfo segment) async {
@@ -319,6 +359,7 @@ class LocalSegmentsPage extends StatefulWidget {
 class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
   final SegmentsRepository _repository = SegmentsRepository();
   final LocalSegmentsService _localSegmentsService = LocalSegmentsService();
+  final SegmentsMetadataService _metadataService = SegmentsMetadataService();
   late Future<List<SegmentInfo>> _segmentsFuture;
   bool _segmentsUpdated = false;
 
@@ -402,11 +443,49 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
 
   Future<void> _onSegmentLongPress(SegmentInfo segment) async {
     final action = await showSegmentActionsSheet(context, segment);
-    if (!mounted || action != SegmentAction.delete) {
+    if (!mounted || action == null) {
       return;
     }
 
-    await _confirmAndDeleteSegment(segment);
+    switch (action) {
+      case SegmentAction.delete:
+        await _confirmAndDeleteSegment(segment);
+        break;
+      case SegmentAction.deactivate:
+        await _setSegmentDeactivated(segment, true);
+        break;
+      case SegmentAction.activate:
+        await _setSegmentDeactivated(segment, false);
+        break;
+    }
+  }
+
+  Future<void> _setSegmentDeactivated(
+    SegmentInfo segment,
+    bool deactivate,
+  ) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await _metadataService.setSegmentDeactivated(segment.id, deactivate);
+      if (!mounted) return;
+
+      final message = deactivate
+          ? 'Segment ${segment.displayId} hidden. Cameras and warnings are disabled.'
+          : 'Segment ${segment.displayId} is visible again. Cameras and warnings restored.';
+      messenger.showSnackBar(SnackBar(content: Text(message)));
+      _segmentsUpdated = true;
+      setState(() {
+        _segmentsFuture = _repository.loadSegments(onlyLocal: true);
+      });
+    } on SegmentsMetadataException catch (error) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            'Failed to update segment ${segment.displayId}: ${error.message}',
+          ),
+        ),
+      );
+    }
   }
 
   Future<void> _confirmAndDeleteSegment(SegmentInfo segment) async {

--- a/lib/presentation/widgets/add_segment/segment_action_dialogs.dart
+++ b/lib/presentation/widgets/add_segment/segment_action_dialogs.dart
@@ -2,13 +2,14 @@ import 'package:flutter/material.dart';
 
 import 'package:toll_cam_finder/services/segments_repository.dart';
 
-enum SegmentAction { delete }
+enum SegmentAction { delete, deactivate, activate }
 
 Future<SegmentAction?> showSegmentActionsSheet(
   BuildContext context,
   SegmentInfo segment,
 ) {
   final canDelete = segment.isLocalOnly;
+  final isDeactivated = segment.isDeactivated;
   return showModalBottomSheet<SegmentAction>(
     context: context,
     builder: (context) {
@@ -16,6 +17,24 @@ Future<SegmentAction?> showSegmentActionsSheet(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            ListTile(
+              leading: Icon(
+                isDeactivated ? Icons.visibility : Icons.visibility_off,
+              ),
+              title: Text(
+                isDeactivated
+                    ? 'Show segment on map'
+                    : 'Hide segment on map',
+              ),
+              subtitle: Text(
+                isDeactivated
+                    ? 'Cameras and warnings for this segment will be restored.'
+                    : 'No cameras or warnings will appear for this segment.',
+              ),
+              onTap: () => Navigator.of(context).pop(
+                isDeactivated ? SegmentAction.activate : SegmentAction.deactivate,
+              ),
+            ),
             ListTile(
               leading: const Icon(Icons.delete_outline),
               title: const Text('Delete segment'),

--- a/lib/presentation/widgets/add_segment/segment_card.dart
+++ b/lib/presentation/widgets/add_segment/segment_card.dart
@@ -15,6 +15,7 @@ class SegmentCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final hasBadges = segment.isLocalOnly || segment.isDeactivated;
     return Card(
       child: InkWell(
         onLongPress: onLongPress,
@@ -33,9 +34,9 @@ class SegmentCard extends StatelessWidget {
                       style: theme.textTheme.titleMedium,
                     ),
                   ),
-                  if (segment.isLocalOnly) ...[
+                  if (hasBadges) ...[
                     const SizedBox(width: 8),
-                    const _LocalBadge(),
+                    _SegmentBadges(segment: segment),
                   ],
                 ],
               ),
@@ -82,6 +83,55 @@ class _LocalBadge extends StatelessWidget {
           color: theme.colorScheme.onSecondaryContainer,
         ),
       ),
+    );
+  }
+}
+
+class _DeactivatedBadge extends StatelessWidget {
+  const _DeactivatedBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        'Hidden',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onErrorContainer,
+        ),
+      ),
+    );
+  }
+}
+
+class _SegmentBadges extends StatelessWidget {
+  const _SegmentBadges({required this.segment});
+
+  final SegmentInfo segment;
+
+  @override
+  Widget build(BuildContext context) {
+    final badges = <Widget>[];
+    if (segment.isDeactivated) {
+      badges.add(const _DeactivatedBadge());
+    }
+    if (segment.isLocalOnly) {
+      badges.add(const _LocalBadge());
+    }
+
+    if (badges.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: badges,
     );
   }
 }

--- a/lib/services/segments_metadata_service.dart
+++ b/lib/services/segments_metadata_service.dart
@@ -1,0 +1,220 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:toll_cam_finder/services/toll_segments_file_system.dart';
+import 'package:toll_cam_finder/services/toll_segments_file_system_stub.dart'
+    if (dart.library.io) 'package:toll_cam_finder/services/toll_segments_file_system_io.dart'
+    as fs_impl;
+import 'package:toll_cam_finder/services/toll_segments_paths.dart';
+
+class SegmentsMetadata {
+  const SegmentsMetadata({
+    Map<String, bool>? publicFlags,
+    Set<String>? deactivatedSegmentIds,
+  })  : publicFlags = Map.unmodifiable(publicFlags ?? const <String, bool>{}),
+        deactivatedSegmentIds =
+            Set.unmodifiable(deactivatedSegmentIds ?? const <String>{});
+
+  final Map<String, bool> publicFlags;
+  final Set<String> deactivatedSegmentIds;
+
+  bool get isEmpty =>
+      publicFlags.isEmpty && deactivatedSegmentIds.isEmpty;
+
+  SegmentsMetadata copyWith({
+    Map<String, bool>? publicFlags,
+    Set<String>? deactivatedSegmentIds,
+  }) {
+    return SegmentsMetadata(
+      publicFlags: publicFlags ?? this.publicFlags,
+      deactivatedSegmentIds:
+          deactivatedSegmentIds ?? this.deactivatedSegmentIds,
+    );
+  }
+
+  SegmentsMetadata updatePublicFlag(String id, bool isPublic) {
+    final updated = Map<String, bool>.of(publicFlags);
+    if (isPublic) {
+      updated[id] = true;
+    } else {
+      updated.remove(id);
+    }
+    return copyWith(publicFlags: updated);
+  }
+
+  SegmentsMetadata updateDeactivated(String id, bool isDeactivated) {
+    final updated = Set<String>.of(deactivatedSegmentIds);
+    if (isDeactivated) {
+      updated.add(id);
+    } else {
+      updated.remove(id);
+    }
+    return copyWith(deactivatedSegmentIds: updated);
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'publicFlags': publicFlags,
+      'deactivatedSegments': deactivatedSegmentIds.toList()..sort(),
+    };
+  }
+
+  factory SegmentsMetadata.fromJson(dynamic json) {
+    if (json is Map<String, dynamic>) {
+      if (json.containsKey('publicFlags') ||
+          json.containsKey('deactivatedSegments')) {
+        final dynamic flagsRaw = json['publicFlags'];
+        final dynamic deactivatedRaw = json['deactivatedSegments'];
+
+        final flags = <String, bool>{};
+        if (flagsRaw is Map<String, dynamic>) {
+          for (final entry in flagsRaw.entries) {
+            flags[entry.key] = entry.value == true;
+          }
+        }
+
+        final deactivated = <String>{};
+        if (deactivatedRaw is List) {
+          for (final value in deactivatedRaw) {
+            if (value is String && value.isNotEmpty) {
+              deactivated.add(value);
+            }
+          }
+        }
+
+        return SegmentsMetadata(
+          publicFlags: flags,
+          deactivatedSegmentIds: deactivated,
+        );
+      }
+
+      // Legacy structure: map of id -> bool indicating public flag.
+      final flags = <String, bool>{};
+      for (final entry in json.entries) {
+        flags[entry.key] = entry.value == true;
+      }
+      return SegmentsMetadata(publicFlags: flags);
+    }
+
+    return const SegmentsMetadata();
+  }
+}
+
+class SegmentsMetadataService {
+  SegmentsMetadataService({
+    TollSegmentsFileSystem? fileSystem,
+    TollSegmentsPathResolver? pathResolver,
+  })  : _fileSystem = fileSystem ?? fs_impl.createFileSystem(),
+        _pathResolver = pathResolver;
+
+  final TollSegmentsFileSystem _fileSystem;
+  final TollSegmentsPathResolver? _pathResolver;
+
+  Future<SegmentsMetadata> load() async {
+    if (kIsWeb) {
+      return const SegmentsMetadata();
+    }
+
+    try {
+      final path = await resolveTollSegmentsMetadataPath(
+        overrideResolver: _pathResolver,
+      );
+      if (!await _fileSystem.exists(path)) {
+        return const SegmentsMetadata();
+      }
+
+      final contents = await _fileSystem.readAsString(path);
+      if (contents.trim().isEmpty) {
+        return const SegmentsMetadata();
+      }
+
+      final dynamic decoded = jsonDecode(contents);
+      return SegmentsMetadata.fromJson(decoded);
+    } on TollSegmentsFileSystemException catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        SegmentsMetadataException(
+          'Failed to access the segments metadata file.',
+          cause: error,
+        ),
+        stackTrace,
+      );
+    } on FormatException catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        SegmentsMetadataException(
+          'Failed to parse the segments metadata file.',
+          cause: error,
+        ),
+        stackTrace,
+      );
+    }
+  }
+
+  Future<void> updatePublicFlag(String id, bool isPublic) async {
+    if (kIsWeb) {
+      throw const SegmentsMetadataException(
+        'Segment metadata cannot be updated on the web.',
+      );
+    }
+
+    await _updateMetadata(
+      (metadata) => metadata.updatePublicFlag(id, isPublic),
+    );
+  }
+
+  Future<void> setSegmentDeactivated(String id, bool isDeactivated) async {
+    if (kIsWeb) {
+      throw const SegmentsMetadataException(
+        'Segment metadata cannot be updated on the web.',
+      );
+    }
+
+    await _updateMetadata(
+      (metadata) => metadata.updateDeactivated(id, isDeactivated),
+    );
+  }
+
+  Future<void> _updateMetadata(
+    SegmentsMetadata Function(SegmentsMetadata) transform,
+  ) async {
+    try {
+      final path = await resolveTollSegmentsMetadataPath(
+        overrideResolver: _pathResolver,
+      );
+      await _fileSystem.ensureParentDirectory(path);
+
+      final current = await load();
+      final updated = transform(current);
+
+      if (updated.isEmpty) {
+        await _fileSystem.writeAsString(path, '');
+        return;
+      }
+
+      await _fileSystem.writeAsString(
+        path,
+        jsonEncode(updated.toJson()),
+      );
+    } on SegmentsMetadataException {
+      rethrow;
+    } on TollSegmentsFileSystemException catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        SegmentsMetadataException(
+          'Failed to write to the segments metadata file.',
+          cause: error,
+        ),
+        stackTrace,
+      );
+    }
+  }
+}
+
+class SegmentsMetadataException implements Exception {
+  const SegmentsMetadataException(this.message, {this.cause});
+
+  final String message;
+  final Object? cause;
+
+  @override
+  String toString() => 'SegmentsMetadataException: $message';
+}


### PR DESCRIPTION
## Summary
- add a metadata service to persist segment visibility and reuse the existing public flags
- allow segments to be deactivated/reactivated from the lists with updated UI messaging and badges
- filter segment tracking and camera overlays by the stored deactivated segment ids so hidden entries disappear from the map

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2441e750c832db9f48f5f2c1fbeea