### PR TITLE
Add UI for toggling public segments and hide their cameras

### DIFF
--- a/lib/presentation/pages/map/toll_camera_controller.dart
+++ b/lib/presentation/pages/map/toll_camera_controller.dart
@@ -17,8 +17,14 @@ class TollCameraController {
         visibleCameras: _cameras.visibleCameras,
       );
 
-  Future<void> loadFromAsset(String assetPath) async {
-    await _cameras.loadFromAsset(assetPath);
+  Future<void> loadFromAsset(
+    String assetPath, {
+    Set<String> disabledSegmentIds = const <String>{},
+  }) async {
+    await _cameras.loadFromAsset(
+      assetPath,
+      disabledSegmentIds: disabledSegmentIds,
+    );
   }
 
   void updateVisible({LatLngBounds? bounds}) {

--- a/lib/presentation/pages/map_page.dart
+++ b/lib/presentation/pages/map_page.dart
@@ -16,6 +16,7 @@ import 'package:toll_cam_finder/presentation/widgets/toll_cameras_overlay.dart';
 import 'package:toll_cam_finder/services/average_speed_est.dart';
 import 'package:toll_cam_finder/services/speed_smoother.dart';
 import 'package:toll_cam_finder/services/segment_tracker.dart';
+import 'package:toll_cam_finder/services/segments_metadata_service.dart';
 import 'package:toll_cam_finder/services/toll_segments_sync_service.dart';
 
 import '../../app/app_routes.dart';
@@ -62,6 +63,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
   final SegmentTracker _segmentTracker = SegmentTracker(
     indexService: SegmentIndexService.instance,
   );
+  final SegmentsMetadataService _metadataService = SegmentsMetadataService();
 
   SegmentTrackerDebugData _segmentDebugData =
       const SegmentTrackerDebugData.empty();
@@ -343,7 +345,11 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
   }
 
   Future<void> _loadCameras() async {
-    await _cameraController.loadFromAsset(AppConstants.camerasAsset);
+    final metadata = await _metadataService.load();
+    await _cameraController.loadFromAsset(
+      AppConstants.camerasAsset,
+      disabledSegmentIds: metadata.deactivatedPublicSegmentIds,
+    );
     if (!mounted) return;
     _updateVisibleCameras();
   }
@@ -575,10 +581,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
       assetPath: AppConstants.pathToTollSegments,
     );
 
-    await _cameraController.loadFromAsset(AppConstants.camerasAsset);
-    if (!mounted) return;
-
-    _updateVisibleCameras();
+    await _loadCameras();
     if (!mounted) return;
 
     _resetSegmentState();

--- a/lib/presentation/widgets/add_segment/segment_action_dialogs.dart
+++ b/lib/presentation/widgets/add_segment/segment_action_dialogs.dart
@@ -2,13 +2,14 @@ import 'package:flutter/material.dart';
 
 import 'package:toll_cam_finder/services/segments_repository.dart';
 
-enum SegmentAction { delete }
+enum SegmentAction { delete, toggleActivation }
 
 Future<SegmentAction?> showSegmentActionsSheet(
   BuildContext context,
   SegmentInfo segment,
 ) {
   final canDelete = segment.isLocalOnly;
+  final canToggleActivation = segment.isMarkedPublic && !segment.isLocalOnly;
   return showModalBottomSheet<SegmentAction>(
     context: context,
     builder: (context) {
@@ -16,6 +17,23 @@ Future<SegmentAction?> showSegmentActionsSheet(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            if (canToggleActivation)
+              ListTile(
+                leading: Icon(
+                  segment.isActive
+                      ? Icons.visibility_off_outlined
+                      : Icons.visibility_outlined,
+                ),
+                title: Text(
+                  segment.isActive
+                      ? 'Deactivate segment'
+                      : 'Activate segment',
+                ),
+                onTap: () =>
+                    Navigator.of(context).pop(SegmentAction.toggleActivation),
+              ),
+            if (canToggleActivation && canDelete)
+              const Divider(height: 0),
             ListTile(
               leading: const Icon(Icons.delete_outline),
               title: const Text('Delete segment'),

--- a/lib/presentation/widgets/add_segment/segment_card.dart
+++ b/lib/presentation/widgets/add_segment/segment_card.dart
@@ -19,44 +19,47 @@ class SegmentCard extends StatelessWidget {
       child: InkWell(
         onLongPress: onLongPress,
         borderRadius: BorderRadius.circular(12),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Expanded(
-                    child: Text(
-                      segment.name,
-                      style: theme.textTheme.titleMedium,
+        child: Opacity(
+          opacity: segment.isActive ? 1.0 : 0.5,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        segment.name,
+                        style: theme.textTheme.titleMedium,
+                      ),
                     ),
-                  ),
-                  if (segment.isLocalOnly) ...[
-                    const SizedBox(width: 8),
-                    const _LocalBadge(),
+                    if (segment.isLocalOnly) ...[
+                      const SizedBox(width: 8),
+                      const _LocalBadge(),
+                    ],
                   ],
-                ],
-              ),
-              const SizedBox(height: 16),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: _SegmentLocation(
-                      value: segment.startDisplayName,
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: _SegmentLocation(
+                        value: segment.startDisplayName,
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: _SegmentLocation(
-                      value: segment.endDisplayName,
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: _SegmentLocation(
+                        value: segment.endDisplayName,
+                      ),
                     ),
-                  ),
-                ],
-              ),
-            ],
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/services/segments_metadata_service.dart
+++ b/lib/services/segments_metadata_service.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:toll_cam_finder/services/toll_segments_file_system.dart';
+import 'package:toll_cam_finder/services/toll_segments_file_system_stub.dart'
+    if (dart.library.io) 'package:toll_cam_finder/services/toll_segments_file_system_io.dart'
+    as fs_impl;
+import 'package:toll_cam_finder/services/toll_segments_paths.dart';
+
+class SegmentsMetadata {
+  SegmentsMetadata({
+    Map<String, bool>? publicFlags,
+    Set<String>? deactivatedPublicSegmentIds,
+  })  : publicFlags = Map<String, bool>.from(publicFlags ?? const {}),
+        deactivatedPublicSegmentIds =
+            Set<String>.from(deactivatedPublicSegmentIds ?? const {});
+
+  final Map<String, bool> publicFlags;
+  final Set<String> deactivatedPublicSegmentIds;
+
+  bool get isEmpty =>
+      publicFlags.isEmpty && deactivatedPublicSegmentIds.isEmpty;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      if (publicFlags.isNotEmpty) 'publicFlags': publicFlags,
+      if (deactivatedPublicSegmentIds.isNotEmpty)
+        'deactivatedPublicSegments': deactivatedPublicSegmentIds.toList(),
+    };
+  }
+
+  static SegmentsMetadata fromDynamic(dynamic data) {
+    if (data is! Map<String, dynamic>) {
+      return SegmentsMetadata();
+    }
+
+    if (data.containsKey('publicFlags') ||
+        data.containsKey('deactivatedPublicSegments') ||
+        data.containsKey('deactivatedSegments')) {
+      final publicFlags = <String, bool>{};
+      final rawPublicFlags = data['publicFlags'];
+      if (rawPublicFlags is Map) {
+        rawPublicFlags.forEach((key, value) {
+          final id = key?.toString() ?? '';
+          if (id.isEmpty) return;
+          publicFlags[id] = value == true;
+        });
+      }
+
+      final deactivated = <String>{};
+      final rawDeactivated =
+          data['deactivatedPublicSegments'] ?? data['deactivatedSegments'];
+      if (rawDeactivated is List) {
+        for (final entry in rawDeactivated) {
+          final id = entry?.toString().trim();
+          if (id != null && id.isNotEmpty) {
+            deactivated.add(id);
+          }
+        }
+      }
+
+      return SegmentsMetadata(
+        publicFlags: publicFlags,
+        deactivatedPublicSegmentIds: deactivated,
+      );
+    }
+
+    final legacyFlags = <String, bool>{};
+    var legacyFormat = true;
+    data.forEach((key, value) {
+      if (value is bool) {
+        legacyFlags[key] = value;
+      } else if (value == null) {
+        // Ignore null entries.
+      } else {
+        legacyFormat = false;
+      }
+    });
+
+    if (!legacyFormat) {
+      return SegmentsMetadata();
+    }
+
+    return SegmentsMetadata(publicFlags: legacyFlags);
+  }
+}
+
+class SegmentsMetadataService {
+  SegmentsMetadataService({
+    TollSegmentsFileSystem? fileSystem,
+    TollSegmentsPathResolver? pathResolver,
+  })  : _fileSystem = fileSystem ?? fs_impl.createFileSystem(),
+        _pathResolver = pathResolver;
+
+  final TollSegmentsFileSystem _fileSystem;
+  final TollSegmentsPathResolver? _pathResolver;
+
+  Future<SegmentsMetadata> load() async {
+    if (kIsWeb) {
+      return SegmentsMetadata();
+    }
+
+    final path = await resolveTollSegmentsMetadataPath(
+      overrideResolver: _pathResolver,
+    );
+
+    if (!await _fileSystem.exists(path)) {
+      return SegmentsMetadata();
+    }
+
+    final contents = await _fileSystem.readAsString(path);
+    if (contents.trim().isEmpty) {
+      return SegmentsMetadata();
+    }
+
+    try {
+      final dynamic decoded = jsonDecode(contents);
+      return SegmentsMetadata.fromDynamic(decoded);
+    } catch (_) {
+      return SegmentsMetadata();
+    }
+  }
+
+  Future<void> save(SegmentsMetadata metadata) async {
+    if (kIsWeb) {
+      return;
+    }
+
+    final path = await resolveTollSegmentsMetadataPath(
+      overrideResolver: _pathResolver,
+    );
+    await _fileSystem.ensureParentDirectory(path);
+
+    if (metadata.isEmpty) {
+      await _fileSystem.writeAsString(path, '');
+      return;
+    }
+
+    await _fileSystem.writeAsString(path, jsonEncode(metadata.toJson()));
+  }
+
+  Future<void> setPublicFlag(String id, bool isPublic) async {
+    if (kIsWeb) {
+      return;
+    }
+
+    final metadata = await load();
+    if (isPublic) {
+      metadata.publicFlags[id] = true;
+    } else {
+      metadata.publicFlags.remove(id);
+    }
+
+    await save(metadata);
+  }
+
+  Future<void> setSegmentActivation(String id, bool isActive) async {
+    if (kIsWeb) {
+      return;
+    }
+
+    final metadata = await load();
+    if (isActive) {
+      metadata.deactivatedPublicSegmentIds.remove(id);
+    } else {
+      metadata.deactivatedPublicSegmentIds.add(id);
+    }
+
+    await save(metadata);
+  }
+}


### PR DESCRIPTION
## Summary
- add a metadata service that stores public visibility flags and deactivated segment ids
- allow toggling public segments from the segments list, separate inactive entries, and gray them out
- load metadata when rendering the map so cameras from deactivated segments are filtered out

## Testing
- not run (Flutter tooling unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e25b5ec8f8832dad8417b80693641e