### PR TITLE
Persist segment routes locally and show stored overlays

### DIFF
--- a/lib/presentation/pages/map/widgets/segment_overlays.dart
+++ b/lib/presentation/pages/map/widgets/segment_overlays.dart
@@ -7,6 +7,35 @@ import 'package:latlong2/latlong.dart';
 import 'package:toll_cam_finder/core/spatial/segment_geometry.dart';
 import 'package:toll_cam_finder/services/segment_tracker.dart';
 
+class StoredSegmentsOverlay extends StatelessWidget {
+  const StoredSegmentsOverlay({
+    super.key,
+    required this.paths,
+  });
+
+  final Iterable<List<LatLng>> paths;
+
+  @override
+  Widget build(BuildContext context) {
+    final polylines = paths
+        .where((points) => points.length >= 2)
+        .map(
+          (points) => Polyline(
+            points: points,
+            strokeWidth: 3.0,
+            color: Colors.orangeAccent.withOpacity(0.7),
+          ),
+        )
+        .toList(growable: false);
+
+    if (polylines.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return PolylineLayer(polylines: polylines);
+  }
+}
+
 class QuerySquareOverlay extends StatelessWidget {
   const QuerySquareOverlay({
     super.key,

--- a/lib/services/segment_path_cache_service.dart
+++ b/lib/services/segment_path_cache_service.dart
@@ -1,0 +1,221 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:toll_cam_finder/core/spatial/geo.dart';
+import 'package:toll_cam_finder/services/toll_segments_file_system.dart';
+import 'package:toll_cam_finder/services/toll_segments_file_system_stub.dart'
+    if (dart.library.io) 'package:toll_cam_finder/services/toll_segments_file_system_io.dart'
+    as fs_impl;
+import 'package:toll_cam_finder/services/toll_segments_paths.dart';
+
+/// Persists detailed segment paths fetched from remote routing services so they
+/// can be reused across app launches.
+class SegmentPathCacheService {
+  SegmentPathCacheService({
+    TollSegmentsFileSystem? fileSystem,
+    TollSegmentsPathResolver? pathResolver,
+  })  : _fileSystem = fileSystem ?? fs_impl.createFileSystem(),
+        _pathResolver = pathResolver;
+
+  final TollSegmentsFileSystem _fileSystem;
+  final TollSegmentsPathResolver? _pathResolver;
+  Map<String, List<GeoPoint>>? _cache;
+
+  /// Loads all cached segment paths from disk.
+  Future<Map<String, List<GeoPoint>>> loadAllPaths() async {
+    if (kIsWeb) {
+      _cache = const <String, List<GeoPoint>>{};
+      return _cache!;
+    }
+
+    if (_cache != null) {
+      return _cache!;
+    }
+
+    try {
+      final path = await resolveSegmentPathsCachePath(
+        overrideResolver: _pathResolver,
+      );
+      if (!await _fileSystem.exists(path)) {
+        _cache = const <String, List<GeoPoint>>{};
+        return _cache!;
+      }
+
+      final raw = await _fileSystem.readAsString(path);
+      if (raw.trim().isEmpty) {
+        _cache = const <String, List<GeoPoint>>{};
+        return _cache!;
+      }
+
+      final dynamic decoded = jsonDecode(raw);
+      final parsed = _parseFeatureCollection(decoded);
+      _cache = _asUnmodifiable(parsed);
+      return _cache!;
+    } on TollSegmentsFileSystemException catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        SegmentPathCacheException(
+          'Failed to access the stored segment paths.',
+          cause: error,
+        ),
+        stackTrace,
+      );
+    } on FormatException catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        SegmentPathCacheException(
+          'Failed to parse the stored segment paths.',
+          cause: error,
+        ),
+        stackTrace,
+      );
+    }
+  }
+
+  /// Stores or replaces the cached path for [segmentId].
+  Future<void> savePath(String segmentId, List<GeoPoint> path) async {
+    if (kIsWeb) {
+      return;
+    }
+
+    final normalized = List<GeoPoint>.unmodifiable(
+      path.map((p) => GeoPoint(p.lat, p.lon)),
+    );
+
+    final current = Map<String, List<GeoPoint>>.from(await loadAllPaths());
+    current[segmentId] = normalized;
+
+    final unmodifiable = _asUnmodifiable(current);
+    final payload = jsonEncode(_buildFeatureCollection(unmodifiable));
+
+    try {
+      final path = await resolveSegmentPathsCachePath(
+        overrideResolver: _pathResolver,
+      );
+      await _fileSystem.ensureParentDirectory(path);
+      await _fileSystem.writeAsString(path, payload);
+      _cache = unmodifiable;
+    } on TollSegmentsFileSystemException catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        SegmentPathCacheException(
+          'Failed to persist the segment path for $segmentId.',
+          cause: error,
+        ),
+        stackTrace,
+      );
+    }
+  }
+
+  Map<String, List<GeoPoint>> _parseFeatureCollection(dynamic data) {
+    if (data is! Map<String, dynamic>) {
+      throw const FormatException('GeoJSON must be an object.');
+    }
+    if (data['type'] != 'FeatureCollection') {
+      throw const FormatException('GeoJSON must be a FeatureCollection.');
+    }
+    final features = data['features'];
+    if (features is! List) {
+      throw const FormatException('GeoJSON FeatureCollection missing features.');
+    }
+
+    final result = <String, List<GeoPoint>>{};
+    for (final feature in features) {
+      if (feature is! Map<String, dynamic>) {
+        continue;
+      }
+
+      final props = feature['properties'];
+      String? id;
+      if (props is Map<String, dynamic>) {
+        final dynamic rawId = props['segment_id'] ?? props['id'];
+        if (rawId != null) {
+          id = '$rawId';
+        }
+      }
+      id ??= feature['id']?.toString();
+      if (id == null || id.isEmpty) {
+        continue;
+      }
+
+      final geometry = feature['geometry'];
+      if (geometry is! Map<String, dynamic>) {
+        continue;
+      }
+
+      if (geometry['type'] != 'LineString') {
+        continue;
+      }
+
+      final coords = geometry['coordinates'];
+      if (coords is! List || coords.length < 2) {
+        continue;
+      }
+
+      final path = <GeoPoint>[];
+      for (final coord in coords) {
+        if (coord is List && coord.length >= 2) {
+          final lon = (coord[0] as num).toDouble();
+          final lat = (coord[1] as num).toDouble();
+          path.add(GeoPoint(lat, lon));
+        }
+      }
+
+      if (path.length < 2) {
+        continue;
+      }
+
+      result[id] = List<GeoPoint>.unmodifiable(path);
+    }
+
+    return result;
+  }
+
+  Map<String, List<GeoPoint>> _asUnmodifiable(
+    Map<String, List<GeoPoint>> input,
+  ) {
+    return Map<String, List<GeoPoint>>.unmodifiable(
+      input.map(
+        (key, value) => MapEntry(
+          key,
+          List<GeoPoint>.unmodifiable(value),
+        ),
+      ),
+    );
+  }
+
+  Map<String, dynamic> _buildFeatureCollection(
+    Map<String, List<GeoPoint>> data,
+  ) {
+    final features = <Map<String, dynamic>>[];
+    data.forEach((id, points) {
+      if (points.length < 2) {
+        return;
+      }
+      features.add({
+        'type': 'Feature',
+        'properties': <String, dynamic>{'segment_id': id},
+        'geometry': <String, dynamic>{
+          'type': 'LineString',
+          'coordinates': points
+              .map((point) => <double>[point.lon, point.lat])
+              .toList(growable: false),
+        },
+      });
+    });
+
+    return <String, dynamic>{
+      'type': 'FeatureCollection',
+      'features': features,
+    };
+  }
+}
+
+class SegmentPathCacheException implements Exception {
+  const SegmentPathCacheException(this.message, {this.cause, this.stackTrace});
+
+  final String message;
+  final Object? cause;
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() => 'SegmentPathCacheException: $message';
+}

--- a/lib/services/toll_segments_paths.dart
+++ b/lib/services/toll_segments_paths.dart
@@ -11,6 +11,10 @@ const String kTollSegmentsFileName = 'toll_segments.csv';
 /// Suffix appended to the toll segments CSV path to store local metadata.
 const String kTollSegmentsMetadataSuffix = '_metadata.json';
 
+/// Suffix appended to the toll segments CSV path to store cached segment paths
+/// as GeoJSON.
+const String kSegmentPathsSuffix = '_paths.geojson';
+
 /// Function signature for providing a custom on-disk location for the synced
 /// toll segments CSV. Useful for tests.
 typedef TollSegmentsPathResolver = Future<String> Function();
@@ -47,5 +51,15 @@ Future<String> resolveTollSegmentsMetadataPath({
     overrideResolver: overrideResolver,
   );
   return '$csvPath$kTollSegmentsMetadataSuffix';
+}
+
+/// Resolves the path where cached segment path GeoJSON data should be stored.
+Future<String> resolveSegmentPathsCachePath({
+  TollSegmentsPathResolver? overrideResolver,
+}) async {
+  final csvPath = await resolveTollSegmentsDataPath(
+    overrideResolver: overrideResolver,
+  );
+  return '$csvPath$kSegmentPathsSuffix';
 }
 

--- a/test/services/segment_path_cache_service_test.dart
+++ b/test/services/segment_path_cache_service_test.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:toll_cam_finder/core/spatial/geo.dart';
+import 'package:toll_cam_finder/services/segment_path_cache_service.dart';
+import 'package:toll_cam_finder/services/toll_segments_file_system.dart';
+import 'package:toll_cam_finder/services/toll_segments_paths.dart';
+
+class _FakeTollSegmentsFileSystem extends TollSegmentsFileSystem {
+  final Map<String, String> files = <String, String>{};
+  final Set<String> ensuredDirectories = <String>{};
+
+  @override
+  Future<void> ensureParentDirectory(String path) async {
+    ensuredDirectories.add(p.dirname(path));
+  }
+
+  @override
+  Future<bool> exists(String path) async => files.containsKey(path);
+
+  @override
+  Future<String> readAsString(String path) async {
+    final contents = files[path];
+    if (contents == null) {
+      throw const TollSegmentsFileSystemException('File not found');
+    }
+    return contents;
+  }
+
+  @override
+  Future<void> writeAsString(String path, String data) async {
+    files[path] = data;
+  }
+}
+
+void main() {
+  const csvPath = '/tmp/toll_segments.csv';
+  final cachePath = '$csvPath$kSegmentPathsSuffix';
+
+  SegmentPathCacheService _createService(_FakeTollSegmentsFileSystem fs) {
+    return SegmentPathCacheService(
+      fileSystem: fs,
+      pathResolver: () async => csvPath,
+    );
+  }
+
+  test('loadAllPaths returns empty map when cache is missing', () async {
+    final fs = _FakeTollSegmentsFileSystem();
+    final service = _createService(fs);
+
+    final result = await service.loadAllPaths();
+
+    expect(result, isEmpty);
+    expect(fs.files.containsKey(cachePath), isFalse);
+  });
+
+  test('savePath persists GeoJSON and can be reloaded', () async {
+    final fs = _FakeTollSegmentsFileSystem();
+    final service = _createService(fs);
+
+    await service.savePath('123', const <GeoPoint>[
+      GeoPoint(10.0, 20.0),
+      GeoPoint(11.0, 21.0),
+      GeoPoint(12.0, 22.0),
+    ]);
+
+    expect(fs.files.containsKey(cachePath), isTrue);
+    expect(fs.ensuredDirectories, contains(p.dirname(cachePath)));
+
+    final decoded = jsonDecode(fs.files[cachePath]!);
+    expect(decoded, isA<Map<String, dynamic>>());
+    expect(decoded['type'], 'FeatureCollection');
+
+    final loaded = await service.loadAllPaths();
+    final restored = loaded['123'];
+    expect(restored, isNotNull);
+    expect(restored, hasLength(3));
+    expect(restored!.first.lat, 10.0);
+    expect(restored.first.lon, 20.0);
+  });
+
+  test('savePath replaces existing entry', () async {
+    final fs = _FakeTollSegmentsFileSystem();
+    final service = _createService(fs);
+
+    await service.savePath('abc', const <GeoPoint>[
+      GeoPoint(0.0, 1.0),
+      GeoPoint(2.0, 3.0),
+    ]);
+
+    await service.savePath('abc', const <GeoPoint>[
+      GeoPoint(4.0, 5.0),
+      GeoPoint(6.0, 7.0),
+      GeoPoint(8.0, 9.0),
+    ]);
+
+    final loaded = await service.loadAllPaths();
+    final restored = loaded['abc'];
+    expect(restored, isNotNull);
+    expect(restored, hasLength(3));
+    expect(restored!.first.lat, 4.0);
+    expect(restored.last.lon, 9.0);
+  });
+
+  test('loadAllPaths throws when GeoJSON cannot be parsed', () async {
+    final fs = _FakeTollSegmentsFileSystem();
+    fs.files[cachePath] = 'not-json';
+    final service = _createService(fs);
+
+    await expectLater(
+      service.loadAllPaths(),
+      throwsA(isA<SegmentPathCacheException>()),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add a segment path cache service that persists GeoJSON route data alongside the toll segments CSV
- hook the segment tracker and map page into the cache so stored routes are restored and displayed even when no segment is active
- render cached segment polylines via a new overlay and cover the cache service with unit tests

## Testing
- Not run (environment lacks Flutter/Dart tooling)


------
https://chatgpt.com/codex/tasks/task_e_68e266692714832d9325db3aa50e7b4e