### PR TITLE
Add option to submit local segments for public review

### DIFF
--- a/lib/presentation/widgets/add_segment/segment_action_dialogs.dart
+++ b/lib/presentation/widgets/add_segment/segment_action_dialogs.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
+import 'package:toll_cam_finder/services/auth_controller.dart';
 import 'package:toll_cam_finder/services/segments_repository.dart';
 
-enum SegmentAction { delete, deactivate, activate }
+enum SegmentAction { delete, deactivate, activate, makePublic }
 
 Future<SegmentAction?> showSegmentActionsSheet(
   BuildContext context,
@@ -13,6 +15,16 @@ Future<SegmentAction?> showSegmentActionsSheet(
   return showModalBottomSheet<SegmentAction>(
     context: context,
     builder: (context) {
+      AuthController? authController;
+      try {
+        authController = context.read<AuthController>();
+      } catch (_) {
+        authController = null;
+      }
+      final isLoggedIn = authController?.isLoggedIn == true;
+      final isAuthConfigured = authController?.isConfigured == true;
+      final canMakePublic =
+          segment.isLocalOnly && !segment.isMarkedPublic && isAuthConfigured;
       return SafeArea(
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -35,6 +47,20 @@ Future<SegmentAction?> showSegmentActionsSheet(
                     : SegmentAction.deactivate,
               ),
             ),
+            if (segment.isLocalOnly && !segment.isMarkedPublic)
+              ListTile(
+                leading: const Icon(Icons.public),
+                title: const Text('Share segment publicly'),
+                subtitle: !isAuthConfigured
+                    ? const Text('Public sharing is not available.')
+                    : isLoggedIn
+                        ? const Text('Submit this segment for public review.')
+                        : const Text('Please sign in to share segments publicly.'),
+                enabled: canMakePublic && isLoggedIn,
+                onTap: canMakePublic && isLoggedIn
+                    ? () => Navigator.of(context).pop(SegmentAction.makePublic)
+                    : null,
+              ),
             ListTile(
               leading: const Icon(Icons.delete_outline),
               title: const Text('Delete segment'),


### PR DESCRIPTION
## Summary
- extend the segment actions sheet to offer a “share publicly” option for local segments when the user is authenticated
- add a helper to rebuild saved local segments into drafts that can be sent to the moderation service
- wire long-press actions on both segment lists to submit existing local segments for review and flag them as public locally

## Testing
- Not run (Flutter SDK is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e277d3c408832d81b9d24ed987ca1a