### PR TITLE
Centralize user-facing messages in AppMessages

### DIFF
--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -1,0 +1,449 @@
+/// Collection of user-facing strings displayed throughout the app.
+///
+/// Keeping messages together near [AppConstants] simplifies translation and
+/// ensures copy updates remain consistent across the UI.
+class AppMessages {
+  /// Shown after returning from the segment creation flow when a draft has
+  /// been saved to local storage instead of being published immediately.
+  static const String segmentSavedLocally = 'Segment saved locally.';
+
+  /// Label shown when offering to reveal a segment that was previously hidden
+  /// on the map.
+  static const String showSegmentOnMapAction = 'Show segment on map';
+
+  /// Label shown when offering to hide a segment from the map.
+  static const String hideSegmentOnMapAction = 'Hide segment on map';
+
+  /// Subtitle explaining that restoring a segment will re-enable cameras and
+  /// warnings for it.
+  static const String segmentVisibilityRestoreSubtitle =
+      'Cameras and warnings for this segment will be restored.';
+
+  /// Subtitle explaining that hiding a segment will disable cameras and
+  /// warnings for it.
+  static const String segmentVisibilityDisableSubtitle =
+      'No cameras or warnings will appear for this segment.';
+
+  /// Shown after the user hides a segment; confirms the display id is now
+  /// hidden and that related warnings are disabled.
+  static String segmentHidden(String displayId) =>
+      'Segment $displayId hidden. Cameras and warnings are disabled.';
+
+  /// Shown after the user reactivates a segment; confirms visibility and
+  /// warnings have been restored.
+  static String segmentVisible(String displayId) =>
+      'Segment $displayId is visible again. Cameras and warnings restored.';
+
+  /// Shown when updating a segment's metadata fails and the error message
+  /// should be surfaced to the user.
+  static String failedToUpdateSegment(
+    String displayId,
+    String errorMessage,
+  ) =>
+      'Failed to update segment $displayId: $errorMessage';
+
+  /// Shown when the user attempts to share a segment publicly without a valid
+  /// authenticated session.
+  static const String signInToShareSegment =
+      'Please sign in to share segments publicly.';
+
+  /// Label for the bottom sheet option that begins the public sharing flow for
+  /// a segment.
+  static const String shareSegmentPubliclyAction = 'Share segment publicly';
+
+  /// Shown when the remote sharing infrastructure is not available, preventing
+  /// the submission of public segments.
+  static const String publicSharingUnavailable =
+      'Public segment sharing is currently unavailable.';
+
+  /// Short subtitle explaining that public sharing is currently unavailable in
+  /// contexts where space is limited.
+  static const String publicSharingUnavailableShort =
+      'Public sharing is not available.';
+
+  /// Subtitle informing the user that choosing to share publicly will submit
+  /// the segment for moderation.
+  static const String submitSegmentForPublicReviewSubtitle =
+      'Submit this segment for public review.';
+
+  /// Shown when the app cannot determine the logged in user during a public
+  /// submission flow.
+  static const String unableToDetermineLoggedInAccount =
+      'Unable to determine the logged in account.';
+
+  /// Shown when loading local draft data fails while preparing a public
+  /// submission.
+  static const String failedToPrepareSegmentForReview =
+      'Failed to prepare the segment for public review.';
+
+  /// Shown when checking the public submission status fails with a generic
+  /// error.
+  static const String failedToCheckSubmissionStatus =
+      'Failed to check the public submission status.';
+
+  /// Shown when submitting a segment for moderation fails unexpectedly.
+  static const String failedToSubmitForModeration =
+      'Failed to submit the segment for moderation.';
+
+  /// Shown when a segment has already been submitted for public review by the
+  /// same user and is awaiting moderation.
+  static String segmentAlreadyAwaitingReview(String displayId) =>
+      'Segment $displayId is already awaiting public review.';
+
+  /// Shown when a segment is successfully submitted for public review and the
+  /// segment id should be echoed back to the user.
+  static String segmentSubmittedForPublicReview(String displayId) =>
+      'Segment $displayId submitted for public review.';
+
+  /// Shown when a segment is successfully submitted for public review but no
+  /// display id is available (e.g. immediately after draft creation).
+  static const String segmentSubmittedForPublicReviewGeneric =
+      'Segment submitted for public review.';
+
+  /// Shown when the app cannot withdraw a public submission due to missing
+  /// authentication state.
+  static const String unableToWithdrawSubmission =
+      'Unable to withdraw the public submission.';
+
+  /// Shown when the user must sign in before they can withdraw a public
+  /// submission.
+  static const String signInToWithdrawSubmission =
+      'Please sign in to withdraw the public submission.';
+
+  /// Shown when a public submission has been successfully cancelled and the
+  /// review process will no longer continue.
+  static String segmentNoLongerUnderReview(String displayId) =>
+      'Segment $displayId will no longer be reviewed for public release.';
+
+  /// Shown when withdrawing a public submission fails due to a missing internet
+  /// connection; informs the user that only the local delete will proceed.
+  static const String noConnectionCannotWithdrawSubmission =
+      'No internet connection. The public submission cannot be withdrawn and the segment will only be deleted locally.';
+
+  /// Shown when the app fails to cancel an in-progress public review request.
+  static const String failedToCancelPublicReview =
+      'Failed to cancel the public review for this segment.';
+
+  /// Shown when deleting a segment fails for any reason.
+  static const String failedToDeleteSegment =
+      'Failed to delete the segment.';
+
+  /// Label for the delete option in segment action sheets and dialogs.
+  static const String deleteSegmentAction = 'Delete segment';
+
+  /// Subtitle explaining why a segment cannot currently be deleted.
+  static const String onlyLocalSegmentsCanBeDeleted =
+      'Only local segments can be deleted.';
+
+  /// Shown after a segment has been deleted from the local store.
+  static String segmentDeleted(String displayId) =>
+      'Segment $displayId deleted.';
+
+  /// Title shown when confirming whether a segment should be deleted.
+  static const String deleteSegmentConfirmationTitle = 'Delete segment';
+
+  /// Message shown when asking the user to confirm segment deletion.
+  static String confirmDeleteSegment(String displayId) =>
+      'Are you sure you want to delete segment $displayId?';
+
+  /// Shown when the app cannot determine the logged in account and suggests
+  /// signing in again.
+  static const String unableToDetermineLoggedInAccountRetry =
+      'Unable to determine the logged in account. Please sign in again.';
+
+  /// Shown when prompting the user to choose if a new segment should be visible
+  /// publicly after creation.
+  static const String chooseSegmentVisibilityQuestion =
+      'Do you want the segment to be publically visible?';
+
+  /// Shown when asking the user to confirm keeping a segment private.
+  static const String confirmKeepSegmentPrivate =
+      'Are you sure that you want to keep the segment only to yourself?';
+
+  /// Shown when asking the user to confirm making a segment public.
+  static const String confirmMakeSegmentPublic =
+      'Are you sure you want to make this segment public?';
+
+  /// Title used when asking the user to withdraw a public submission.
+  static const String withdrawPublicSubmissionTitle =
+      'Withdraw public submission?';
+
+  /// Message shown when confirming if the user wants to withdraw a submission.
+  static const String withdrawPublicSubmissionMessage =
+      'You have submitted this segment for review. Do you want to withdraw the submission?';
+
+  /// Generic fallback error shown when an operation fails unexpectedly.
+  static const String somethingWentWrongTryAgain =
+      'Something went wrong. Please try again.';
+
+  /// Shown after a new account is created to prompt email confirmation.
+  static const String accountCreatedCheckEmail =
+      'Account created! Check your email to confirm it.';
+
+  /// Shown when logging out fails unexpectedly.
+  static const String unableToLogOutTryAgain =
+      'Unable to log out. Please try again.';
+
+  /// Shown when authentication services have not been configured.
+  static const String authenticationNotConfigured =
+      'Authentication is not configured. Please add Supabase credentials.';
+
+  /// Shown when sign-in fails due to an unexpected platform error.
+  static const String unexpectedErrorSigningIn =
+      'Unexpected error while signing in.';
+
+  /// Shown when account creation fails due to an unexpected platform error.
+  static const String unexpectedErrorCreatingAccount =
+      'Unexpected error while creating the account.';
+
+  /// Shown when sign-out fails due to an unexpected platform error.
+  static const String unexpectedErrorSigningOut =
+      'Unexpected error while signing out.';
+
+  /// Validation message shown when the name field is left empty.
+  static const String enterYourName = 'Please enter your name';
+
+  /// Validation message shown when the email field is left empty.
+  static const String enterYourEmail = 'Please enter your email';
+
+  /// Validation message shown when the password field is left empty.
+  static const String enterYourPassword = 'Please enter your password';
+
+  /// Validation message shown when the password confirmation is missing.
+  static const String confirmYourPassword = 'Please confirm your password';
+
+  /// Validation message shown when creating a new password requires input.
+  static const String createPasswordPrompt = 'Please create a password';
+
+  /// Validation message shown when the password is shorter than the minimum.
+  static const String passwordTooShort =
+      'Password must be at least 6 characters';
+
+  /// Validation message shown when the password and confirmation do not match.
+  static const String passwordsDoNotMatch = 'Passwords do not match';
+
+  /// Message displayed when loading segments fails in list views.
+  static const String failedToLoadSegments = 'Failed to load segments.';
+
+  /// Generic retry button label used across error surfaces.
+  static const String retryAction = 'Retry';
+
+  /// Generic affirmative button label.
+  static const String yesAction = 'Yes';
+
+  /// Generic negative button label.
+  static const String noAction = 'No';
+
+  /// Generic cancel action label.
+  static const String cancelAction = 'Cancel';
+
+  /// Generic delete action label.
+  static const String deleteAction = 'Delete';
+
+  /// Hint shown before either endpoint has been positioned on the map.
+  static const String mapHintPlacePointA =
+      'Tap anywhere on the map to place point A.';
+
+  /// Hint shown after the start point has been placed but not the end point.
+  static const String mapHintPlacePointB =
+      'Tap a second location to place point B.';
+
+  /// Hint shown once both endpoints exist, explaining how to reposition them.
+  static const String mapHintDragPoint =
+      'Touch and hold A or B for 0.5s, then drag to reposition that point.';
+
+  /// Message shown when loading camera data fails.
+  static String failedToLoadCameras(String error) =>
+      'Failed to load cameras: $error';
+
+  /// Message shown when the app cannot access the segments metadata file.
+  static const String failedToAccessSegmentsMetadataFile =
+      'Failed to access the segments metadata file.';
+
+  /// Message shown when the segments metadata file cannot be parsed.
+  static const String failedToParseSegmentsMetadataFile =
+      'Failed to parse the segments metadata file.';
+
+  /// Message shown when the segments metadata file cannot be written.
+  static const String failedToWriteSegmentsMetadataFile =
+      'Failed to write to the segments metadata file.';
+
+  /// Message shown when submitting a segment for moderation fails.
+  static String failedToSubmitSegmentForModerationWithReason(String reason) =>
+      'Failed to submit the segment for moderation: $reason';
+
+  /// Message shown when checking the submission status fails.
+  static String failedToCheckSubmissionStatusWithReason(String reason) =>
+      'Failed to check the public submission status: $reason';
+
+  /// Message shown when cancelling a submission fails.
+  static String failedToCancelSubmissionWithReason(String reason) =>
+      'Failed to cancel the public submission: $reason';
+
+  /// Message shown when downloading toll segments fails.
+  static String failedToDownloadTollSegments(String reason) =>
+      'Failed to download toll segments: $reason';
+
+  /// Message shown when accessing the local toll segments file fails.
+  static String failedToAccessTollSegmentsFile(String reason) =>
+      'Failed to access the toll segments file: $reason';
+
+  /// Message shown when the local storage path for toll segments cannot be
+  /// determined.
+  static const String failedToDetermineTollSegmentsPath =
+      'Failed to determine the local toll segments storage path.';
+
+  /// Message shown when attempting to edit metadata on unsupported platforms.
+  static const String segmentMetadataUpdateUnavailable =
+      'Segment metadata cannot be updated on the web.';
+
+  /// Message shown when Supabase is not configured for moderation submissions.
+  static const String supabaseNotConfiguredForModeration =
+      'Supabase is not configured. Unable to submit the segment for moderation.';
+
+  /// Message shown when Supabase is not configured for managing public submissions.
+  static const String supabaseNotConfiguredForPublicSubmissions =
+      'Supabase is not configured. Unable to manage public submissions.';
+
+  /// Message shown when a logged-in user is required to submit a segment.
+  static const String userRequiredForPublicModeration =
+      'A logged in user is required to submit a public segment for moderation.';
+
+  /// Message shown when there is no internet connection for moderation actions.
+  static const String noConnectionUnableToSubmitForModeration =
+      'No internet connection. Unable to submit the segment for moderation.';
+
+  /// Message shown when there is no internet connection for managing submissions.
+  static const String noConnectionUnableToManageSubmissions =
+      'No internet connection. Unable to manage public submissions.';
+
+  /// Message shown when an unexpected error occurs while submitting a segment.
+  static const String unexpectedErrorSubmittingForModeration =
+      'Unexpected error while submitting the segment for moderation.';
+
+  /// Message shown when an unexpected error occurs while checking submission status.
+  static const String unexpectedErrorCheckingSubmissionStatus =
+      'Unexpected error while checking the public submission status.';
+
+  /// Message shown when an unexpected error occurs while cancelling a submission.
+  static const String unexpectedErrorCancellingSubmission =
+      'Unexpected error while cancelling the public submission.';
+
+  /// Message shown when there are no more available segment ids.
+  static const String unableToAssignNewSegmentId =
+      'Unable to assign a new segment id: all smallint values are exhausted.';
+
+  /// Message shown when a non-numeric segment id is encountered.
+  static const String nonNumericSegmentIdEncountered =
+      'Encountered an existing segment with a non-numeric id.';
+
+  /// Message shown when sync is not supported on the current platform.
+  static const String syncNotSupportedOnWeb =
+      'Syncing toll segments is not supported on the web.';
+
+  /// Message shown when the remote table returns no rows.
+  static String tableReturnedNoRows(String tableName) =>
+      'The $tableName table did not return any rows.';
+
+  /// Message shown when none of the candidate tables returned any rows.
+  static String noTollSegmentRowsFound(String tablesChecked) =>
+      'No toll segment rows were returned from Supabase. Checked tables: '
+      '$tablesChecked. Ensure your account has access to the data.';
+
+  /// Message shown when a required moderation column is missing.
+  static String tableMissingModerationColumn(String tableName, String column) =>
+      'The "$tableName" table is missing the "$column" column required for moderation.';
+
+  /// Message shown when the local CSV is missing required start/end columns.
+  static const String csvMissingStartEndColumns =
+      'CSV must contain "Start" and "End" columns';
+
+  /// Message shown when an expected column is absent in the remote table.
+  static String missingRequiredColumn(String column) =>
+      'Missing required column "$column" in the Toll_Segments table.';
+
+  /// Title for the dialog prompting the user to sign in before sharing a
+  /// segment publicly.
+  static const String signInToSharePubliclyTitle =
+      'Sign in to share publicly';
+
+  /// Body copy shown when the user must sign in before sharing publicly and is
+  /// given the option to save locally instead.
+  static const String signInToSharePubliclyBody =
+      'You need to be logged in to submit a public segment. Would you like to log in or save the segment locally instead?';
+
+  /// Label for dialog actions that save a draft locally instead of logging in.
+  static const String saveLocallyAction = 'Save locally';
+
+  /// Label for dialog actions that initiate the login flow.
+  static const String loginAction = 'Login';
+
+  /// Shown when saving a draft locally fails unexpectedly.
+  static const String failedToSaveSegmentLocally =
+      'Failed to save the segment locally.';
+
+  /// Shown when the draft form is missing required coordinate values.
+  static const String startEndCoordinatesRequired =
+      'Start and end coordinates are required.';
+
+  /// Shown after a successful login when the user is returned to the draft
+  /// flow and needs to press the save button again to continue submission.
+  static const String loggedInRetrySavePrompt =
+      'Logged in successfully. Tap "Save segment" again to submit the segment.';
+
+  /// Shown when launching the OpenStreetMap copyright page fails.
+  static const String osmCopyrightLaunchFailed =
+      'Could not open the OpenStreetMap copyright page.';
+
+  /// Shown when the app fails to load the persisted segment metadata
+  /// preferences and falls back to defaults.
+  static String failedToLoadSegmentPreferences(String errorMessage) =>
+      'Failed to load segment preferences: $errorMessage';
+
+  /// Shown when Supabase credentials are missing and online sync cannot start.
+  static const String supabaseNotConfiguredForSync =
+      'Supabase is not configured. Please add credentials to enable sync.';
+
+  /// Shown when an unexpected error occurs during the toll segment sync flow.
+  static const String unexpectedSyncError =
+      'Unexpected error while syncing toll segments.';
+
+  /// Builds the sync completion summary shown after the toll segments database
+  /// has been refreshed.
+  static String syncCompleteSummary({
+    required int addedSegments,
+    required int removedSegments,
+    required int totalSegments,
+    required int approvedLocalSegments,
+  }) {
+    final parts = <String>[];
+    if (addedSegments > 0) {
+      final label = addedSegments == 1 ? 'segment' : 'segments';
+      parts.add('$addedSegments $label added');
+    }
+    if (removedSegments > 0) {
+      final label = removedSegments == 1 ? 'segment' : 'segments';
+      parts.add('$removedSegments $label removed');
+    }
+
+    final changesSummary = parts.isEmpty
+        ? 'No changes detected.'
+        : parts.join(', ') + '.';
+    final buffer = StringBuffer(
+      'Sync complete. $changesSummary $totalSegments total segments available.',
+    );
+
+    if (approvedLocalSegments > 0) {
+      final verb = approvedLocalSegments == 1 ? 'was' : 'were';
+      final visibilityVerb = approvedLocalSegments == 1 ? 'is' : 'are';
+      buffer.write(
+        ' $approvedLocalSegments of your submitted segments ',
+      );
+      buffer.write(
+        '$verb approved and now $visibilityVerb visible to everyone.',
+      );
+    }
+
+    return buffer.toString();
+  }
+}

--- a/lib/features/segemnt_index_service.dart
+++ b/lib/features/segemnt_index_service.dart
@@ -4,6 +4,7 @@ import 'package:csv/csv.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:latlong2/latlong.dart';
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/spatial/geo.dart';
 
 // add these if not present:
@@ -232,7 +233,7 @@ class SegmentIndexService {
     final endIdx = header.indexOf('end');
 
     if (startIdx == -1 || endIdx == -1) {
-      throw const FormatException('CSV must contain "Start" and "End" columns');
+      throw const FormatException(AppMessages.csvMissingStartEndColumns);
     }
 
     final nameIdx = header.indexOf('name');

--- a/lib/presentation/pages/auth/login_page.dart
+++ b/lib/presentation/pages/auth/login_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
+import 'package:toll_cam_finder/core/app_messages.dart';
 
 import '../../../app/app_routes.dart';
 import '../../../services/auth_controller.dart';
@@ -72,7 +73,7 @@ class _LoginPageState extends State<LoginPage> {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('Something went wrong. Please try again.'),
+          content: Text(AppMessages.somethingWentWrongTryAgain),
         ),
       );
     } finally {
@@ -114,7 +115,7 @@ class _LoginPageState extends State<LoginPage> {
                   ),
                   validator: (value) {
                     if (value == null || value.trim().isEmpty) {
-                      return 'Please enter your email';
+                      return AppMessages.enterYourEmail;
                     }
                     return null;
                   },
@@ -129,7 +130,7 @@ class _LoginPageState extends State<LoginPage> {
                   ),
                   validator: (value) {
                     if (value == null || value.isEmpty) {
-                      return 'Please enter your password';
+                      return AppMessages.enterYourPassword;
                     }
                     return null;
                   },

--- a/lib/presentation/pages/auth/profile_page.dart
+++ b/lib/presentation/pages/auth/profile_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
+import 'package:toll_cam_finder/core/app_messages.dart';
 
 import '../../../app/app_routes.dart';
 import '../../../services/auth_controller.dart';
@@ -56,7 +57,7 @@ class ProfilePage extends StatelessWidget {
                     debugPrint('Logout error: $error\n$stackTrace');
                     messenger.showSnackBar(
                       const SnackBar(
-                        content: Text('Unable to log out. Please try again.'),
+                        content: Text(AppMessages.unableToLogOutTryAgain),
                       ),
                     );
                   }

--- a/lib/presentation/pages/auth/sign_up_page.dart
+++ b/lib/presentation/pages/auth/sign_up_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter/foundation.dart';
+import 'package:toll_cam_finder/core/app_messages.dart';
 
 import '../../../app/app_routes.dart';
 import '../../../services/auth_controller.dart';
@@ -48,7 +49,7 @@ class _SignUpPageState extends State<SignUpPage> {
       Navigator.of(context).pushReplacementNamed(AppRoutes.login);
       messenger.showSnackBar(
         const SnackBar(
-          content: Text('Account created! Check your email to confirm it.'),
+          content: Text(AppMessages.accountCreatedCheckEmail),
         ),
       );
     } on AuthFailure catch (error) {
@@ -61,7 +62,7 @@ class _SignUpPageState extends State<SignUpPage> {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('Something went wrong. Please try again.'),
+          content: Text(AppMessages.somethingWentWrongTryAgain),
         ),
       );
     } finally {
@@ -101,7 +102,7 @@ class _SignUpPageState extends State<SignUpPage> {
                   ),
                   validator: (value) {
                     if (value == null || value.trim().isEmpty) {
-                      return 'Please enter your name';
+                      return AppMessages.enterYourName;
                     }
                     return null;
                   },
@@ -116,7 +117,7 @@ class _SignUpPageState extends State<SignUpPage> {
                   ),
                   validator: (value) {
                     if (value == null || value.trim().isEmpty) {
-                      return 'Please enter your email';
+                      return AppMessages.enterYourEmail;
                     }
                     return null;
                   },
@@ -131,10 +132,10 @@ class _SignUpPageState extends State<SignUpPage> {
                   ),
                   validator: (value) {
                     if (value == null || value.isEmpty) {
-                      return 'Please create a password';
+                      return AppMessages.createPasswordPrompt;
                     }
                     if (value.length < 6) {
-                      return 'Password must be at least 6 characters';
+                      return AppMessages.passwordTooShort;
                     }
                     return null;
                   },
@@ -149,10 +150,10 @@ class _SignUpPageState extends State<SignUpPage> {
                   ),
                   validator: (value) {
                     if (value == null || value.isEmpty) {
-                      return 'Please confirm your password';
+                      return AppMessages.confirmYourPassword;
                     }
                     if (value != _passwordController.text) {
-                      return 'Passwords do not match';
+                      return AppMessages.passwordsDoNotMatch;
                     }
                     return null;
                   },

--- a/lib/presentation/pages/create_segment_page.dart
+++ b/lib/presentation/pages/create_segment_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:toll_cam_finder/app/app_routes.dart';
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart';
 import 'package:toll_cam_finder/presentation/widgets/segment_picker/segment_picker_map.dart';
 import 'package:toll_cam_finder/services/auth_controller.dart';
@@ -256,21 +257,21 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text(
-            'Do you want the segment to be publically visible?',
+          content: const Text(
+            AppMessages.chooseSegmentVisibilityQuestion,
           ),
           actions: [
             TextButton(
               onPressed: () {
                 Navigator.of(context).pop(_SegmentVisibilityChoice.private);
               },
-              child: const Text('No'),
+              child: const Text(AppMessages.noAction),
             ),
             FilledButton(
               onPressed: () {
                 Navigator.of(context).pop(_SegmentVisibilityChoice.public);
               },
-              child: const Text('Yes'),
+              child: const Text(AppMessages.yesAction),
             ),
           ],
         );
@@ -284,8 +285,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     switch (visibilityChoice) {
       case _SegmentVisibilityChoice.private:
         final confirmPrivate = await _showConfirmationDialog(
-          message:
-              'Are you sure that you want to keep the segment only to yourself?',
+          message: AppMessages.confirmKeepSegmentPrivate,
         );
         if (confirmPrivate == true) {
           await _handlePrivateSegmentSaved();
@@ -293,7 +293,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
         break;
       case _SegmentVisibilityChoice.public:
         final confirmPublic = await _showConfirmationDialog(
-          message: 'Are you sure you want to make this segment public?',
+          message: AppMessages.confirmMakeSegmentPublic,
         );
         if (confirmPublic == true) {
           await _handlePublicSegmentSaved();
@@ -311,11 +311,11 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(false),
-              child: const Text('No'),
+              child: const Text(AppMessages.noAction),
             ),
             FilledButton(
               onPressed: () => Navigator.of(context).pop(true),
-              child: const Text('Yes'),
+              child: const Text(AppMessages.yesAction),
             ),
           ],
         );
@@ -348,23 +348,20 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
         useRootNavigator: true,
         builder: (context) {
           return AlertDialog(
-            title: const Text('Sign in to share publicly'),
-            content: const Text(
-              'You need to be logged in to submit a public segment. '
-              'Would you like to log in or save the segment locally instead?',
-            ),
+            title: const Text(AppMessages.signInToSharePubliclyTitle),
+            content: const Text(AppMessages.signInToSharePubliclyBody),
             actions: [
               TextButton(
                 onPressed: () {
                   Navigator.of(context).pop(_LoginOrLocalChoice.saveLocally);
                 },
-                child: const Text('Save locally'),
+                child: const Text(AppMessages.saveLocallyAction),
               ),
               FilledButton(
                 onPressed: () {
                   Navigator.of(context).pop(_LoginOrLocalChoice.login);
                 },
-                child: const Text('Login'),
+                child: const Text(AppMessages.loginAction),
               ),
             ],
           );
@@ -387,7 +384,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
             final loggedIn = result is bool ? result : null;
             if (loggedIn == true && mounted) {
               _showSnackBar(
-                'Logged in successfully. Tap "Save segment" again to submit the segment.',
+                AppMessages.loggedInRetrySavePrompt,
               );
             }
           } finally {
@@ -406,7 +403,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     final userId = auth.currentUserId;
     if (userId == null || userId.isEmpty) {
       _showSnackBar(
-        'Unable to determine the logged in account. Please sign in again.',
+        AppMessages.unableToDetermineLoggedInAccountRetry,
       );
       return;
     }
@@ -436,14 +433,16 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
       return;
     } catch (_) {
       await _rollbackLocalDraft(localId);
-      _showSnackBar('Failed to submit the segment for moderation.');
+      _showSnackBar(AppMessages.failedToSubmitForModeration);
       return;
     }
 
     if (!mounted) return;
 
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Segment submitted for public review.')),
+      const SnackBar(
+        content: Text(AppMessages.segmentSubmittedForPublicReviewGeneric),
+      ),
     );
     _resetDraftState();
     Navigator.of(context).pop(true);
@@ -452,7 +451,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
   SegmentDraft? _buildDraft({required bool isPublic}) {
     if (_startController.text.trim().isEmpty ||
         _endController.text.trim().isEmpty) {
-      _showSnackBar('Start and end coordinates are required.');
+      _showSnackBar(AppMessages.startEndCoordinatesRequired);
       return null;
     }
 
@@ -478,7 +477,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     } on LocalSegmentsServiceException catch (error) {
       _showSnackBar(error.message);
     } catch (_) {
-      _showSnackBar('Failed to save the segment locally.');
+      _showSnackBar(AppMessages.failedToSaveSegmentLocally);
     }
     return null;
   }

--- a/lib/presentation/pages/map_page.dart
+++ b/lib/presentation/pages/map_page.dart
@@ -8,6 +8,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/features/segemnt_index_service.dart';
 import 'package:toll_cam_finder/presentation/widgets/base_tile_layer.dart';
@@ -367,7 +368,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              'Failed to load segment preferences: ${error.message}',
+              AppMessages.failedToLoadSegmentPreferences(error.message),
             ),
           ),
         );
@@ -665,9 +666,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
     if (client == null) {
       messenger.showSnackBar(
         const SnackBar(
-          content: Text(
-            'Supabase is not configured. Please add credentials to enable sync.',
-          ),
+          content: Text(AppMessages.supabaseNotConfiguredForSync),
         ),
       );
       return;
@@ -705,7 +704,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
       debugPrint('Failed to sync toll segments: $error\n$stackTrace');
       messenger.showSnackBar(
         const SnackBar(
-          content: Text('Unexpected error while syncing toll segments.'),
+          content: Text(AppMessages.unexpectedSyncError),
         ),
       );
     } finally {
@@ -719,34 +718,11 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
   }
 
   String _buildSyncSuccessMessage(TollSegmentsSyncResult result) {
-    final parts = <String>[];
-    if (result.addedSegments > 0) {
-      final label = result.addedSegments == 1 ? 'segment' : 'segments';
-      parts.add('${result.addedSegments} $label added');
-    }
-    if (result.removedSegments > 0) {
-      final label = result.removedSegments == 1 ? 'segment' : 'segments';
-      parts.add('${result.removedSegments} $label removed');
-    }
-
-    final changesSummary = parts.isEmpty
-        ? 'No changes detected.'
-        : parts.join(', ') + '.';
-    final buffer = StringBuffer(
-      'Sync complete. $changesSummary ${result.totalSegments} total segments available.',
+    return AppMessages.syncCompleteSummary(
+      addedSegments: result.addedSegments,
+      removedSegments: result.removedSegments,
+      totalSegments: result.totalSegments,
+      approvedLocalSegments: result.approvedLocalSegments,
     );
-
-    if (result.approvedLocalSegments > 0) {
-      final verb = result.approvedLocalSegments == 1 ? 'was' : 'were';
-      final visibilityVerb = result.approvedLocalSegments == 1 ? 'is' : 'are';
-      buffer.write(
-        ' ${result.approvedLocalSegments} of your submitted segments ',
-      );
-      buffer.write(
-        '$verb approved and now $visibilityVerb visible to everyone.',
-      );
-    }
-
-    return buffer.toString();
   }
 }

--- a/lib/presentation/pages/segments_page.dart
+++ b/lib/presentation/pages/segments_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/services/auth_controller.dart';
 import 'package:toll_cam_finder/services/local_segments_service.dart';
 import 'package:toll_cam_finder/services/remote_segments_service.dart';
@@ -122,7 +123,9 @@ class _SegmentsPageState extends State<SegmentsPage> {
 
     ScaffoldMessenger.of(
       context,
-    ).showSnackBar(const SnackBar(content: Text('Segment saved locally.')));
+    ).showSnackBar(
+      SnackBar(content: Text(AppMessages.segmentSavedLocally)),
+    );
 
     _segmentsUpdated = true;
     setState(() {
@@ -162,8 +165,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
       if (!mounted) return;
 
       final message = deactivate
-          ? 'Segment ${segment.displayId} hidden. Cameras and warnings are disabled.'
-          : 'Segment ${segment.displayId} is visible again. Cameras and warnings restored.';
+          ? AppMessages.segmentHidden(segment.displayId)
+          : AppMessages.segmentVisible(segment.displayId);
       messenger.showSnackBar(SnackBar(content: Text(message)));
       _segmentsUpdated = true;
       setState(() {
@@ -173,7 +176,10 @@ class _SegmentsPageState extends State<SegmentsPage> {
       messenger.showSnackBar(
         SnackBar(
           content: Text(
-            'Failed to update segment ${segment.displayId}: ${error.message}',
+            AppMessages.failedToUpdateSegment(
+              segment.displayId,
+              error.message,
+            ),
           ),
         ),
       );
@@ -188,8 +194,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
       authController = context.read<AuthController>();
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Please sign in to share segments publicly.'),
+        SnackBar(
+          content: Text(AppMessages.signInToShareSegment),
         ),
       );
       return;
@@ -197,8 +203,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
 
     if (!authController.isConfigured || authController.client == null) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Public segment sharing is currently unavailable.'),
+        SnackBar(
+          content: Text(AppMessages.publicSharingUnavailable),
         ),
       );
       return;
@@ -206,8 +212,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
 
     if (!authController.isLoggedIn) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Please sign in to share segments publicly.'),
+        SnackBar(
+          content: Text(AppMessages.signInToShareSegment),
         ),
       );
       return;
@@ -216,8 +222,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
     final userId = authController.currentUserId;
     if (userId == null || userId.isEmpty) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Unable to determine the logged in account.'),
+        SnackBar(
+          content: Text(AppMessages.unableToDetermineLoggedInAccount),
         ),
       );
       return;
@@ -231,8 +237,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
       return;
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Failed to prepare the segment for public review.'),
+        SnackBar(
+          content: Text(AppMessages.failedToPrepareSegmentForReview),
         ),
       );
       return;
@@ -267,8 +273,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
       return;
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Failed to check the public submission status.'),
+        SnackBar(
+          content: Text(AppMessages.failedToCheckSubmissionStatus),
         ),
       );
       return;
@@ -285,8 +291,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
       return;
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Failed to submit the segment for moderation.'),
+        SnackBar(
+          content: Text(AppMessages.failedToSubmitForModeration),
         ),
       );
       return;
@@ -343,8 +349,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
       auth = context.read<AuthController>();
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Unable to withdraw the public submission.'),
+        SnackBar(
+          content: Text(AppMessages.unableToWithdrawSubmission),
         ),
       );
       return false;
@@ -352,8 +358,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
 
     if (!auth.isLoggedIn || !auth.isConfigured) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Please sign in to withdraw the public submission.'),
+        SnackBar(
+          content: Text(AppMessages.signInToWithdrawSubmission),
         ),
       );
       return false;
@@ -363,8 +369,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
     final client = auth.client;
     if (userId == null || userId.isEmpty || client == null) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Unable to withdraw the public submission.'),
+        SnackBar(
+          content: Text(AppMessages.unableToWithdrawSubmission),
         ),
       );
       return false;
@@ -415,9 +421,9 @@ class _SegmentsPageState extends State<SegmentsPage> {
     } on RemoteSegmentsServiceException catch (error) {
       if (error.cause is SocketException) {
         messenger.showSnackBar(
-          const SnackBar(
+          SnackBar(
             content: Text(
-              'No internet connection. The public submission cannot be withdrawn and the segment will only be deleted locally.',
+              AppMessages.noConnectionCannotWithdrawSubmission,
             ),
           ),
         );
@@ -428,8 +434,8 @@ class _SegmentsPageState extends State<SegmentsPage> {
       return false;
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Failed to cancel the public review for this segment.'),
+        SnackBar(
+          content: Text(AppMessages.failedToCancelPublicReview),
         ),
       );
       return false;
@@ -449,13 +455,15 @@ class _SegmentsPageState extends State<SegmentsPage> {
 
       if (!deleted) {
         messenger.showSnackBar(
-          const SnackBar(content: Text('Failed to delete the segment.')),
+          SnackBar(content: Text(AppMessages.failedToDeleteSegment)),
         );
         return;
       }
 
       messenger.showSnackBar(
-        SnackBar(content: Text('Segment ${segment.displayId} deleted.')),
+        SnackBar(
+          content: Text(AppMessages.segmentDeleted(segment.displayId)),
+        ),
       );
       _segmentsUpdated = true;
       setState(() {
@@ -471,7 +479,7 @@ class _SegmentsPageState extends State<SegmentsPage> {
         return;
       }
       messenger.showSnackBar(
-        const SnackBar(content: Text('Failed to delete the segment.')),
+        SnackBar(content: Text(AppMessages.failedToDeleteSegment)),
       );
     }
   }
@@ -561,7 +569,9 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
 
     ScaffoldMessenger.of(
       context,
-    ).showSnackBar(const SnackBar(content: Text('Segment saved locally.')));
+    ).showSnackBar(
+      SnackBar(content: Text(AppMessages.segmentSavedLocally)),
+    );
 
     _segmentsUpdated = true;
     setState(() {
@@ -601,8 +611,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
       if (!mounted) return;
 
       final message = deactivate
-          ? 'Segment ${segment.displayId} hidden. Cameras and warnings are disabled.'
-          : 'Segment ${segment.displayId} is visible again. Cameras and warnings restored.';
+          ? AppMessages.segmentHidden(segment.displayId)
+          : AppMessages.segmentVisible(segment.displayId);
       messenger.showSnackBar(SnackBar(content: Text(message)));
       _segmentsUpdated = true;
       setState(() {
@@ -612,7 +622,10 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
       messenger.showSnackBar(
         SnackBar(
           content: Text(
-            'Failed to update segment ${segment.displayId}: ${error.message}',
+            AppMessages.failedToUpdateSegment(
+              segment.displayId,
+              error.message,
+            ),
           ),
         ),
       );
@@ -627,8 +640,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
       authController = context.read<AuthController>();
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Please sign in to share segments publicly.'),
+        SnackBar(
+          content: Text(AppMessages.signInToShareSegment),
         ),
       );
       return;
@@ -636,8 +649,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
 
     if (!authController.isConfigured || authController.client == null) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Public segment sharing is currently unavailable.'),
+        SnackBar(
+          content: Text(AppMessages.publicSharingUnavailable),
         ),
       );
       return;
@@ -645,8 +658,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
 
     if (!authController.isLoggedIn) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Please sign in to share segments publicly.'),
+        SnackBar(
+          content: Text(AppMessages.signInToShareSegment),
         ),
       );
       return;
@@ -655,8 +668,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
     final userId = authController.currentUserId;
     if (userId == null || userId.isEmpty) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Unable to determine the logged in account.'),
+        SnackBar(
+          content: Text(AppMessages.unableToDetermineLoggedInAccount),
         ),
       );
       return;
@@ -670,8 +683,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
       return;
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Failed to prepare the segment for public review.'),
+        SnackBar(
+          content: Text(AppMessages.failedToPrepareSegmentForReview),
         ),
       );
       return;
@@ -691,7 +704,7 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
         messenger.showSnackBar(
           SnackBar(
             content: Text(
-              'Segment ${segment.displayId} is already awaiting public review.',
+              AppMessages.segmentAlreadyAwaitingReview(segment.displayId),
             ),
           ),
         );
@@ -706,8 +719,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
       return;
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Failed to check the public submission status.'),
+        SnackBar(
+          content: Text(AppMessages.failedToCheckSubmissionStatus),
         ),
       );
       return;
@@ -724,8 +737,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
       return;
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Failed to submit the segment for moderation.'),
+        SnackBar(
+          content: Text(AppMessages.failedToSubmitForModeration),
         ),
       );
       return;
@@ -734,7 +747,7 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
     messenger.showSnackBar(
       SnackBar(
         content: Text(
-          'Segment ${segment.displayId} submitted for public review.',
+          AppMessages.segmentSubmittedForPublicReview(segment.displayId),
         ),
       ),
     );
@@ -782,8 +795,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
       auth = context.read<AuthController>();
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Unable to withdraw the public submission.'),
+        SnackBar(
+          content: Text(AppMessages.unableToWithdrawSubmission),
         ),
       );
       return false;
@@ -791,8 +804,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
 
     if (!auth.isLoggedIn || !auth.isConfigured) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Please sign in to withdraw the public submission.'),
+        SnackBar(
+          content: Text(AppMessages.signInToWithdrawSubmission),
         ),
       );
       return false;
@@ -802,8 +815,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
     final client = auth.client;
     if (userId == null || userId.isEmpty || client == null) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Unable to withdraw the public submission.'),
+        SnackBar(
+          content: Text(AppMessages.unableToWithdrawSubmission),
         ),
       );
       return false;
@@ -843,7 +856,7 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
           messenger.showSnackBar(
             SnackBar(
               content: Text(
-                'Segment ${segment.displayId} will no longer be reviewed for public release.',
+                AppMessages.segmentNoLongerUnderReview(segment.displayId),
               ),
             ),
           );
@@ -854,9 +867,9 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
     } on RemoteSegmentsServiceException catch (error) {
       if (error.cause is SocketException) {
         messenger.showSnackBar(
-          const SnackBar(
+          SnackBar(
             content: Text(
-              'No internet connection. The public submission cannot be withdrawn and the segment will only be deleted locally.',
+              AppMessages.noConnectionCannotWithdrawSubmission,
             ),
           ),
         );
@@ -867,8 +880,8 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
       return false;
     } catch (_) {
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Failed to cancel the public review for this segment.'),
+        SnackBar(
+          content: Text(AppMessages.failedToCancelPublicReview),
         ),
       );
       return false;
@@ -888,13 +901,15 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
 
       if (!deleted) {
         messenger.showSnackBar(
-          const SnackBar(content: Text('Failed to delete the segment.')),
+          SnackBar(content: Text(AppMessages.failedToDeleteSegment)),
         );
         return;
       }
 
       messenger.showSnackBar(
-        SnackBar(content: Text('Segment ${segment.displayId} deleted.')),
+        SnackBar(
+          content: Text(AppMessages.segmentDeleted(segment.displayId)),
+        ),
       );
       _segmentsUpdated = true;
       setState(() {
@@ -910,7 +925,7 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
         return;
       }
       messenger.showSnackBar(
-        const SnackBar(content: Text('Failed to delete the segment.')),
+        SnackBar(content: Text(AppMessages.failedToDeleteSegment)),
       );
     }
   }

--- a/lib/presentation/widgets/add_segment/segment_action_dialogs.dart
+++ b/lib/presentation/widgets/add_segment/segment_action_dialogs.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/services/auth_controller.dart';
 import 'package:toll_cam_finder/services/segments_repository.dart';
 
@@ -34,12 +35,14 @@ Future<SegmentAction?> showSegmentActionsSheet(
                 isDeactivated ? Icons.visibility : Icons.visibility_off,
               ),
               title: Text(
-                isDeactivated ? 'Show segment on map' : 'Hide segment on map',
+                isDeactivated
+                    ? AppMessages.showSegmentOnMapAction
+                    : AppMessages.hideSegmentOnMapAction,
               ),
               subtitle: Text(
                 isDeactivated
-                    ? 'Cameras and warnings for this segment will be restored.'
-                    : 'No cameras or warnings will appear for this segment.',
+                    ? AppMessages.segmentVisibilityRestoreSubtitle
+                    : AppMessages.segmentVisibilityDisableSubtitle,
               ),
               onTap: () => Navigator.of(context).pop(
                 isDeactivated
@@ -50,12 +53,14 @@ Future<SegmentAction?> showSegmentActionsSheet(
             if (segment.isLocalOnly && !segment.isMarkedPublic)
               ListTile(
                 leading: const Icon(Icons.public),
-                title: const Text('Share segment publicly'),
+                title: const Text(AppMessages.shareSegmentPubliclyAction),
                 subtitle: !isAuthConfigured
-                    ? const Text('Public sharing is not available.')
+                    ? const Text(AppMessages.publicSharingUnavailableShort)
                     : isLoggedIn
-                        ? const Text('Submit this segment for public review.')
-                        : const Text('Please sign in to share segments publicly.'),
+                        ? const Text(
+                            AppMessages.submitSegmentForPublicReviewSubtitle,
+                          )
+                        : const Text(AppMessages.signInToShareSegment),
                 enabled: canMakePublic && isLoggedIn,
                 onTap: canMakePublic && isLoggedIn
                     ? () => Navigator.of(context).pop(SegmentAction.makePublic)
@@ -63,10 +68,10 @@ Future<SegmentAction?> showSegmentActionsSheet(
               ),
             ListTile(
               leading: const Icon(Icons.delete_outline),
-              title: const Text('Delete segment'),
+              title: const Text(AppMessages.deleteSegmentAction),
               subtitle: canDelete
                   ? null
-                  : const Text('Only local segments can be deleted.'),
+                  : const Text(AppMessages.onlyLocalSegmentsCanBeDeleted),
               enabled: canDelete,
               onTap: canDelete
                   ? () => Navigator.of(context).pop(SegmentAction.delete)
@@ -87,18 +92,18 @@ Future<bool> showDeleteConfirmationDialog(
     context: context,
     builder: (context) {
       return AlertDialog(
-        title: const Text('Delete segment'),
+        title: const Text(AppMessages.deleteSegmentConfirmationTitle),
         content: Text(
-          'Are you sure you want to delete segment ${segment.displayId}?',
+          AppMessages.confirmDeleteSegment(segment.displayId),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
+            child: const Text(AppMessages.cancelAction),
           ),
           FilledButton(
             onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Delete'),
+            child: const Text(AppMessages.deleteAction),
           ),
         ],
       );
@@ -116,19 +121,16 @@ Future<bool> showCancelRemoteSubmissionDialog(
     context: context,
     builder: (context) {
       return AlertDialog(
-        title: const Text('Withdraw public submission?'),
-        content: const Text(
-          'You have submitted this segment for review. '
-          'Do you want to withdraw the submission?',
-        ),
+        title: const Text(AppMessages.withdrawPublicSubmissionTitle),
+        content: const Text(AppMessages.withdrawPublicSubmissionMessage),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('No'),
+            child: const Text(AppMessages.noAction),
           ),
           FilledButton(
             onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Yes'),
+            child: const Text(AppMessages.yesAction),
           ),
         ],
       );

--- a/lib/presentation/widgets/add_segment/segments_error_view.dart
+++ b/lib/presentation/widgets/add_segment/segments_error_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:toll_cam_finder/core/app_messages.dart';
 
 class SegmentsErrorView extends StatelessWidget {
   const SegmentsErrorView({
@@ -14,11 +15,11 @@ class SegmentsErrorView extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Text('Failed to load segments.'),
+          const Text(AppMessages.failedToLoadSegments),
           const SizedBox(height: 12),
           ElevatedButton(
             onPressed: onRetry,
-            child: const Text('Retry'),
+            child: const Text(AppMessages.retryAction),
           ),
         ],
       ),

--- a/lib/presentation/widgets/base_tile_layer.dart
+++ b/lib/presentation/widgets/base_tile_layer.dart
@@ -1,6 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -47,7 +48,7 @@ class BaseTileLayer extends StatelessWidget {
   static void _showLaunchError(BuildContext context) {
     ScaffoldMessenger.maybeOf(context)?.showSnackBar(
       const SnackBar(
-        content: Text('Could not open the OpenStreetMap copyright page.'),
+        content: Text(AppMessages.osmCopyrightLaunchFailed),
       ),
     );
   }

--- a/lib/presentation/widgets/segment_picker/map_hint_card.dart
+++ b/lib/presentation/widgets/segment_picker/map_hint_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 
 class MapHintCard extends StatelessWidget {
@@ -43,10 +44,10 @@ class MapHintCard extends StatelessWidget {
 
   String _buildMessage() {
     if (!hasStart && !hasEnd) {
-      return 'Tap anywhere on the map to place point A.';
+      return AppMessages.mapHintPlacePointA;
     } else if (hasStart && !hasEnd) {
-      return 'Tap a second location to place point B.';
+      return AppMessages.mapHintPlacePointB;
     }
-    return 'Touch and hold A or B for 0.5s, then drag to reposition that point.';
+    return AppMessages.mapHintDragPoint;
   }
 }

--- a/lib/services/auth_controller.dart
+++ b/lib/services/auth_controller.dart
@@ -2,6 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'dart:async';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../core/app_messages.dart';
+
 /// Simple wrapper around Supabase authentication that exposes the user state to
 /// the widget tree. Errors are surfaced via [AuthFailure] so the UI can display
 /// friendly messages without crashing the app.
@@ -41,9 +43,7 @@ class AuthController extends ChangeNotifier {
   /// Placeholder login flow. Replace with real implementation.
   Future<void> logIn({required String email, required String password}) async {
     if (_client == null) {
-      throw const AuthFailure(
-        'Authentication is not configured. Please add Supabase credentials.',
-      );
+      throw const AuthFailure(AppMessages.authenticationNotConfigured);
     }
 
     try {
@@ -64,7 +64,7 @@ class AuthController extends ChangeNotifier {
       throw AuthFailure(error.message);
     } catch (error, stackTrace) {
       debugPrint('Login failed: $error\n$stackTrace');
-      throw const AuthFailure('Unexpected error while signing in.');
+      throw const AuthFailure(AppMessages.unexpectedErrorSigningIn);
     }
   }
 
@@ -75,9 +75,7 @@ class AuthController extends ChangeNotifier {
     String? fullName,
   }) async {
     if (_client == null) {
-      throw const AuthFailure(
-        'Authentication is not configured. Please add Supabase credentials.',
-      );
+      throw const AuthFailure(AppMessages.authenticationNotConfigured);
     }
 
     try {
@@ -101,9 +99,7 @@ class AuthController extends ChangeNotifier {
       throw AuthFailure(error.message);
     } catch (error, stackTrace) {
       debugPrint('Sign-up failed: $error\n$stackTrace');
-      throw const AuthFailure(
-        'Unexpected error while creating the account.',
-      );
+      throw const AuthFailure(AppMessages.unexpectedErrorCreatingAccount);
     }
   }
 
@@ -120,7 +116,7 @@ class AuthController extends ChangeNotifier {
       throw AuthFailure(error.message);
     } catch (error, stackTrace) {
       debugPrint('Sign-out failed: $error\n$stackTrace');
-      throw const AuthFailure('Unexpected error while signing out.');
+      throw const AuthFailure(AppMessages.unexpectedErrorSigningOut);
     }
   }
 

--- a/lib/services/camera_utils.dart
+++ b/lib/services/camera_utils.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/services/toll_segments_file_system.dart';
 import 'package:toll_cam_finder/services/toll_segments_file_system_stub.dart'
@@ -54,7 +55,7 @@ class CameraUtils {
       _loading = false;
     } catch (e) {
       _loading = false;
-      _error = 'Failed to load cameras: $e';
+      _error = AppMessages.failedToLoadCameras('$e');
     }
   }
 
@@ -117,7 +118,7 @@ class CameraUtils {
     final endIdx = header.indexOf('end');
 
     if (startIdx == -1 || endIdx == -1) {
-      throw const FormatException('CSV must contain "Start" and "End" columns');
+      throw const FormatException(AppMessages.csvMissingStartEndColumns);
     }
 
     final pts = <LatLng>[];

--- a/lib/services/remote_segments_service.dart
+++ b/lib/services/remote_segments_service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../core/app_messages.dart';
 import 'local_segments_service.dart';
 
 /// Possible moderation statuses returned for a submitted segment.
@@ -36,13 +37,13 @@ class RemoteSegmentsService {
     final client = _client;
     if (client == null) {
       throw const RemoteSegmentsServiceException(
-        'Supabase is not configured. Unable to submit the segment for moderation.',
+        AppMessages.supabaseNotConfiguredForModeration,
       );
     }
 
     if (addedByUserId.trim().isEmpty) {
       throw const RemoteSegmentsServiceException(
-        'A logged in user is required to submit a public segment for moderation.',
+        AppMessages.userRequiredForPublicModeration,
       );
     }
 
@@ -62,17 +63,19 @@ class RemoteSegmentsService {
       });
     } on SocketException catch (error) {
       throw RemoteSegmentsServiceException(
-        'No internet connection. Unable to submit the segment for moderation.',
+        AppMessages.noConnectionUnableToSubmitForModeration,
         cause: error,
       );
     } on PostgrestException catch (error) {
       throw RemoteSegmentsServiceException(
-        'Failed to submit the segment for moderation: ${error.message}',
+        AppMessages.failedToSubmitSegmentForModerationWithReason(
+          error.message,
+        ),
         cause: error,
       );
     } catch (error, stackTrace) {
       throw RemoteSegmentsServiceException(
-        'Unexpected error while submitting the segment for moderation.',
+        AppMessages.unexpectedErrorSubmittingForModeration,
         cause: error,
         stackTrace: stackTrace,
       );
@@ -90,7 +93,7 @@ class RemoteSegmentsService {
     final client = _client;
     if (client == null) {
       throw const RemoteSegmentsServiceException(
-        'Supabase is not configured. Unable to manage public submissions.',
+        AppMessages.supabaseNotConfiguredForPublicSubmissions,
       );
     }
 
@@ -109,17 +112,17 @@ class RemoteSegmentsService {
       return rows.isNotEmpty;
     } on SocketException catch (error) {
       throw RemoteSegmentsServiceException(
-        'No internet connection. Unable to manage public submissions.',
+        AppMessages.noConnectionUnableToManageSubmissions,
         cause: error,
       );
     } on PostgrestException catch (error) {
       throw RemoteSegmentsServiceException(
-        'Failed to check the public submission status: ${error.message}',
+        AppMessages.failedToCheckSubmissionStatusWithReason(error.message),
         cause: error,
       );
     } catch (error, stackTrace) {
       throw RemoteSegmentsServiceException(
-        'Unexpected error while checking the public submission status.',
+        AppMessages.unexpectedErrorCheckingSubmissionStatus,
         cause: error,
         stackTrace: stackTrace,
       );
@@ -138,7 +141,7 @@ class RemoteSegmentsService {
     final client = _client;
     if (client == null) {
       throw const RemoteSegmentsServiceException(
-        'Supabase is not configured. Unable to manage public submissions.',
+        AppMessages.supabaseNotConfiguredForPublicSubmissions,
       );
     }
 
@@ -156,17 +159,17 @@ class RemoteSegmentsService {
       return deleted.isNotEmpty;
     } on SocketException catch (error) {
       throw RemoteSegmentsServiceException(
-        'No internet connection. Unable to manage public submissions.',
+        AppMessages.noConnectionUnableToManageSubmissions,
         cause: error,
       );
     } on PostgrestException catch (error) {
       throw RemoteSegmentsServiceException(
-        'Failed to cancel the public submission: ${error.message}',
+        AppMessages.failedToCancelSubmissionWithReason(error.message),
         cause: error,
       );
     } catch (error, stackTrace) {
       throw RemoteSegmentsServiceException(
-        'Unexpected error while cancelling the public submission.',
+        AppMessages.unexpectedErrorCancellingSubmission,
         cause: error,
         stackTrace: stackTrace,
       );
@@ -183,7 +186,7 @@ class RemoteSegmentsService {
     final client = _client;
     if (client == null) {
       throw const RemoteSegmentsServiceException(
-        'Supabase is not configured. Unable to manage public submissions.',
+        AppMessages.supabaseNotConfiguredForPublicSubmissions,
       );
     }
 
@@ -217,17 +220,17 @@ class RemoteSegmentsService {
       return SegmentSubmissionStatus.other;
     } on SocketException catch (error) {
       throw RemoteSegmentsServiceException(
-        'No internet connection. Unable to manage public submissions.',
+        AppMessages.noConnectionUnableToManageSubmissions,
         cause: error,
       );
     } on PostgrestException catch (error) {
       throw RemoteSegmentsServiceException(
-        'Failed to check the public submission status: ${error.message}',
+        AppMessages.failedToCheckSubmissionStatusWithReason(error.message),
         cause: error,
       );
     } catch (error, stackTrace) {
       throw RemoteSegmentsServiceException(
-        'Unexpected error while checking the public submission status.',
+        AppMessages.unexpectedErrorCheckingSubmissionStatus,
         cause: error,
         stackTrace: stackTrace,
       );
@@ -249,7 +252,7 @@ class RemoteSegmentsService {
 
     if (nextId > _smallIntMax) {
       throw const RemoteSegmentsServiceException(
-        'Unable to assign a new segment id: all smallint values are exhausted.',
+        AppMessages.unableToAssignNewSegmentId,
       );
     }
 
@@ -277,7 +280,7 @@ class RemoteSegmentsService {
     }
 
     throw const RemoteSegmentsServiceException(
-      'Encountered an existing segment with a non-numeric id.',
+      AppMessages.nonNumericSegmentIdEncountered,
     );
   }
 }

--- a/lib/services/segments_metadata_service.dart
+++ b/lib/services/segments_metadata_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/services/toll_segments_file_system.dart';
 import 'package:toll_cam_finder/services/toll_segments_file_system_stub.dart'
     if (dart.library.io) 'package:toll_cam_finder/services/toll_segments_file_system_io.dart'
@@ -134,7 +135,7 @@ class SegmentsMetadataService {
     } on TollSegmentsFileSystemException catch (error, stackTrace) {
       Error.throwWithStackTrace(
         SegmentsMetadataException(
-          'Failed to access the segments metadata file.',
+          AppMessages.failedToAccessSegmentsMetadataFile,
           cause: error,
         ),
         stackTrace,
@@ -142,7 +143,7 @@ class SegmentsMetadataService {
     } on FormatException catch (error, stackTrace) {
       Error.throwWithStackTrace(
         SegmentsMetadataException(
-          'Failed to parse the segments metadata file.',
+          AppMessages.failedToParseSegmentsMetadataFile,
           cause: error,
         ),
         stackTrace,
@@ -153,7 +154,7 @@ class SegmentsMetadataService {
   Future<void> updatePublicFlag(String id, bool isPublic) async {
     if (kIsWeb) {
       throw const SegmentsMetadataException(
-        'Segment metadata cannot be updated on the web.',
+        AppMessages.segmentMetadataUpdateUnavailable,
       );
     }
 
@@ -165,7 +166,7 @@ class SegmentsMetadataService {
   Future<void> setSegmentDeactivated(String id, bool isDeactivated) async {
     if (kIsWeb) {
       throw const SegmentsMetadataException(
-        'Segment metadata cannot be updated on the web.',
+        AppMessages.segmentMetadataUpdateUnavailable,
       );
     }
 
@@ -200,7 +201,7 @@ class SegmentsMetadataService {
     } on TollSegmentsFileSystemException catch (error, stackTrace) {
       Error.throwWithStackTrace(
         SegmentsMetadataException(
-          'Failed to write to the segments metadata file.',
+          AppMessages.failedToWriteSegmentsMetadataFile,
           cause: error,
         ),
         stackTrace,


### PR DESCRIPTION
## Summary
- add a documented `AppMessages` class that centralizes user-visible strings and builders
- refactor UI pages and widgets to consume the shared messages for snackbars, dialogs, and validation
- update service-layer exceptions to reuse the centralized messaging helpers

## Testing
- not run (flutter not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68e29930098c832d8b29aa07bc08a6d5