### PR TITLE
Update segments UI to surface identifiers and speed limits

### DIFF
--- a/lib/presentation/widgets/add_segment/segment_card.dart
+++ b/lib/presentation/widgets/add_segment/segment_card.dart
@@ -12,6 +12,8 @@ class SegmentCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final hasBadges = segment.isLocalOnly || segment.isDeactivated;
+    final speedLimit = segment.speedLimitKph?.trim();
+    final hasSpeedLimit = speedLimit != null && speedLimit.isNotEmpty;
     return Card(
       child: InkWell(
         onLongPress: onLongPress,
@@ -22,12 +24,14 @@ class SegmentCard extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Expanded(
                     child: Text(
-                      segment.name,
-                      style: theme.textTheme.titleMedium,
+                      segment.displayId,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                   ),
                   if (hasBadges) ...[
@@ -36,19 +40,36 @@ class SegmentCard extends StatelessWidget {
                   ],
                 ],
               ),
+              const SizedBox(height: 8),
+              Text(
+                segment.name,
+                style: theme.textTheme.titleMedium,
+              ),
               const SizedBox(height: 16),
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Expanded(
-                    child: _SegmentLocation(value: segment.startDisplayName),
+                    child: _SegmentLocation(
+                      title: 'Start',
+                      value: segment.startDisplayName,
+                      fallback: segment.startCoordinates,
+                    ),
                   ),
                   const SizedBox(width: 16),
                   Expanded(
-                    child: _SegmentLocation(value: segment.endDisplayName),
+                    child: _SegmentLocation(
+                      title: 'End',
+                      value: segment.endDisplayName,
+                      fallback: segment.endCoordinates,
+                    ),
                   ),
                 ],
               ),
+              if (hasSpeedLimit) ...[
+                const SizedBox(height: 16),
+                _SegmentSpeed(speedLimit: speedLimit!),
+              ],
             ],
           ),
         ),
@@ -151,23 +172,65 @@ class _SegmentBadges extends StatelessWidget {
 }
 
 class _SegmentLocation extends StatelessWidget {
-  const _SegmentLocation({required this.value});
+  const _SegmentLocation({
+    required this.title,
+    required this.value,
+    required this.fallback,
+  });
 
+  final String title;
   final String value;
+  final String fallback;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final trimmedValue = value.trim();
+    final trimmedFallback = fallback.trim();
+    final displayValue = trimmedValue.isNotEmpty
+        ? trimmedValue
+        : (trimmedFallback.isNotEmpty ? trimmedFallback : '—');
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          trimmedValue.isEmpty ? '—' : trimmedValue,
-          style: theme.textTheme.bodyMedium,
+          title,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.primary,
+            fontWeight: FontWeight.w600,
+          ),
         ),
         const SizedBox(height: 4),
-        Text(value, style: theme.textTheme.bodyMedium),
+        Text(
+          displayValue,
+          style: theme.textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+}
+
+class _SegmentSpeed extends StatelessWidget {
+  const _SegmentSpeed({required this.speedLimit});
+
+  final String speedLimit;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          Icons.speed,
+          size: 16,
+          color: theme.colorScheme.primary,
+        ),
+        const SizedBox(width: 8),
+        Text(
+          'Max speed: $speedLimit km/h',
+          style: theme.textTheme.bodyMedium,
+        ),
       ],
     );
   }

--- a/lib/services/segments_repository.dart
+++ b/lib/services/segments_repository.dart
@@ -18,6 +18,7 @@ class SegmentInfo {
     required this.endDisplayName,
     required this.startCoordinates,
     required this.endCoordinates,
+    this.speedLimitKph,
     this.isLocalOnly = false,
     this.isMarkedPublic = false,
     this.isDeactivated = false,
@@ -29,6 +30,7 @@ class SegmentInfo {
   final String endDisplayName;
   final String startCoordinates;
   final String endCoordinates;
+  final String? speedLimitKph;
   final bool isLocalOnly;
   final bool isMarkedPublic;
   final bool isDeactivated;
@@ -92,6 +94,7 @@ class SegmentsRepository {
     final startCoordinatesIndex = header.indexOf('start');
     final endNameIndex = header.indexOf('end name');
     final endCoordinatesIndex = header.indexOf('end');
+    final speedLimitIndex = header.indexOf('speed_limit_kph');
 
     if (idIndex == -1 ||
         nameIndex == -1 ||
@@ -128,6 +131,7 @@ class SegmentsRepository {
       final endDisplayName = _stringAt(row, endNameIndex);
       final startCoordinates = _stringAt(row, startCoordinatesIndex);
       final endCoordinates = _stringAt(row, endCoordinatesIndex);
+      final speedLimit = _stringAt(row, speedLimitIndex);
 
       if (id.isEmpty &&
           name.isEmpty &&
@@ -153,6 +157,7 @@ class SegmentsRepository {
           endDisplayName: endDisplayName,
           startCoordinates: startCoordinates,
           endCoordinates: endCoordinates,
+          speedLimitKph: speedLimit.isEmpty ? null : speedLimit,
           isLocalOnly: isLocalOnly,
           isMarkedPublic: publicFlags[id] ?? false,
           isDeactivated: deactivatedSegments.contains(id),


### PR DESCRIPTION
## Summary
- display the segment identifier at the top of each segment card and keep existing status badges
- emphasise the start and end names with clearer labels and fallbacks to coordinates
- surface the maximum speed limit when provided by extending the SegmentInfo model to read it from CSV data

## Testing
- Not run (Flutter tooling is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e2a01c6054832dbe377dfaa9f996af