### PR TITLE
Add language selection drawer entry

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:provider/provider.dart';
+
+import '../services/language_controller.dart';
 import 'app_routes.dart';
 import 'app_theme.dart';
 
@@ -7,12 +11,23 @@ class TollCamApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'TollCam',
-      theme: buildAppTheme(),
-      initialRoute: AppRoutes.map,
-      routes: AppRoutes.routes,
-      debugShowCheckedModeBanner: false,
+    return Consumer<LanguageController>(
+      builder: (context, languageController, _) {
+        return MaterialApp(
+          title: 'TollCam',
+          theme: buildAppTheme(),
+          initialRoute: AppRoutes.map,
+          routes: AppRoutes.routes,
+          debugShowCheckedModeBanner: false,
+          locale: languageController.locale,
+          supportedLocales: languageController.supportedLocales,
+          localizationsDelegates: const [
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:toll_cam_finder/services/average_speed_est.dart';
 
 import 'app/app.dart';
 import 'services/auth_controller.dart';
+import 'services/language_controller.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -32,7 +33,10 @@ void main() async {
         ),
         ChangeNotifierProvider(
           create: (_) => AuthController(client: supabaseClient),
-                  ),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => LanguageController(),
+        ),
       ],
       child: const TollCamApp(),
     ),

--- a/lib/presentation/pages/map_page.dart
+++ b/lib/presentation/pages/map_page.dart
@@ -22,6 +22,7 @@ import 'package:toll_cam_finder/services/toll_segments_sync_service.dart';
 
 import '../../app/app_routes.dart';
 import '../../services/auth_controller.dart';
+import '../../services/language_controller.dart';
 import '../../services/location_service.dart';
 import '../../services/permission_service.dart';
 import 'map/blue_dot_animator.dart';
@@ -527,6 +528,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
   }
 
   Drawer _buildOptionsDrawer() {
+    final languageController = context.watch<LanguageController>();
     return Drawer(
       child: SafeArea(
         child: ListView(
@@ -551,6 +553,12 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
               onTap: _onSegmentsSelected,
             ),
             ListTile(
+              leading: const Icon(Icons.language),
+              title: const Text('Language'),
+              subtitle: Text(languageController.currentOption.label),
+              onTap: _onLanguageSelected,
+            ),
+            ListTile(
               leading: const Icon(Icons.person_outline),
               title: const Text('Profile'),
               onTap: () {
@@ -565,6 +573,50 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
         ),
       ),
     );
+  }
+
+  void _onLanguageSelected() {
+    Navigator.of(context).pop();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      showModalBottomSheet<void>(
+        context: context,
+        builder: (sheetContext) {
+          return SafeArea(
+            child: Consumer<LanguageController>(
+              builder: (context, controller, _) {
+                final options = controller.languageOptions;
+                return ListView(
+                  shrinkWrap: true,
+                  children: [
+                    const ListTile(
+                      title: Text('Select language'),
+                    ),
+                    for (final option in options)
+                      ListTile(
+                        title: Text(option.label),
+                        trailing: option.locale == controller.locale
+                            ? const Icon(Icons.check)
+                            : null,
+                        enabled: option.available,
+                        subtitle: option.available
+                            ? null
+                            : const Text('Coming soon'),
+                        onTap: option.available
+                            ? () {
+                                controller.setLocale(option.locale);
+                                Navigator.of(sheetContext).pop();
+                              }
+                            : null,
+                      ),
+                  ],
+                );
+              },
+            ),
+          );
+        },
+      );
+    });
   }
 
   void _onProfileSelected() {

--- a/lib/services/language_controller.dart
+++ b/lib/services/language_controller.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+class LanguageOption {
+  const LanguageOption({
+    required this.locale,
+    required this.label,
+    this.available = true,
+  });
+
+  final Locale locale;
+  final String label;
+  final bool available;
+}
+
+class LanguageController extends ChangeNotifier {
+  LanguageController();
+
+  static const List<LanguageOption> _languageOptions = [
+    LanguageOption(
+      locale: Locale('en'),
+      label: 'English',
+      available: true,
+    ),
+    LanguageOption(
+      locale: Locale('es'),
+      label: 'Español',
+      available: false,
+    ),
+  ];
+
+  Locale _locale = const Locale('en');
+
+  Locale get locale => _locale;
+
+  List<LanguageOption> get languageOptions => _languageOptions;
+
+  List<Locale> get supportedLocales => _languageOptions
+      .where((option) => option.available)
+      .map((option) => option.locale)
+      .toList();
+
+  LanguageOption get currentOption => _languageOptions.firstWhere(
+        (option) => option.locale == _locale,
+        orElse: () => _languageOptions.first,
+      );
+
+  void setLocale(Locale locale) {
+    if (_locale == locale) {
+      return;
+    }
+    final isSupported = _languageOptions.any(
+      (option) => option.available && option.locale == locale,
+    );
+    if (!isSupported) {
+      return;
+    }
+
+    _locale = locale;
+    notifyListeners();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_map: ^8.2.1
   flutter_compass: ^0.8.1
   geolocator: ^14.0.2


### PR DESCRIPTION
## Summary
- add a language controller and provider to manage the current locale
- wire the MaterialApp to the language controller and expose language selection from the options drawer with a placeholder for the next language
- include flutter_localizations to prepare for future translations

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2a148aa80832d8834bb3734330dfc