### PR TITLE
Expand localization coverage across the app

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../services/language_controller.dart';
 import 'app_routes.dart';
 import 'app_theme.dart';
+import 'localization/app_localizations.dart';
 
 class TollCamApp extends StatelessWidget {
   const TollCamApp({super.key});
@@ -13,8 +14,9 @@ class TollCamApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<LanguageController>(
       builder: (context, languageController, _) {
+        final appLocalizations = AppLocalizations(languageController.locale);
         return MaterialApp(
-          title: 'TollCam',
+          title: appLocalizations.appTitle,
           theme: buildAppTheme(),
           initialRoute: AppRoutes.map,
           routes: AppRoutes.routes,
@@ -25,6 +27,7 @@ class TollCamApp extends StatelessWidget {
             GlobalMaterialLocalizations.delegate,
             GlobalWidgetsLocalizations.delegate,
             GlobalCupertinoLocalizations.delegate,
+            AppLocalizationsDelegate(),
           ],
         );
       },

--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -1,0 +1,391 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+class AppLocalizations {
+  AppLocalizations(this.locale);
+
+  final Locale locale;
+
+  static const supportedLanguageCodes = ['en', 'es'];
+
+  static const Map<String, Map<String, String>> _localizedStrings = {
+    'en': {
+      'accountCreatedCheckEmail': 'Account created! Check your email to confirm it.',
+      'appTitle': 'TollCam',
+      'authenticationNotConfigured':
+          'Authentication is not configured. Please add Supabase credentials.',
+      'averageSpeedResetTooltip': 'Reset Avg',
+      'averageSpeedStartTooltip': 'Start Avg',
+      'cancelAction': 'Cancel',
+      'chooseSegmentVisibilityQuestion':
+          'Do you want the segment to be publically visible?',
+      'comingSoon': 'Coming soon',
+      'confirmDeleteSegment':
+          'Are you sure you want to delete segment {displayId}?',
+      'confirmKeepSegmentPrivate':
+          'Are you sure that you want to keep the segment only to yourself?',
+      'confirmMakeSegmentPublic': 'Are you sure you want to make this segment public?',
+      'confirmPasswordLabel': 'Confirm password',
+      'confirmYourPassword': 'Please confirm your password',
+      'continue': 'Continue',
+      'createAccount': 'Create account',
+      'createAccountCta': 'Create an account',
+      'createAccountDescription': 'Already have an account? Log in',
+      'createNewAccount': 'Create a new account',
+      'createPasswordPrompt': 'Please create a password',
+      'createSegment': 'Create segment',
+      'csvMissingStartEndColumns': 'CSV must contain "Start" and "End" columns',
+      'deleteAction': 'Delete',
+      'deleteSegmentAction': 'Delete segment',
+      'deleteSegmentConfirmationTitle': 'Delete segment',
+      'emailLabel': 'Email',
+      'enterYourEmail': 'Please enter your email',
+      'enterYourName': 'Please enter your name',
+      'enterYourPassword': 'Please enter your password',
+      'failedToAccessSegmentsMetadataFile':
+          'Failed to access the segments metadata file.',
+      'failedToAccessTollSegmentsFile':
+          'Failed to access the toll segments file: {reason}',
+      'failedToCancelPublicReview':
+          'Failed to cancel the public review for this segment.',
+      'failedToCancelSubmissionWithReason':
+          'Failed to cancel the public submission: {reason}',
+      'failedToCheckSubmissionStatus':
+          'Failed to check the public submission status.',
+      'failedToCheckSubmissionStatusWithReason':
+          'Failed to check the public submission status: {reason}',
+      'failedToDeleteSegment': 'Failed to delete the segment.',
+      'failedToDetermineTollSegmentsPath':
+          'Failed to determine the local toll segments storage path.',
+      'failedToDownloadTollSegments':
+          'Failed to download toll segments: {reason}',
+      'failedToLoadCameras': 'Failed to load cameras: {error}',
+      'failedToLoadSegmentPreferences':
+          'Failed to load segment preferences: {errorMessage}',
+      'failedToLoadSegments': 'Failed to load segments.',
+      'failedToParseSegmentsMetadataFile':
+          'Failed to parse the segments metadata file.',
+      'failedToPrepareSegmentForReview':
+          'Failed to prepare the segment for public review.',
+      'failedToSaveSegmentLocally': 'Failed to save the segment locally.',
+      'failedToSubmitForModeration':
+          'Failed to submit the segment for moderation.',
+      'failedToSubmitSegmentForModerationWithReason':
+          'Failed to submit the segment for moderation: {reason}',
+      'failedToUpdateSegment':
+          'Failed to update segment {displayId}: {errorMessage}',
+      'failedToWriteSegmentsMetadataFile':
+          'Failed to write to the segments metadata file.',
+      'fullNameLabel': 'Full name',
+      'hideSegmentOnMapAction': 'Hide segment on map',
+      'joinTollCam': 'Join TollCam',
+      'language': 'Language',
+      'languageButton': 'Change language',
+      'localSegments': 'Local segments',
+      'logIn': 'Log in',
+      'logOut': 'Log out',
+      'loggedInRetrySavePrompt':
+          'Logged in successfully. Tap "Save segment" again to submit the segment.',
+      'loginAction': 'Login',
+      'mapHintDragPoint':
+          'Touch and hold A or B for 0.5s, then drag to reposition that point.',
+      'mapHintPlacePointA': 'Tap anywhere on the map to place point A.',
+      'mapHintPlacePointB': 'Tap a second location to place point B.',
+      'missingRequiredColumn':
+          'Missing required column "{column}" in the Toll_Segments table.',
+      'noAction': 'No',
+      'noConnectionCannotWithdrawSubmission':
+          'No internet connection. The public submission cannot be withdrawn and the segment will only be deleted locally.',
+      'noConnectionUnableToManageSubmissions':
+          'No internet connection. Unable to manage public submissions.',
+      'noConnectionUnableToSubmitForModeration':
+          'No internet connection. Unable to submit the segment for moderation.',
+      'noLocalSegments': 'No local segments saved yet.',
+      'noSegmentsAvailable': 'No segments available.',
+      'noTollSegmentRowsFound':
+          'No toll segment rows were returned from Supabase. Checked tables: {tablesChecked}. Ensure your account has access to the data.',
+      'nonNumericSegmentIdEncountered':
+          'Encountered an existing segment with a non-numeric id.',
+      'onlyLocalSegmentsCanBeDeleted': 'Only local segments can be deleted.',
+      'openMenu': 'Open menu',
+      'osmCopyrightLaunchFailed':
+          'Could not open the OpenStreetMap copyright page.',
+      'passwordLabel': 'Password',
+      'passwordTooShort': 'Password must be at least 6 characters',
+      'passwordsDoNotMatch': 'Passwords do not match',
+      'profile': 'Profile',
+      'profileSubtitle': 'Manage your TollCam account and preferences.',
+      'publicSharingUnavailable':
+          'Public segment sharing is currently unavailable.',
+      'publicSharingUnavailableShort': 'Public sharing is not available.',
+      'recenter': 'Recenter',
+      'retryAction': 'Retry',
+      'saveLocallyAction': 'Save locally',
+      'saveSegment': 'Save segment',
+      'segmentAlreadyAwaitingReview':
+          'Segment {displayId} is already awaiting public review.',
+      'segmentDebugDistanceKilometersLeft': '{distance} km left',
+      'segmentDebugDistanceMeters': '{distance} m',
+      'segmentDebugHeadingDiff': 'Δθ={angle}°',
+      'segmentDebugTagApprox': 'approx',
+      'segmentDebugTagDetailed': 'detailed',
+      'segmentDebugTagDirectionFail': 'dir✖',
+      'segmentDebugTagDirectionPass': 'dir✔',
+      'segmentDebugTagEnd': 'end',
+      'segmentDebugTagSeparator': ' · ',
+      'segmentDebugTagStart': 'start',
+      'segmentDeleted': 'Segment {displayId} deleted.',
+      'segmentHidden':
+          'Segment {displayId} hidden. Cameras and warnings are disabled.',
+      'segmentMetadataUpdateUnavailable':
+          'Segment metadata cannot be updated on the web.',
+      'segmentNoLongerUnderReview':
+          'Segment {displayId} will no longer be reviewed for public release.',
+      'segmentProgressEndKilometers': '{distance} km to segment end',
+      'segmentProgressEndMeters': '{distance} m to segment end',
+      'segmentProgressEndNearby': 'Segment end nearby',
+      'segmentProgressStartKilometers': '{distance} km to segment start',
+      'segmentProgressStartMeters': '{distance} m to segment start',
+      'segmentProgressStartNearby': 'Segment start nearby',
+      'segmentSavedLocally': 'Segment saved locally.',
+      'segmentSubmittedForPublicReview':
+          'Segment {displayId} submitted for public review.',
+      'segmentSubmittedForPublicReviewGeneric': 'Segment submitted for public review.',
+      'segmentVisibilityDisableSubtitle':
+          'No cameras or warnings will appear for this segment.',
+      'segmentVisibilityRestoreSubtitle':
+          'Cameras and warnings for this segment will be restored.',
+      'segmentVisible':
+          'Segment {displayId} is visible again. Cameras and warnings restored.',
+      'segments': 'Segments',
+      'selectLanguage': 'Select language',
+      'shareSegmentPubliclyAction': 'Share segment publicly',
+      'showSegmentOnMapAction': 'Show segment on map',
+      'signInToSharePubliclyBody':
+          'You need to be logged in to submit a public segment. Would you like to log in or save the segment locally instead?',
+      'signInToSharePubliclyTitle': 'Sign in to share publicly',
+      'signInToShareSegment': 'Please sign in to share segments publicly.',
+      'signInToWithdrawSubmission': 'Please sign in to withdraw the public submission.',
+      'somethingWentWrongTryAgain': 'Something went wrong. Please try again.',
+      'speedDialAverageTitle': 'Avg Speed',
+      'speedDialCurrentTitle': 'Speed',
+      'speedDialDebugSummary': 'Segments: {count}  r={radius}{unit}',
+      'speedDialLastSegmentAverage':
+          'Avg speed for the last segment: {value}{unit}',
+      'speedDialLimitLabel': 'Limit: {value} {unit}',
+      'speedDialNoActiveSegment': 'No active segment',
+      'speedDialUnitKmh': 'km/h',
+      'syncAddedMany': '{count} segments added',
+      'syncAddedOne': '{count} segment added',
+      'syncApprovedSummaryPlural':
+          '{count} of your submitted segments were approved and are now visible to everyone.',
+      'syncApprovedSummarySingular':
+          '{count} of your submitted segments was approved and is now visible to everyone.',
+      'syncCompleteIntro': 'Sync complete.',
+      'syncNoChangesDetected': 'No changes detected.',
+      'syncRemovedMany': '{count} segments removed',
+      'syncRemovedOne': '{count} segment removed',
+      'syncTotalSegmentsSummary': '{count} total segments available.',
+      'startEndCoordinatesRequired': 'Start and end coordinates are required.',
+      'submitSegmentForPublicReviewSubtitle':
+          'Submit this segment for public review.',
+      'supabaseNotConfiguredForModeration':
+          'Supabase is not configured. Unable to submit the segment for moderation.',
+      'supabaseNotConfiguredForPublicSubmissions':
+          'Supabase is not configured. Unable to manage public submissions.',
+      'supabaseNotConfiguredForSync':
+          'Supabase is not configured. Please add credentials to enable sync.',
+      'sync': 'Sync',
+      'syncNotSupportedOnWeb': 'Syncing toll segments is not supported on the web.',
+      'tableMissingModerationColumn':
+          'The "{tableName}" table is missing the "{column}" column required for moderation.',
+      'tableReturnedNoRows':
+          'The {tableName} table did not return any rows.',
+      'unableToAssignNewSegmentId':
+          'Unable to assign a new segment id: all smallint values are exhausted.',
+      'unableToDetermineLoggedInAccount':
+          'Unable to determine the logged in account.',
+      'unableToDetermineLoggedInAccountRetry':
+          'Unable to determine the logged in account. Please sign in again.',
+      'unableToLogOutTryAgain': 'Unable to log out. Please try again.',
+      'unableToWithdrawSubmission': 'Unable to withdraw the public submission.',
+      'unexpectedErrorCancellingSubmission':
+          'Unexpected error while cancelling the public submission.',
+      'unexpectedErrorCheckingSubmissionStatus':
+          'Unexpected error while checking the public submission status.',
+      'unexpectedErrorCreatingAccount':
+          'Unexpected error while creating the account.',
+      'unexpectedErrorSigningIn': 'Unexpected error while signing in.',
+      'unexpectedErrorSigningOut': 'Unexpected error while signing out.',
+      'unexpectedErrorSubmittingForModeration':
+          'Unexpected error while submitting the segment for moderation.',
+      'unexpectedSyncError': 'Unexpected error while syncing toll segments.',
+      'unitKilometersShort': 'km',
+      'unitMetersShort': 'm',
+      'unknownUserLabel': 'Unknown user',
+      'userRequiredForPublicModeration':
+          'A logged in user is required to submit a public segment for moderation.',
+      'welcomeTitle': 'Welcome',
+      'withdrawPublicSubmissionMessage':
+          'You have submitted this segment for review. Do you want to withdraw the submission?',
+      'withdrawPublicSubmissionTitle': 'Withdraw public submission?',
+      'yesAction': 'Yes',
+      'yourProfile': 'Your profile',
+    },
+    'es': {
+      'appTitle': 'TollCam',
+      'averageSpeedResetTooltip': 'Reiniciar promedio',
+      'averageSpeedStartTooltip': 'Iniciar promedio',
+      'comingSoon': 'Próximamente',
+      'confirmPasswordLabel': 'Confirmar contraseña',
+      'continue': 'Continuar',
+      'createAccount': 'Crear cuenta',
+      'createAccountCta': 'Crear una cuenta',
+      'createAccountDescription': '¿Ya tienes una cuenta? Inicia sesión',
+      'createNewAccount': 'Crear una cuenta nueva',
+      'createSegment': 'Crear segmento',
+      'emailLabel': 'Correo electrónico',
+      'fullNameLabel': 'Nombre completo',
+      'joinTollCam': 'Únete a TollCam',
+      'language': 'Idioma',
+      'languageButton': 'Cambiar idioma',
+      'localSegments': 'Segmentos locales',
+      'logIn': 'Iniciar sesión',
+      'logOut': 'Cerrar sesión',
+      'noLocalSegments': 'Aún no hay segmentos locales guardados.',
+      'noSegmentsAvailable': 'No hay segmentos disponibles.',
+      'openMenu': 'Abrir menú',
+      'passwordLabel': 'Contraseña',
+      'profile': 'Perfil',
+      'profileSubtitle': 'Administra tu cuenta y preferencias de TollCam.',
+      'recenter': 'Recentrar',
+      'saveSegment': 'Guardar segmento',
+      'segmentDebugDistanceKilometersLeft': '{distance} km restantes',
+      'segmentDebugDistanceMeters': '{distance} m',
+      'segmentDebugHeadingDiff': 'Δθ={angle}°',
+      'segmentDebugTagApprox': 'aprox',
+      'segmentDebugTagDetailed': 'detallado',
+      'segmentDebugTagDirectionFail': 'dir✖',
+      'segmentDebugTagDirectionPass': 'dir✔',
+      'segmentDebugTagEnd': 'fin',
+      'segmentDebugTagSeparator': ' · ',
+      'segmentDebugTagStart': 'inicio',
+      'segmentProgressEndKilometers':
+          '{distance} km hasta el final del segmento',
+      'segmentProgressEndMeters': '{distance} m hasta el final del segmento',
+      'segmentProgressEndNearby': 'Final del segmento cercano',
+      'segmentProgressStartKilometers':
+          '{distance} km hasta el inicio del segmento',
+      'segmentProgressStartMeters': '{distance} m hasta el inicio del segmento',
+      'segmentProgressStartNearby': 'Inicio del segmento cercano',
+      'segments': 'Segmentos',
+      'selectLanguage': 'Seleccionar idioma',
+      'speedDialAverageTitle': 'Velocidad promedio',
+      'speedDialCurrentTitle': 'Velocidad',
+      'speedDialDebugSummary': 'Segmentos: {count}  r={radius}{unit}',
+      'speedDialLastSegmentAverage':
+          'Velocidad promedio del último segmento: {value}{unit}',
+      'speedDialLimitLabel': 'Límite: {value} {unit}',
+      'speedDialNoActiveSegment': 'Sin segmento activo',
+      'speedDialUnitKmh': 'km/h',
+      'syncAddedMany': '{count} segmentos añadidos',
+      'syncAddedOne': '{count} segmento añadido',
+      'syncApprovedSummaryPlural':
+          '{count} de tus segmentos enviados fueron aprobados y ahora son visibles para todos.',
+      'syncApprovedSummarySingular':
+          '{count} de tus segmentos enviados fue aprobado y ahora es visible para todos.',
+      'syncCompleteIntro': 'Sincronización completa.',
+      'syncNoChangesDetected': 'No se detectaron cambios.',
+      'syncRemovedMany': '{count} segmentos eliminados',
+      'syncRemovedOne': '{count} segmento eliminado',
+      'syncTotalSegmentsSummary': '{count} segmentos totales disponibles.',
+      'sync': 'Sincronizar',
+      'unitKilometersShort': 'km',
+      'unitMetersShort': 'm',
+      'unknownUserLabel': 'Usuario desconocido',
+      'welcomeTitle': 'Bienvenido',
+      'yourProfile': 'Tu perfil',
+    },
+  };
+
+  static List<Locale> get supportedLocales =>
+      supportedLanguageCodes.map((code) => Locale(code)).toList(growable: false);
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  String _value(String key) {
+    return _localizedStrings[locale.languageCode]?[key] ??
+        _localizedStrings['en']![key]!;
+  }
+
+  String translate(String key, [Map<String, String>? replacements]) {
+    var value = _value(key);
+    if (replacements != null) {
+      replacements.forEach((placeholder, replacement) {
+        value = value.replaceAll('{$placeholder}', replacement);
+      });
+    }
+    return value;
+  }
+
+  String get appTitle => _value('appTitle');
+  String get sync => _value('sync');
+  String get segments => _value('segments');
+  String get language => _value('language');
+  String get profile => _value('profile');
+  String get selectLanguage => _value('selectLanguage');
+  String get comingSoon => _value('comingSoon');
+  String get openMenu => _value('openMenu');
+  String get logIn => _value('logIn');
+  String get createAccount => _value('createAccount');
+  String get createAccountCta => _value('createAccountCta');
+  String get createAccountDescription => _value('createAccountDescription');
+  String get continueLabel => _value('continue');
+  String get createNewAccount => _value('createNewAccount');
+  String get yourProfile => _value('yourProfile');
+  String get logOut => _value('logOut');
+  String get localSegments => _value('localSegments');
+  String get createSegmentLabel => _value('createSegment');
+  String get saveSegmentLabel => _value('saveSegment');
+  String get noSegmentsAvailable => _value('noSegmentsAvailable');
+  String get noLocalSegments => _value('noLocalSegments');
+  String get recenter => _value('recenter');
+  String get languageButton => _value('languageButton');
+  String get welcomeTitle => _value('welcomeTitle');
+  String get joinTollCam => _value('joinTollCam');
+  String get emailLabel => _value('emailLabel');
+  String get passwordLabel => _value('passwordLabel');
+  String get confirmPasswordLabel => _value('confirmPasswordLabel');
+  String get fullNameLabel => _value('fullNameLabel');
+  String get profileSubtitle => _value('profileSubtitle');
+  String get unknownUserLabel => _value('unknownUserLabel');
+  String get averageSpeedStartTooltip => _value('averageSpeedStartTooltip');
+  String get averageSpeedResetTooltip => _value('averageSpeedResetTooltip');
+  String get speedDialCurrentTitle => _value('speedDialCurrentTitle');
+  String get speedDialAverageTitle => _value('speedDialAverageTitle');
+  String get speedDialUnitKmh => _value('speedDialUnitKmh');
+  String get speedDialNoActiveSegment => _value('speedDialNoActiveSegment');
+}
+
+class AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) {
+    return AppLocalizations.supportedLanguageCodes
+        .contains(locale.languageCode);
+  }
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(AppLocalizations(locale));
+  }
+
+  @override
+  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) {
+    return false;
+  }
+}

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -1,446 +1,262 @@
-/// Collection of user-facing strings displayed throughout the app.
-///
-/// Keeping messages together near [AppConstants] simplifies translation and
-/// ensures copy updates remain consistent across the UI.
+import 'dart:ui';
+
+import '../app/localization/app_localizations.dart';
+
 class AppMessages {
-  /// Shown after returning from the segment creation flow when a draft has
-  /// been saved to local storage instead of being published immediately.
-  static const String segmentSavedLocally = 'Segment saved locally.';
+  AppMessages._();
 
-  /// Label shown when offering to reveal a segment that was previously hidden
-  /// on the map.
-  static const String showSegmentOnMapAction = 'Show segment on map';
+  static Locale _locale = const Locale('en');
+  static AppLocalizations _localizations = AppLocalizations(_locale);
 
-  /// Label shown when offering to hide a segment from the map.
-  static const String hideSegmentOnMapAction = 'Hide segment on map';
+  static void updateLocale(Locale locale) {
+    if (_locale == locale) return;
+    _locale = locale;
+    _localizations = AppLocalizations(locale);
+  }
 
-  /// Subtitle explaining that restoring a segment will re-enable cameras and
-  /// warnings for it.
-  static const String segmentVisibilityRestoreSubtitle =
-      'Cameras and warnings for this segment will be restored.';
+  static AppLocalizations get _l => _localizations;
 
-  /// Subtitle explaining that hiding a segment will disable cameras and
-  /// warnings for it.
-  static const String segmentVisibilityDisableSubtitle =
-      'No cameras or warnings will appear for this segment.';
-
-  /// Shown after the user hides a segment; confirms the display id is now
-  /// hidden and that related warnings are disabled.
+  static String get segmentSavedLocally =>
+      _l.translate('segmentSavedLocally');
+  static String get showSegmentOnMapAction =>
+      _l.translate('showSegmentOnMapAction');
+  static String get hideSegmentOnMapAction =>
+      _l.translate('hideSegmentOnMapAction');
+  static String get segmentVisibilityRestoreSubtitle =>
+      _l.translate('segmentVisibilityRestoreSubtitle');
+  static String get segmentVisibilityDisableSubtitle =>
+      _l.translate('segmentVisibilityDisableSubtitle');
   static String segmentHidden(String displayId) =>
-      'Segment $displayId hidden. Cameras and warnings are disabled.';
-
-  /// Shown after the user reactivates a segment; confirms visibility and
-  /// warnings have been restored.
+      _l.translate('segmentHidden', {'displayId': displayId});
   static String segmentVisible(String displayId) =>
-      'Segment $displayId is visible again. Cameras and warnings restored.';
-
-  /// Shown when updating a segment's metadata fails and the error message
-  /// should be surfaced to the user.
+      _l.translate('segmentVisible', {'displayId': displayId});
   static String failedToUpdateSegment(
     String displayId,
     String errorMessage,
   ) =>
-      'Failed to update segment $displayId: $errorMessage';
-
-  /// Shown when the user attempts to share a segment publicly without a valid
-  /// authenticated session.
-  static const String signInToShareSegment =
-      'Please sign in to share segments publicly.';
-
-  /// Label for the bottom sheet option that begins the public sharing flow for
-  /// a segment.
-  static const String shareSegmentPubliclyAction = 'Share segment publicly';
-
-  /// Shown when the remote sharing infrastructure is not available, preventing
-  /// the submission of public segments.
-  static const String publicSharingUnavailable =
-      'Public segment sharing is currently unavailable.';
-
-  /// Short subtitle explaining that public sharing is currently unavailable in
-  /// contexts where space is limited.
-  static const String publicSharingUnavailableShort =
-      'Public sharing is not available.';
-
-  /// Subtitle informing the user that choosing to share publicly will submit
-  /// the segment for moderation.
-  static const String submitSegmentForPublicReviewSubtitle =
-      'Submit this segment for public review.';
-
-  /// Shown when the app cannot determine the logged in user during a public
-  /// submission flow.
-  static const String unableToDetermineLoggedInAccount =
-      'Unable to determine the logged in account.';
-
-  /// Shown when loading local draft data fails while preparing a public
-  /// submission.
-  static const String failedToPrepareSegmentForReview =
-      'Failed to prepare the segment for public review.';
-
-  /// Shown when checking the public submission status fails with a generic
-  /// error.
-  static const String failedToCheckSubmissionStatus =
-      'Failed to check the public submission status.';
-
-  /// Shown when submitting a segment for moderation fails unexpectedly.
-  static const String failedToSubmitForModeration =
-      'Failed to submit the segment for moderation.';
-
-  /// Shown when a segment has already been submitted for public review by the
-  /// same user and is awaiting moderation.
+      _l.translate('failedToUpdateSegment', {
+        'displayId': displayId,
+        'errorMessage': errorMessage,
+      });
+  static String get signInToShareSegment =>
+      _l.translate('signInToShareSegment');
+  static String get shareSegmentPubliclyAction =>
+      _l.translate('shareSegmentPubliclyAction');
+  static String get publicSharingUnavailable =>
+      _l.translate('publicSharingUnavailable');
+  static String get publicSharingUnavailableShort =>
+      _l.translate('publicSharingUnavailableShort');
+  static String get submitSegmentForPublicReviewSubtitle =>
+      _l.translate('submitSegmentForPublicReviewSubtitle');
+  static String get unableToDetermineLoggedInAccount =>
+      _l.translate('unableToDetermineLoggedInAccount');
+  static String get failedToPrepareSegmentForReview =>
+      _l.translate('failedToPrepareSegmentForReview');
+  static String get failedToCheckSubmissionStatus =>
+      _l.translate('failedToCheckSubmissionStatus');
+  static String get failedToSubmitForModeration =>
+      _l.translate('failedToSubmitForModeration');
   static String segmentAlreadyAwaitingReview(String displayId) =>
-      'Segment $displayId is already awaiting public review.';
-
-  /// Shown when a segment is successfully submitted for public review and the
-  /// segment id should be echoed back to the user.
+      _l.translate('segmentAlreadyAwaitingReview', {'displayId': displayId});
   static String segmentSubmittedForPublicReview(String displayId) =>
-      'Segment $displayId submitted for public review.';
-
-  /// Shown when a segment is successfully submitted for public review but no
-  /// display id is available (e.g. immediately after draft creation).
-  static const String segmentSubmittedForPublicReviewGeneric =
-      'Segment submitted for public review.';
-
-  /// Shown when the app cannot withdraw a public submission due to missing
-  /// authentication state.
-  static const String unableToWithdrawSubmission =
-      'Unable to withdraw the public submission.';
-
-  /// Shown when the user must sign in before they can withdraw a public
-  /// submission.
-  static const String signInToWithdrawSubmission =
-      'Please sign in to withdraw the public submission.';
-
-  /// Shown when a public submission has been successfully cancelled and the
-  /// review process will no longer continue.
+      _l.translate('segmentSubmittedForPublicReview', {'displayId': displayId});
+  static String get segmentSubmittedForPublicReviewGeneric =>
+      _l.translate('segmentSubmittedForPublicReviewGeneric');
+  static String get unableToWithdrawSubmission =>
+      _l.translate('unableToWithdrawSubmission');
+  static String get signInToWithdrawSubmission =>
+      _l.translate('signInToWithdrawSubmission');
   static String segmentNoLongerUnderReview(String displayId) =>
-      'Segment $displayId will no longer be reviewed for public release.';
-
-  /// Shown when withdrawing a public submission fails due to a missing internet
-  /// connection; informs the user that only the local delete will proceed.
-  static const String noConnectionCannotWithdrawSubmission =
-      'No internet connection. The public submission cannot be withdrawn and the segment will only be deleted locally.';
-
-  /// Shown when the app fails to cancel an in-progress public review request.
-  static const String failedToCancelPublicReview =
-      'Failed to cancel the public review for this segment.';
-
-  /// Shown when deleting a segment fails for any reason.
-  static const String failedToDeleteSegment =
-      'Failed to delete the segment.';
-
-  /// Label for the delete option in segment action sheets and dialogs.
-  static const String deleteSegmentAction = 'Delete segment';
-
-  /// Subtitle explaining why a segment cannot currently be deleted.
-  static const String onlyLocalSegmentsCanBeDeleted =
-      'Only local segments can be deleted.';
-
-  /// Shown after a segment has been deleted from the local store.
+      _l.translate('segmentNoLongerUnderReview', {'displayId': displayId});
+  static String get noConnectionCannotWithdrawSubmission =>
+      _l.translate('noConnectionCannotWithdrawSubmission');
+  static String get failedToCancelPublicReview =>
+      _l.translate('failedToCancelPublicReview');
+  static String get failedToDeleteSegment =>
+      _l.translate('failedToDeleteSegment');
+  static String get deleteSegmentAction =>
+      _l.translate('deleteSegmentAction');
+  static String get onlyLocalSegmentsCanBeDeleted =>
+      _l.translate('onlyLocalSegmentsCanBeDeleted');
   static String segmentDeleted(String displayId) =>
-      'Segment $displayId deleted.';
-
-  /// Title shown when confirming whether a segment should be deleted.
-  static const String deleteSegmentConfirmationTitle = 'Delete segment';
-
-  /// Message shown when asking the user to confirm segment deletion.
+      _l.translate('segmentDeleted', {'displayId': displayId});
+  static String get deleteSegmentConfirmationTitle =>
+      _l.translate('deleteSegmentConfirmationTitle');
   static String confirmDeleteSegment(String displayId) =>
-      'Are you sure you want to delete segment $displayId?';
-
-  /// Shown when the app cannot determine the logged in account and suggests
-  /// signing in again.
-  static const String unableToDetermineLoggedInAccountRetry =
-      'Unable to determine the logged in account. Please sign in again.';
-
-  /// Shown when prompting the user to choose if a new segment should be visible
-  /// publicly after creation.
-  static const String chooseSegmentVisibilityQuestion =
-      'Do you want the segment to be publically visible?';
-
-  /// Shown when asking the user to confirm keeping a segment private.
-  static const String confirmKeepSegmentPrivate =
-      'Are you sure that you want to keep the segment only to yourself?';
-
-  /// Shown when asking the user to confirm making a segment public.
-  static const String confirmMakeSegmentPublic =
-      'Are you sure you want to make this segment public?';
-
-  /// Title used when asking the user to withdraw a public submission.
-  static const String withdrawPublicSubmissionTitle =
-      'Withdraw public submission?';
-
-  /// Message shown when confirming if the user wants to withdraw a submission.
-  static const String withdrawPublicSubmissionMessage =
-      'You have submitted this segment for review. Do you want to withdraw the submission?';
-
-  /// Generic fallback error shown when an operation fails unexpectedly.
-  static const String somethingWentWrongTryAgain =
-      'Something went wrong. Please try again.';
-
-  /// Shown after a new account is created to prompt email confirmation.
-  static const String accountCreatedCheckEmail =
-      'Account created! Check your email to confirm it.';
-
-  /// Shown when logging out fails unexpectedly.
-  static const String unableToLogOutTryAgain =
-      'Unable to log out. Please try again.';
-
-  /// Shown when authentication services have not been configured.
-  static const String authenticationNotConfigured =
-      'Authentication is not configured. Please add Supabase credentials.';
-
-  /// Shown when sign-in fails due to an unexpected platform error.
-  static const String unexpectedErrorSigningIn =
-      'Unexpected error while signing in.';
-
-  /// Shown when account creation fails due to an unexpected platform error.
-  static const String unexpectedErrorCreatingAccount =
-      'Unexpected error while creating the account.';
-
-  /// Shown when sign-out fails due to an unexpected platform error.
-  static const String unexpectedErrorSigningOut =
-      'Unexpected error while signing out.';
-
-  /// Validation message shown when the name field is left empty.
-  static const String enterYourName = 'Please enter your name';
-
-  /// Validation message shown when the email field is left empty.
-  static const String enterYourEmail = 'Please enter your email';
-
-  /// Validation message shown when the password field is left empty.
-  static const String enterYourPassword = 'Please enter your password';
-
-  /// Validation message shown when the password confirmation is missing.
-  static const String confirmYourPassword = 'Please confirm your password';
-
-  /// Validation message shown when creating a new password requires input.
-  static const String createPasswordPrompt = 'Please create a password';
-
-  /// Validation message shown when the password is shorter than the minimum.
-  static const String passwordTooShort =
-      'Password must be at least 6 characters';
-
-  /// Validation message shown when the password and confirmation do not match.
-  static const String passwordsDoNotMatch = 'Passwords do not match';
-
-  /// Message displayed when loading segments fails in list views.
-  static const String failedToLoadSegments = 'Failed to load segments.';
-
-  /// Generic retry button label used across error surfaces.
-  static const String retryAction = 'Retry';
-
-  /// Generic affirmative button label.
-  static const String yesAction = 'Yes';
-
-  /// Generic negative button label.
-  static const String noAction = 'No';
-
-  /// Generic cancel action label.
-  static const String cancelAction = 'Cancel';
-
-  /// Generic delete action label.
-  static const String deleteAction = 'Delete';
-
-  /// Hint shown before either endpoint has been positioned on the map.
-  static const String mapHintPlacePointA =
-      'Tap anywhere on the map to place point A.';
-
-  /// Hint shown after the start point has been placed but not the end point.
-  static const String mapHintPlacePointB =
-      'Tap a second location to place point B.';
-
-  /// Hint shown once both endpoints exist, explaining how to reposition them.
-  static const String mapHintDragPoint =
-      'Touch and hold A or B for 0.5s, then drag to reposition that point.';
-
-  /// Message shown when loading camera data fails.
+      _l.translate('confirmDeleteSegment', {'displayId': displayId});
+  static String get unableToDetermineLoggedInAccountRetry =>
+      _l.translate('unableToDetermineLoggedInAccountRetry');
+  static String get chooseSegmentVisibilityQuestion =>
+      _l.translate('chooseSegmentVisibilityQuestion');
+  static String get confirmKeepSegmentPrivate =>
+      _l.translate('confirmKeepSegmentPrivate');
+  static String get confirmMakeSegmentPublic =>
+      _l.translate('confirmMakeSegmentPublic');
+  static String get withdrawPublicSubmissionTitle =>
+      _l.translate('withdrawPublicSubmissionTitle');
+  static String get withdrawPublicSubmissionMessage =>
+      _l.translate('withdrawPublicSubmissionMessage');
+  static String get somethingWentWrongTryAgain =>
+      _l.translate('somethingWentWrongTryAgain');
+  static String get accountCreatedCheckEmail =>
+      _l.translate('accountCreatedCheckEmail');
+  static String get unableToLogOutTryAgain =>
+      _l.translate('unableToLogOutTryAgain');
+  static String get authenticationNotConfigured =>
+      _l.translate('authenticationNotConfigured');
+  static String get unexpectedErrorSigningIn =>
+      _l.translate('unexpectedErrorSigningIn');
+  static String get unexpectedErrorCreatingAccount =>
+      _l.translate('unexpectedErrorCreatingAccount');
+  static String get unexpectedErrorSigningOut =>
+      _l.translate('unexpectedErrorSigningOut');
+  static String get enterYourName => _l.translate('enterYourName');
+  static String get enterYourEmail => _l.translate('enterYourEmail');
+  static String get enterYourPassword => _l.translate('enterYourPassword');
+  static String get confirmYourPassword =>
+      _l.translate('confirmYourPassword');
+  static String get createPasswordPrompt =>
+      _l.translate('createPasswordPrompt');
+  static String get passwordTooShort => _l.translate('passwordTooShort');
+  static String get passwordsDoNotMatch =>
+      _l.translate('passwordsDoNotMatch');
+  static String get failedToLoadSegments =>
+      _l.translate('failedToLoadSegments');
+  static String get retryAction => _l.translate('retryAction');
+  static String get yesAction => _l.translate('yesAction');
+  static String get noAction => _l.translate('noAction');
+  static String get cancelAction => _l.translate('cancelAction');
+  static String get deleteAction => _l.translate('deleteAction');
+  static String get mapHintPlacePointA =>
+      _l.translate('mapHintPlacePointA');
+  static String get mapHintPlacePointB =>
+      _l.translate('mapHintPlacePointB');
+  static String get mapHintDragPoint => _l.translate('mapHintDragPoint');
   static String failedToLoadCameras(String error) =>
-      'Failed to load cameras: $error';
-
-  /// Message shown when the app cannot access the segments metadata file.
-  static const String failedToAccessSegmentsMetadataFile =
-      'Failed to access the segments metadata file.';
-
-  /// Message shown when the segments metadata file cannot be parsed.
-  static const String failedToParseSegmentsMetadataFile =
-      'Failed to parse the segments metadata file.';
-
-  /// Message shown when the segments metadata file cannot be written.
-  static const String failedToWriteSegmentsMetadataFile =
-      'Failed to write to the segments metadata file.';
-
-  /// Message shown when submitting a segment for moderation fails.
+      _l.translate('failedToLoadCameras', {'error': error});
+  static String get failedToAccessSegmentsMetadataFile =>
+      _l.translate('failedToAccessSegmentsMetadataFile');
+  static String get failedToParseSegmentsMetadataFile =>
+      _l.translate('failedToParseSegmentsMetadataFile');
+  static String get failedToWriteSegmentsMetadataFile =>
+      _l.translate('failedToWriteSegmentsMetadataFile');
   static String failedToSubmitSegmentForModerationWithReason(String reason) =>
-      'Failed to submit the segment for moderation: $reason';
-
-  /// Message shown when checking the submission status fails.
+      _l.translate('failedToSubmitSegmentForModerationWithReason',
+          {'reason': reason});
   static String failedToCheckSubmissionStatusWithReason(String reason) =>
-      'Failed to check the public submission status: $reason';
-
-  /// Message shown when cancelling a submission fails.
+      _l.translate(
+        'failedToCheckSubmissionStatusWithReason',
+        {'reason': reason},
+      );
   static String failedToCancelSubmissionWithReason(String reason) =>
-      'Failed to cancel the public submission: $reason';
-
-  /// Message shown when downloading toll segments fails.
+      _l.translate('failedToCancelSubmissionWithReason', {'reason': reason});
   static String failedToDownloadTollSegments(String reason) =>
-      'Failed to download toll segments: $reason';
-
-  /// Message shown when accessing the local toll segments file fails.
+      _l.translate('failedToDownloadTollSegments', {'reason': reason});
   static String failedToAccessTollSegmentsFile(String reason) =>
-      'Failed to access the toll segments file: $reason';
-
-  /// Message shown when the local storage path for toll segments cannot be
-  /// determined.
-  static const String failedToDetermineTollSegmentsPath =
-      'Failed to determine the local toll segments storage path.';
-
-  /// Message shown when attempting to edit metadata on unsupported platforms.
-  static const String segmentMetadataUpdateUnavailable =
-      'Segment metadata cannot be updated on the web.';
-
-  /// Message shown when Supabase is not configured for moderation submissions.
-  static const String supabaseNotConfiguredForModeration =
-      'Supabase is not configured. Unable to submit the segment for moderation.';
-
-  /// Message shown when Supabase is not configured for managing public submissions.
-  static const String supabaseNotConfiguredForPublicSubmissions =
-      'Supabase is not configured. Unable to manage public submissions.';
-
-  /// Message shown when a logged-in user is required to submit a segment.
-  static const String userRequiredForPublicModeration =
-      'A logged in user is required to submit a public segment for moderation.';
-
-  /// Message shown when there is no internet connection for moderation actions.
-  static const String noConnectionUnableToSubmitForModeration =
-      'No internet connection. Unable to submit the segment for moderation.';
-
-  /// Message shown when there is no internet connection for managing submissions.
-  static const String noConnectionUnableToManageSubmissions =
-      'No internet connection. Unable to manage public submissions.';
-
-  /// Message shown when an unexpected error occurs while submitting a segment.
-  static const String unexpectedErrorSubmittingForModeration =
-      'Unexpected error while submitting the segment for moderation.';
-
-  /// Message shown when an unexpected error occurs while checking submission status.
-  static const String unexpectedErrorCheckingSubmissionStatus =
-      'Unexpected error while checking the public submission status.';
-
-  /// Message shown when an unexpected error occurs while cancelling a submission.
-  static const String unexpectedErrorCancellingSubmission =
-      'Unexpected error while cancelling the public submission.';
-
-  /// Message shown when there are no more available segment ids.
-  static const String unableToAssignNewSegmentId =
-      'Unable to assign a new segment id: all smallint values are exhausted.';
-
-  /// Message shown when a non-numeric segment id is encountered.
-  static const String nonNumericSegmentIdEncountered =
-      'Encountered an existing segment with a non-numeric id.';
-
-  /// Message shown when sync is not supported on the current platform.
-  static const String syncNotSupportedOnWeb =
-      'Syncing toll segments is not supported on the web.';
-
-  /// Message shown when the remote table returns no rows.
+      _l.translate('failedToAccessTollSegmentsFile', {'reason': reason});
+  static String get failedToDetermineTollSegmentsPath =>
+      _l.translate('failedToDetermineTollSegmentsPath');
+  static String get segmentMetadataUpdateUnavailable =>
+      _l.translate('segmentMetadataUpdateUnavailable');
+  static String get supabaseNotConfiguredForModeration =>
+      _l.translate('supabaseNotConfiguredForModeration');
+  static String get supabaseNotConfiguredForPublicSubmissions =>
+      _l.translate('supabaseNotConfiguredForPublicSubmissions');
+  static String get userRequiredForPublicModeration =>
+      _l.translate('userRequiredForPublicModeration');
+  static String get noConnectionUnableToSubmitForModeration =>
+      _l.translate('noConnectionUnableToSubmitForModeration');
+  static String get noConnectionUnableToManageSubmissions =>
+      _l.translate('noConnectionUnableToManageSubmissions');
+  static String get unexpectedErrorSubmittingForModeration =>
+      _l.translate('unexpectedErrorSubmittingForModeration');
+  static String get unexpectedErrorCheckingSubmissionStatus =>
+      _l.translate('unexpectedErrorCheckingSubmissionStatus');
+  static String get unexpectedErrorCancellingSubmission =>
+      _l.translate('unexpectedErrorCancellingSubmission');
+  static String get unableToAssignNewSegmentId =>
+      _l.translate('unableToAssignNewSegmentId');
+  static String get nonNumericSegmentIdEncountered =>
+      _l.translate('nonNumericSegmentIdEncountered');
+  static String get syncNotSupportedOnWeb =>
+      _l.translate('syncNotSupportedOnWeb');
   static String tableReturnedNoRows(String tableName) =>
-      'The $tableName table did not return any rows.';
-
-  /// Message shown when none of the candidate tables returned any rows.
+      _l.translate('tableReturnedNoRows', {'tableName': tableName});
   static String noTollSegmentRowsFound(String tablesChecked) =>
-      'No toll segment rows were returned from Supabase. Checked tables: '
-      '$tablesChecked. Ensure your account has access to the data.';
-
-  /// Message shown when a required moderation column is missing.
-  static String tableMissingModerationColumn(String tableName, String column) =>
-      'The "$tableName" table is missing the "$column" column required for moderation.';
-
-  /// Message shown when the local CSV is missing required start/end columns.
-  static const String csvMissingStartEndColumns =
-      'CSV must contain "Start" and "End" columns';
-
-  /// Message shown when an expected column is absent in the remote table.
+      _l.translate(
+        'noTollSegmentRowsFound',
+        {'tablesChecked': tablesChecked},
+      );
+  static String tableMissingModerationColumn(
+    String tableName,
+    String column,
+  ) =>
+      _l.translate('tableMissingModerationColumn', {
+        'tableName': tableName,
+        'column': column,
+      });
+  static String get csvMissingStartEndColumns =>
+      _l.translate('csvMissingStartEndColumns');
   static String missingRequiredColumn(String column) =>
-      'Missing required column "$column" in the Toll_Segments table.';
-
-  /// Title for the dialog prompting the user to sign in before sharing a
-  /// segment publicly.
-  static const String signInToSharePubliclyTitle =
-      'Sign in to share publicly';
-
-  /// Body copy shown when the user must sign in before sharing publicly and is
-  /// given the option to save locally instead.
-  static const String signInToSharePubliclyBody =
-      'You need to be logged in to submit a public segment. Would you like to log in or save the segment locally instead?';
-
-  /// Label for dialog actions that save a draft locally instead of logging in.
-  static const String saveLocallyAction = 'Save locally';
-
-  /// Label for dialog actions that initiate the login flow.
-  static const String loginAction = 'Login';
-
-  /// Shown when saving a draft locally fails unexpectedly.
-  static const String failedToSaveSegmentLocally =
-      'Failed to save the segment locally.';
-
-  /// Shown when the draft form is missing required coordinate values.
-  static const String startEndCoordinatesRequired =
-      'Start and end coordinates are required.';
-
-  /// Shown after a successful login when the user is returned to the draft
-  /// flow and needs to press the save button again to continue submission.
-  static const String loggedInRetrySavePrompt =
-      'Logged in successfully. Tap "Save segment" again to submit the segment.';
-
-  /// Shown when launching the OpenStreetMap copyright page fails.
-  static const String osmCopyrightLaunchFailed =
-      'Could not open the OpenStreetMap copyright page.';
-
-  /// Shown when the app fails to load the persisted segment metadata
-  /// preferences and falls back to defaults.
+      _l.translate('missingRequiredColumn', {'column': column});
+  static String get signInToSharePubliclyTitle =>
+      _l.translate('signInToSharePubliclyTitle');
+  static String get signInToSharePubliclyBody =>
+      _l.translate('signInToSharePubliclyBody');
+  static String get saveLocallyAction => _l.translate('saveLocallyAction');
+  static String get loginAction => _l.translate('loginAction');
+  static String get failedToSaveSegmentLocally =>
+      _l.translate('failedToSaveSegmentLocally');
+  static String get startEndCoordinatesRequired =>
+      _l.translate('startEndCoordinatesRequired');
+  static String get loggedInRetrySavePrompt =>
+      _l.translate('loggedInRetrySavePrompt');
+  static String get osmCopyrightLaunchFailed =>
+      _l.translate('osmCopyrightLaunchFailed');
   static String failedToLoadSegmentPreferences(String errorMessage) =>
-      'Failed to load segment preferences: $errorMessage';
+      _l.translate(
+        'failedToLoadSegmentPreferences',
+        {'errorMessage': errorMessage},
+      );
+  static String get supabaseNotConfiguredForSync =>
+      _l.translate('supabaseNotConfiguredForSync');
+  static String get unexpectedSyncError =>
+      _l.translate('unexpectedSyncError');
 
-  /// Shown when Supabase credentials are missing and online sync cannot start.
-  static const String supabaseNotConfiguredForSync =
-      'Supabase is not configured. Please add credentials to enable sync.';
-
-  /// Shown when an unexpected error occurs during the toll segment sync flow.
-  static const String unexpectedSyncError =
-      'Unexpected error while syncing toll segments.';
-
-  /// Builds the sync completion summary shown after the toll segments database
-  /// has been refreshed.
   static String syncCompleteSummary({
     required int addedSegments,
     required int removedSegments,
     required int totalSegments,
     required int approvedLocalSegments,
   }) {
+    final l = _l;
     final parts = <String>[];
     if (addedSegments > 0) {
-      final label = addedSegments == 1 ? 'segment' : 'segments';
-      parts.add('$addedSegments $label added');
+      final key = addedSegments == 1 ? 'syncAddedOne' : 'syncAddedMany';
+      parts.add(l.translate(key, {'count': '$addedSegments'}));
     }
     if (removedSegments > 0) {
-      final label = removedSegments == 1 ? 'segment' : 'segments';
-      parts.add('$removedSegments $label removed');
+      final key = removedSegments == 1 ? 'syncRemovedOne' : 'syncRemovedMany';
+      parts.add(l.translate(key, {'count': '$removedSegments'}));
     }
 
     final changesSummary = parts.isEmpty
-        ? 'No changes detected.'
+        ? l.translate('syncNoChangesDetected')
         : parts.join(', ') + '.';
-    final buffer = StringBuffer(
-      'Sync complete. $changesSummary $totalSegments total segments available.',
-    );
+    final buffer = StringBuffer()
+      ..write(l.translate('syncCompleteIntro') + ' ')
+      ..write(changesSummary + ' ')
+      ..write(l.translate('syncTotalSegmentsSummary', {
+        'count': '$totalSegments',
+      }));
 
     if (approvedLocalSegments > 0) {
-      final verb = approvedLocalSegments == 1 ? 'was' : 'were';
-      final visibilityVerb = approvedLocalSegments == 1 ? 'is' : 'are';
+      final key = approvedLocalSegments == 1
+          ? 'syncApprovedSummarySingular'
+          : 'syncApprovedSummaryPlural';
+      buffer.write(' ');
       buffer.write(
-        ' $approvedLocalSegments of your submitted segments ',
-      );
-      buffer.write(
-        '$verb approved and now $visibilityVerb visible to everyone.',
+        l.translate(key, {'count': '$approvedLocalSegments'}),
       );
     }
 

--- a/lib/presentation/pages/auth/login_page.dart
+++ b/lib/presentation/pages/auth/login_page.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:toll_cam_finder/core/app_messages.dart';
 
 import '../../../app/app_routes.dart';
+import '../../../app/localization/app_localizations.dart';
 import '../../../services/auth_controller.dart';
 
 class LoginPage extends StatefulWidget {
@@ -72,7 +73,7 @@ class _LoginPageState extends State<LoginPage> {
       debugPrint('Login error: $error\n$stackTrace');
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
+        SnackBar(
           content: Text(AppMessages.somethingWentWrongTryAgain),
         ),
       );
@@ -87,9 +88,10 @@ class _LoginPageState extends State<LoginPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Log in'),
+        title: Text(l10n.logIn),
       ),
       body: SafeArea(
         child: SingleChildScrollView(
@@ -101,7 +103,7 @@ class _LoginPageState extends State<LoginPage> {
               children: [
                 const SizedBox(height: 32),
                 Text(
-                  'Welcome',
+                  l10n.welcomeTitle,
                   style: Theme.of(context).textTheme.headlineSmall,
                   textAlign: TextAlign.center,
                 ),
@@ -109,9 +111,9 @@ class _LoginPageState extends State<LoginPage> {
                 TextFormField(
                   controller: _emailController,
                   keyboardType: TextInputType.emailAddress,
-                  decoration: const InputDecoration(
-                    labelText: 'Email',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText: l10n.emailLabel,
+                    border: const OutlineInputBorder(),
                   ),
                   validator: (value) {
                     if (value == null || value.trim().isEmpty) {
@@ -124,9 +126,9 @@ class _LoginPageState extends State<LoginPage> {
                 TextFormField(
                   controller: _passwordController,
                   obscureText: true,
-                  decoration: const InputDecoration(
-                    labelText: 'Password',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText: l10n.passwordLabel,
+                    border: const OutlineInputBorder(),
                   ),
                   validator: (value) {
                     if (value == null || value.isEmpty) {
@@ -144,14 +146,14 @@ class _LoginPageState extends State<LoginPage> {
                           width: 20,
                           child: CircularProgressIndicator(strokeWidth: 2),
                         )
-                      : const Text('Continue'),
+                      : Text(l10n.continueLabel),
                 ),
                 const SizedBox(height: 16),
                 TextButton(
                   onPressed: () {
                     Navigator.of(context).pushReplacementNamed(AppRoutes.signUp);
                   },
-                  child: const Text('Create a new account'),
+                  child: Text(l10n.createNewAccount),
                 ),
               ],
             ),

--- a/lib/presentation/pages/auth/profile_page.dart
+++ b/lib/presentation/pages/auth/profile_page.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:toll_cam_finder/core/app_messages.dart';
 
 import '../../../app/app_routes.dart';
+import '../../../app/localization/app_localizations.dart';
 import '../../../services/auth_controller.dart';
 
 class ProfilePage extends StatelessWidget {
@@ -12,11 +13,13 @@ class ProfilePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final auth = context.watch<AuthController>();
-    final email = auth.currentEmail ?? 'Unknown user';
+    final email = auth.currentEmail ??
+        AppLocalizations.of(context).unknownUserLabel;
 
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Your profile'),
+        title: Text(l10n.yourProfile),
       ),
       body: SafeArea(
         child: Padding(
@@ -36,7 +39,7 @@ class ProfilePage extends StatelessWidget {
               ),
               const SizedBox(height: 8),
               Text(
-                'Manage your TollCam account and preferences.',
+                l10n.profileSubtitle,
                 style: Theme.of(context).textTheme.bodyMedium,
                 textAlign: TextAlign.center,
               ),
@@ -56,13 +59,13 @@ class ProfilePage extends StatelessWidget {
                   } catch (error, stackTrace) {
                     debugPrint('Logout error: $error\n$stackTrace');
                     messenger.showSnackBar(
-                      const SnackBar(
+                      SnackBar(
                         content: Text(AppMessages.unableToLogOutTryAgain),
                       ),
                     );
                   }
                 },
-                child: const Text('Log out'),
+                child: Text(l10n.logOut),
               ),
             ],
           ),

--- a/lib/presentation/pages/auth/sign_up_page.dart
+++ b/lib/presentation/pages/auth/sign_up_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:toll_cam_finder/core/app_messages.dart';
 
 import '../../../app/app_routes.dart';
+import '../../../app/localization/app_localizations.dart';
 import '../../../services/auth_controller.dart';
 
 class SignUpPage extends StatefulWidget {
@@ -48,7 +49,7 @@ class _SignUpPageState extends State<SignUpPage> {
       if (!mounted) return;
       Navigator.of(context).pushReplacementNamed(AppRoutes.login);
       messenger.showSnackBar(
-        const SnackBar(
+        SnackBar(
           content: Text(AppMessages.accountCreatedCheckEmail),
         ),
       );
@@ -61,7 +62,7 @@ class _SignUpPageState extends State<SignUpPage> {
       debugPrint('Sign up error: $error\n$stackTrace');
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
+        SnackBar(
           content: Text(AppMessages.somethingWentWrongTryAgain),
         ),
       );
@@ -76,8 +77,9 @@ class _SignUpPageState extends State<SignUpPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Create account')),
+      appBar: AppBar(title: Text(l10n.createAccount)),
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(24),
@@ -88,7 +90,7 @@ class _SignUpPageState extends State<SignUpPage> {
               children: [
                 const SizedBox(height: 32),
                 Text(
-                  'Join TollCam',
+                  l10n.joinTollCam,
                   style: Theme.of(context).textTheme.headlineSmall,
                   textAlign: TextAlign.center,
                 ),
@@ -96,9 +98,9 @@ class _SignUpPageState extends State<SignUpPage> {
                 TextFormField(
                   controller: _nameController,
                   textCapitalization: TextCapitalization.words,
-                  decoration: const InputDecoration(
-                    labelText: 'Full name',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText: l10n.fullNameLabel,
+                    border: const OutlineInputBorder(),
                   ),
                   validator: (value) {
                     if (value == null || value.trim().isEmpty) {
@@ -111,9 +113,9 @@ class _SignUpPageState extends State<SignUpPage> {
                 TextFormField(
                   controller: _emailController,
                   keyboardType: TextInputType.emailAddress,
-                  decoration: const InputDecoration(
-                    labelText: 'Email',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText: l10n.emailLabel,
+                    border: const OutlineInputBorder(),
                   ),
                   validator: (value) {
                     if (value == null || value.trim().isEmpty) {
@@ -126,9 +128,9 @@ class _SignUpPageState extends State<SignUpPage> {
                 TextFormField(
                   controller: _passwordController,
                   obscureText: true,
-                  decoration: const InputDecoration(
-                    labelText: 'Password',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText: l10n.passwordLabel,
+                    border: const OutlineInputBorder(),
                   ),
                   validator: (value) {
                     if (value == null || value.isEmpty) {
@@ -144,9 +146,9 @@ class _SignUpPageState extends State<SignUpPage> {
                 TextFormField(
                   controller: _confirmPasswordController,
                   obscureText: true,
-                  decoration: const InputDecoration(
-                    labelText: 'Confirm password',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText: l10n.confirmPasswordLabel,
+                    border: const OutlineInputBorder(),
                   ),
                   validator: (value) {
                     if (value == null || value.isEmpty) {
@@ -160,21 +162,21 @@ class _SignUpPageState extends State<SignUpPage> {
                 ),
                 const SizedBox(height: 24),
                 ElevatedButton(
-                 onPressed: _isSubmitting ? null : _submit,
+                  onPressed: _isSubmitting ? null : _submit,
                   child: _isSubmitting
                       ? const SizedBox(
                           height: 20,
                           width: 20,
                           child: CircularProgressIndicator(strokeWidth: 2),
                         )
-                      : const Text('Create account'),
+                      : Text(l10n.createAccount),
                 ),
                 const SizedBox(height: 16),
                 TextButton(
                   onPressed: () {
                     Navigator.of(context).pushReplacementNamed(AppRoutes.login);
                   },
-                  child: const Text('Already have an account? Log in'),
+                  child: Text(l10n.createAccountDescription),
                 ),
               ],
             ),

--- a/lib/presentation/pages/create_segment_page.dart
+++ b/lib/presentation/pages/create_segment_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:toll_cam_finder/app/app_routes.dart';
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
 import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart';
 import 'package:toll_cam_finder/presentation/widgets/segment_picker/segment_picker_map.dart';
@@ -86,9 +87,10 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Create segment')),
+      appBar: AppBar(title: Text(l10n.createSegment)),
       body: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
@@ -238,7 +240,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
                         child: FilledButton.icon(
                           onPressed: _onSavePressed,
                           icon: const Icon(Icons.check_circle),
-                          label: const Text('Save segment'),
+                          label: Text(l10n.saveSegment),
                         ),
                       ),
                     ],
@@ -440,7 +442,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     if (!mounted) return;
 
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
+      SnackBar(
         content: Text(AppMessages.segmentSubmittedForPublicReviewGeneric),
       ),
     );

--- a/lib/presentation/pages/map/widgets/map_controls_panel.dart
+++ b/lib/presentation/pages/map/widgets/map_controls_panel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/presentation/widgets/avg_speed_dial.dart';
 import 'package:toll_cam_finder/presentation/widgets/curretn_speed_dial.dart';
@@ -32,14 +33,21 @@ class MapControlsPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        CurrentSpeedDial(speedKmh: speedKmh, unit: 'km/h'),
+        CurrentSpeedDial(
+          speedKmh: speedKmh,
+          title: l10n.speedDialCurrentTitle,
+          unit: l10n.speedDialUnitKmh,
+        ),
         const SizedBox(height: AppConstants.speedDialStackSpacing),
         AverageSpeedDial(
           controller: avgController,
-          unit: 'km/h',
+          title: l10n.speedDialAverageTitle,
+          unit: l10n.speedDialUnitKmh,
           isActive: hasActiveSegment,
           speedLimitKph:
               hasActiveSegment ? segmentSpeedLimitKph : null,
@@ -78,8 +86,14 @@ class MapControlsPanel extends StatelessWidget {
                   BorderRadius.circular(AppConstants.speedDialBannerRadius),
             ),
             child: Text(
-              'avg speed for the last segment: '
-              '${lastSegmentAvgKmh!.toStringAsFixed(1)}kph',
+              l10n.translate(
+                'speedDialLastSegmentAverage',
+                {
+                  'value': lastSegmentAvgKmh!
+                      .toStringAsFixed(1),
+                  'unit': l10n.speedDialUnitKmh,
+                },
+              ),
               style: const TextStyle(
                 color: Colors.white,
                 fontSize: 12,
@@ -100,7 +114,14 @@ class MapControlsPanel extends StatelessWidget {
                   BorderRadius.circular(AppConstants.speedDialDebugBadgeRadius),
             ),
             child: Text(
-              'Segments: $segmentCount  r=${segmentRadiusMeters.toInt()}m',
+              l10n.translate(
+                'speedDialDebugSummary',
+                {
+                  'count': '$segmentCount',
+                  'radius': '${segmentRadiusMeters.toInt()}',
+                  'unit': l10n.translate('unitMetersShort'),
+                },
+              ),
               style: const TextStyle(color: Colors.white, fontSize: 12),
             ),
           ),

--- a/lib/presentation/pages/map/widgets/map_fab_column.dart
+++ b/lib/presentation/pages/map/widgets/map_fab_column.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
 import 'package:toll_cam_finder/presentation/widgets/avg_speed_button.dart';
 import 'package:toll_cam_finder/services/average_speed_est.dart';
 
@@ -27,7 +28,7 @@ class MapFabColumn extends StatelessWidget {
           icon: Icon(
             followUser ? Icons.my_location : Icons.my_location_outlined,
           ),
-          label: const Text('Recenter'),
+          label: Text(AppLocalizations.of(context).recenter),
         ),
         const SizedBox(height: 12),
         AverageSpeedButton(controller: avgController),

--- a/lib/presentation/pages/map/widgets/segment_overlays.dart
+++ b/lib/presentation/pages/map/widgets/segment_overlays.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+
 import 'package:toll_cam_finder/core/spatial/segment_geometry.dart';
 import 'package:toll_cam_finder/services/segment_tracker.dart';
 
@@ -217,12 +219,18 @@ class _SegmentDebugMarker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final l10n = AppLocalizations.of(context);
     final tags = <String>[
-      path.isDetailed ? 'detailed' : 'approx',
-      path.passesDirection ? 'dir✔' : 'dir✖',
-      if (path.startHit) 'start',
-      if (path.endHit) 'end',
+      path.isDetailed
+          ? l10n.translate('segmentDebugTagDetailed')
+          : l10n.translate('segmentDebugTagApprox'),
+      path.passesDirection
+          ? l10n.translate('segmentDebugTagDirectionPass')
+          : l10n.translate('segmentDebugTagDirectionFail'),
+      if (path.startHit) l10n.translate('segmentDebugTagStart'),
+      if (path.endHit) l10n.translate('segmentDebugTagEnd'),
     ];
+    final separator = l10n.translate('segmentDebugTagSeparator');
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -248,14 +256,30 @@ class _SegmentDebugMarker extends StatelessWidget {
                   path.id,
                   style: const TextStyle(fontWeight: FontWeight.w600),
                 ),
-                Text('${path.distanceMeters.toStringAsFixed(1)} m'),
+                Text(
+                  l10n.translate(
+                    'segmentDebugDistanceMeters',
+                    {'distance': path.distanceMeters.toStringAsFixed(1)},
+                  ),
+                ),
                 if (path.remainingDistanceMeters.isFinite)
                   Text(
-                    '${(path.remainingDistanceMeters / 1000).toStringAsFixed(2)} km left',
+                    l10n.translate(
+                      'segmentDebugDistanceKilometersLeft',
+                      {
+                        'distance': (path.remainingDistanceMeters / 1000)
+                            .toStringAsFixed(2),
+                      },
+                    ),
                   ),
                 if (path.headingDiffDeg != null)
-                  Text('Δθ=${path.headingDiffDeg!.toStringAsFixed(0)}°'),
-                if (tags.isNotEmpty) Text(tags.join(' · ')),
+                  Text(
+                    l10n.translate(
+                      'segmentDebugHeadingDiff',
+                      {'angle': path.headingDiffDeg!.toStringAsFixed(0)},
+                    ),
+                  ),
+                if (tags.isNotEmpty) Text(tags.join(separator)),
               ],
             ),
           ),

--- a/lib/presentation/pages/map_page.dart
+++ b/lib/presentation/pages/map_page.dart
@@ -21,6 +21,7 @@ import 'package:toll_cam_finder/services/segments_metadata_service.dart';
 import 'package:toll_cam_finder/services/toll_segments_sync_service.dart';
 
 import '../../app/app_routes.dart';
+import '../../app/localization/app_localizations.dart';
 import '../../services/auth_controller.dart';
 import '../../services/language_controller.dart';
 import '../../services/location_service.dart';
@@ -254,6 +255,8 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
       return null;
     }
 
+    final l10n = AppLocalizations.of(context);
+
     final String? activeId = event.activeSegmentId;
     if (activeId != null) {
       final activePath =
@@ -266,12 +269,18 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
           activePath.remainingDistanceMeters >= 0) {
         final remaining = activePath.remainingDistanceMeters;
         if (remaining >= 1000) {
-          return '${(remaining / 1000).toStringAsFixed(2)} km to segment end';
+          return l10n.translate(
+            'segmentProgressEndKilometers',
+            {'distance': (remaining / 1000).toStringAsFixed(2)},
+          );
         }
         if (remaining >= 1) {
-          return '${remaining.toStringAsFixed(0)} m to segment end';
+          return l10n.translate(
+            'segmentProgressEndMeters',
+            {'distance': remaining.toStringAsFixed(0)},
+          );
         }
-        return 'Segment end nearby';
+        return l10n.translate('segmentProgressEndNearby');
       }
       return null;
     }
@@ -293,12 +302,18 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
 
     final double distance = upcoming.startDistanceMeters;
     if (distance >= 1000) {
-      return '${(distance / 1000).toStringAsFixed(2)} km to segment start';
+      return l10n.translate(
+        'segmentProgressStartKilometers',
+        {'distance': (distance / 1000).toStringAsFixed(2)},
+      );
     }
     if (distance >= 1) {
-      return '${distance.toStringAsFixed(0)} m to segment start';
+      return l10n.translate(
+        'segmentProgressStartMeters',
+        {'distance': distance.toStringAsFixed(0)},
+      );
     }
-    return 'Segment start nearby';
+    return l10n.translate('segmentProgressStartNearby');
   }
 
   SegmentDebugPath? _firstPathMatching(
@@ -508,7 +523,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
                       child: IconButton(
                         onPressed: () => Scaffold.of(context).openEndDrawer(),
                         icon: const Icon(Icons.menu, color: Colors.white),
-                        tooltip: 'Open menu',
+                        tooltip: AppLocalizations.of(context).openMenu,
                       ),
                     );
                   },
@@ -528,6 +543,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
   }
 
   Drawer _buildOptionsDrawer() {
+    final l10n = AppLocalizations.of(context);
     final languageController = context.watch<LanguageController>();
     return Drawer(
       child: SafeArea(
@@ -536,7 +552,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
           children: [
             ListTile(
               leading: const Icon(Icons.sync),
-              title: const Text('Sync'),
+              title: Text(l10n.sync),
               enabled: !_isSyncing,
               trailing: _isSyncing
                   ? const SizedBox(
@@ -549,18 +565,18 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
             ),
             ListTile(
               leading: const Icon(Icons.segment),
-              title: const Text('Segments'),
+              title: Text(l10n.segments),
               onTap: _onSegmentsSelected,
             ),
             ListTile(
               leading: const Icon(Icons.language),
-              title: const Text('Language'),
+              title: Text(l10n.languageButton),
               subtitle: Text(languageController.currentOption.label),
               onTap: _onLanguageSelected,
             ),
             ListTile(
               leading: const Icon(Icons.person_outline),
-              title: const Text('Profile'),
+              title: Text(l10n.profile),
               onTap: () {
                 Navigator.of(context).pop();
                 WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -589,8 +605,8 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
                 return ListView(
                   shrinkWrap: true,
                   children: [
-                    const ListTile(
-                      title: Text('Select language'),
+                    ListTile(
+                      title: Text(l10n.selectLanguage),
                     ),
                     for (final option in options)
                       ListTile(
@@ -601,7 +617,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
                         enabled: option.available,
                         subtitle: option.available
                             ? null
-                            : const Text('Coming soon'),
+                            : Text(l10n.comingSoon),
                         onTap: option.available
                             ? () {
                                 controller.setLocale(option.locale);
@@ -634,7 +650,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
             children: [
               ListTile(
                 leading: const Icon(Icons.login),
-                title: const Text('Log in'),
+                title: Text(l10n.logIn),
                 onTap: () {
                   Navigator.of(sheetContext).pop();
                   Navigator.of(context).pushNamed(AppRoutes.login);
@@ -642,7 +658,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
               ),
               ListTile(
                 leading: const Icon(Icons.person_add_alt),
-                title: const Text('Create an account'),
+                title: Text(l10n.createAccountCta),
                 onTap: () {
                   Navigator.of(sheetContext).pop();
                   Navigator.of(context).pushNamed(AppRoutes.signUp);
@@ -726,7 +742,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
 
     if (client == null) {
       messenger.showSnackBar(
-        const SnackBar(
+        SnackBar(
           content: Text(AppMessages.supabaseNotConfiguredForSync),
         ),
       );
@@ -764,7 +780,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
     } catch (error, stackTrace) {
       debugPrint('Failed to sync toll segments: $error\n$stackTrace');
       messenger.showSnackBar(
-        const SnackBar(
+        SnackBar(
           content: Text(AppMessages.unexpectedSyncError),
         ),
       );

--- a/lib/presentation/pages/segments_page.dart
+++ b/lib/presentation/pages/segments_page.dart
@@ -11,6 +11,7 @@ import 'package:toll_cam_finder/services/segments_metadata_service.dart';
 import 'package:toll_cam_finder/services/segments_repository.dart';
 
 import '../../app/app_routes.dart';
+import '../../app/localization/app_localizations.dart';
 import '../widgets/add_segment/empty_segments_views.dart';
 import '../widgets/add_segment/segment_action_dialogs.dart';
 import '../widgets/add_segment/segment_card.dart';
@@ -38,6 +39,7 @@ class _SegmentsPageState extends State<SegmentsPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return WillPopScope(
       onWillPop: () async {
         Navigator.of(context).pop(_segmentsUpdated);
@@ -45,11 +47,11 @@ class _SegmentsPageState extends State<SegmentsPage> {
       },
       child: Scaffold(
         appBar: AppBar(
-          title: const Text('Segments'),
+          title: Text(l10n.segments),
           actions: [
             IconButton(
               icon: const Icon(Icons.folder_special_outlined),
-              tooltip: 'Local segments',
+              tooltip: l10n.localSegments,
               onPressed: _onShowLocalSegmentsPressed,
             ),
           ],
@@ -93,7 +95,7 @@ class _SegmentsPageState extends State<SegmentsPage> {
         floatingActionButton: FloatingActionButton.extended(
           onPressed: _onCreateSegmentPressed,
           icon: const Icon(Icons.add),
-          label: const Text('Create segment'),
+          label: Text(l10n.createSegment),
         ),
       ),
     );
@@ -507,13 +509,14 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return WillPopScope(
       onWillPop: () async {
         Navigator.of(context).pop(_segmentsUpdated);
         return false;
       },
       child: Scaffold(
-        appBar: AppBar(title: const Text('Local segments')),
+        appBar: AppBar(title: Text(l10n.localSegments)),
         body: FutureBuilder<List<SegmentInfo>>(
           future: _segmentsFuture,
           builder: (context, snapshot) {
@@ -553,7 +556,7 @@ class _LocalSegmentsPageState extends State<LocalSegmentsPage> {
         floatingActionButton: FloatingActionButton.extended(
           onPressed: _onCreateSegmentPressed,
           icon: const Icon(Icons.add),
-          label: const Text('Create segment'),
+          label: Text(l10n.createSegment),
         ),
       ),
     );

--- a/lib/presentation/widgets/add_segment/empty_segments_views.dart
+++ b/lib/presentation/widgets/add_segment/empty_segments_views.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+
 class EmptySegmentsView extends StatelessWidget {
   const EmptySegmentsView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Center(child: Text('No segments available.'));
+    return Center(child: Text(AppLocalizations.of(context).noSegmentsAvailable));
   }
 }
 
@@ -14,6 +16,6 @@ class EmptyLocalSegmentsView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(child: Text('No local segments saved yet.'));
+    return Center(child: Text(AppLocalizations.of(context).noLocalSegments));
   }
 }

--- a/lib/presentation/widgets/avg_speed_button.dart
+++ b/lib/presentation/widgets/avg_speed_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/services/average_speed_est.dart';
 
@@ -14,10 +15,13 @@ class AverageSpeedButton extends StatelessWidget {
       animation: controller,
       builder: (context, _) {
         final running = controller.isRunning;
+        final l10n = AppLocalizations.of(context);
         return FloatingActionButton.small(
           heroTag: 'avg_speed_btn',
           onPressed: () => running ? controller.reset() : controller.start(),
-          tooltip: running ? 'Reset Avg' : 'Start Avg',
+          tooltip: running
+              ? l10n.averageSpeedResetTooltip
+              : l10n.averageSpeedStartTooltip,
           child: AnimatedSwitcher(
             duration: const Duration(
               milliseconds: AppConstants.avgSpeedButtonAnimationMs,

--- a/lib/presentation/widgets/avg_speed_dial.dart
+++ b/lib/presentation/widgets/avg_speed_dial.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/presentation/widgets/smooth_number_text.dart';
 import 'package:toll_cam_finder/services/average_speed_est.dart';
@@ -28,6 +29,8 @@ class AverageSpeedDial extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
+
+    final l10n = AppLocalizations.of(context);
 
     return AnimatedBuilder(
       animation: controller,
@@ -90,9 +93,16 @@ class AverageSpeedDial extends StatelessWidget {
                       Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 4),
                         child: Text(
-                          'Limit: '
-                          '${speedLimitKph!.toStringAsFixed(speedLimitKph! % 1 == 0 ? 0 : decimals)} '
-                          '$unit',
+                          l10n.translate(
+                            'speedDialLimitLabel',
+                            {
+                              'value': speedLimitKph!
+                                  .toStringAsFixed(
+                                    speedLimitKph! % 1 == 0 ? 0 : decimals,
+                                  ),
+                              'unit': unit,
+                            },
+                          ),
                           textAlign: TextAlign.center,
                           style: textTheme.bodyMedium?.copyWith(
                             fontWeight: FontWeight.w600,
@@ -107,7 +117,7 @@ class AverageSpeedDial extends StatelessWidget {
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 4),
                       child: Text(
-                        'no active segment',
+                        l10n.speedDialNoActiveSegment,
                         textAlign: TextAlign.center,
                         style: textTheme.bodyMedium?.copyWith(
                           fontWeight: FontWeight.w500,

--- a/lib/presentation/widgets/base_tile_layer.dart
+++ b/lib/presentation/widgets/base_tile_layer.dart
@@ -47,7 +47,7 @@ class BaseTileLayer extends StatelessWidget {
 
   static void _showLaunchError(BuildContext context) {
     ScaffoldMessenger.maybeOf(context)?.showSnackBar(
-      const SnackBar(
+      SnackBar(
         content: Text(AppMessages.osmCopyrightLaunchFailed),
       ),
     );

--- a/lib/services/language_controller.dart
+++ b/lib/services/language_controller.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import '../app/localization/app_localizations.dart';
+import '../core/app_messages.dart';
+
 class LanguageOption {
   const LanguageOption({
     required this.locale,
@@ -13,7 +16,9 @@ class LanguageOption {
 }
 
 class LanguageController extends ChangeNotifier {
-  LanguageController();
+  LanguageController() {
+    AppMessages.updateLocale(_locale);
+  }
 
   static const List<LanguageOption> _languageOptions = [
     LanguageOption(
@@ -24,7 +29,7 @@ class LanguageController extends ChangeNotifier {
     LanguageOption(
       locale: Locale('es'),
       label: 'Español',
-      available: false,
+      available: true,
     ),
   ];
 
@@ -34,10 +39,7 @@ class LanguageController extends ChangeNotifier {
 
   List<LanguageOption> get languageOptions => _languageOptions;
 
-  List<Locale> get supportedLocales => _languageOptions
-      .where((option) => option.available)
-      .map((option) => option.locale)
-      .toList();
+  List<Locale> get supportedLocales => AppLocalizations.supportedLocales;
 
   LanguageOption get currentOption => _languageOptions.firstWhere(
         (option) => option.locale == _locale,
@@ -56,6 +58,7 @@ class LanguageController extends ChangeNotifier {
     }
 
     _locale = locale;
+    AppMessages.updateLocale(_locale);
     notifyListeners();
   }
 }


### PR DESCRIPTION
## Summary
- extend `AppLocalizations` with a comprehensive translation catalog and helper for placeholder substitution
- update `AppMessages` and the language controller to serve locale-aware strings throughout services and UI
- localize authentication forms, map overlays, speed controls, and snackbars to remove hard-coded English copy

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e5f5d9b024832d890d140c02959cdc