### PR TITLE
Throttle off-segment toll camera checks by distance

### DIFF
--- a/lib/presentation/pages/map/toll_camera_controller.dart
+++ b/lib/presentation/pages/map/toll_camera_controller.dart
@@ -30,4 +30,8 @@ class TollCameraController {
   void updateVisible({LatLngBounds? bounds}) {
     _cameras.updateVisible(bounds: bounds);
   }
+
+  double? nearestCameraDistanceMeters(LatLng point) {
+    return _cameras.nearestCameraDistanceMeters(point);
+  }
 }

--- a/lib/presentation/pages/map_page.dart
+++ b/lib/presentation/pages/map_page.dart
@@ -80,6 +80,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
   String? _segmentProgressLabel;
   bool _isSyncing = false;
   final TollSegmentsSyncService _syncService = TollSegmentsSyncService();
+  DateTime? _nextCameraCheckAt;
 
   @override
   void initState() {
@@ -153,6 +154,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
       compassHeading: _compassHeading,
     );
     _applySegmentEvent(segEvent);
+    _updateCameraPollingSchedule(firstFix);
 
     if (mounted) setState(() {});
 
@@ -174,14 +176,18 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
     _avgCtrl.addSample(shownKmh);
     final previous = _userLatLng;
     _moveBlueDot(next);
-    final segEvent = _segmentTracker.handleLocationUpdate(
-      current: next,
-      previous: previous,
-      rawHeading: position.heading,
-      speedKmh: smoothedKmh,
-      compassHeading: _compassHeading,
-    );
-    _applySegmentEvent(segEvent);
+    final now = DateTime.now();
+    if (_shouldProcessSegmentUpdate(now)) {
+      final segEvent = _segmentTracker.handleLocationUpdate(
+        current: next,
+        previous: previous,
+        rawHeading: position.heading,
+        speedKmh: smoothedKmh,
+        compassHeading: _compassHeading,
+      );
+      _applySegmentEvent(segEvent);
+      _updateCameraPollingSchedule(next);
+    }
 
     if (!mounted) return;
 
@@ -222,6 +228,53 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
     _lastSegmentAvgKmh = null;
     _activeSegmentSpeedLimitKph = null;
     _avgCtrl.reset();
+    _nextCameraCheckAt = null;
+  }
+
+  bool _shouldProcessSegmentUpdate(DateTime now) {
+    if (_segmentTracker.activeSegmentId != null) {
+      return true;
+    }
+    final DateTime? nextCheck = _nextCameraCheckAt;
+    if (nextCheck == null) {
+      return true;
+    }
+    return !now.isBefore(nextCheck);
+  }
+
+  void _updateCameraPollingSchedule(LatLng position) {
+    if (_segmentTracker.activeSegmentId != null) {
+      _nextCameraCheckAt = null;
+      return;
+    }
+
+    final double? distance =
+        _cameraController.nearestCameraDistanceMeters(position);
+    final Duration delay = _cameraPollingDelayForDistance(distance);
+    if (delay <= Duration.zero) {
+      _nextCameraCheckAt = null;
+    } else {
+      _nextCameraCheckAt = DateTime.now().add(delay);
+    }
+  }
+
+  Duration _cameraPollingDelayForDistance(double? distanceMeters) {
+    if (distanceMeters == null) {
+      return const Duration(minutes: 3);
+    }
+    if (distanceMeters > 10000) {
+      return const Duration(minutes: 3);
+    }
+    if (distanceMeters > 5000) {
+      return const Duration(minutes: 1, seconds: 30);
+    }
+    if (distanceMeters > 2000) {
+      return const Duration(seconds: 40);
+    }
+    if (distanceMeters > 1000) {
+      return const Duration(seconds: 15);
+    }
+    return Duration.zero;
   }
 
   double _normalizeSpeed(double metersPerSecond) {
@@ -395,6 +448,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
       excludedSegmentIds: _segmentsMetadata.deactivatedSegmentIds,
     );
     if (!mounted) return;
+    _nextCameraCheckAt = null;
     _updateVisibleCameras();
   }
 
@@ -438,6 +492,7 @@ class _MapPageState extends State<MapPage> with SingleTickerProviderStateMixin {
         compassHeading: _compassHeading,
       );
       _applySegmentEvent(seedEvent);
+      _updateCameraPollingSchedule(_userLatLng!);
     }
 
     setState(() {});

--- a/lib/services/camera_utils.dart
+++ b/lib/services/camera_utils.dart
@@ -28,6 +28,7 @@ class CameraUtils {
   List<LatLng> _visibleCameras = [];
   bool _loading = true;
   String? _error;
+  final Distance _distance = const Distance();
 
   // --- public getters (read-only to the outside) ---
   List<LatLng> get allCameras => _allCameras;
@@ -73,6 +74,23 @@ class CameraUtils {
       if (_boundsContains(padded, p)) res.add(p);
     }
     _visibleCameras = res;
+  }
+
+  /// Calculates the distance to the nearest camera from [point], returning the
+  /// value in meters. When no cameras are loaded the method yields `null`.
+  double? nearestCameraDistanceMeters(LatLng point) {
+    if (_allCameras.isEmpty) {
+      return null;
+    }
+
+    double? best;
+    for (final camera in _allCameras) {
+      final double meters = _distance(point, camera);
+      if (best == null || meters < best) {
+        best = meters;
+      }
+    }
+    return best;
   }
 
   // --- helpers ---


### PR DESCRIPTION
## Summary
- add a helper to compute the nearest camera distance
- throttle segment tracker updates off-segment using a distance-based polling schedule
- reset the polling schedule when camera data or segment state refreshes

## Testing
- not run (flutter not installed in container)

------
https://chatgpt.com/codex/tasks/task_e_68e5fa550064832dba6ad98a7494f585