### PR TITLE
Localize hardcoded UI strings

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -20,6 +20,10 @@ class AppLocalizations {
       'chooseSegmentVisibilityQuestion':
           'Do you want the segment to be publically visible?',
       'comingSoon': 'Coming soon',
+      'coordinatesMustBeProvided':
+          'Coordinates must be provided in the format "lat, lon".',
+      'coordinatesMustBeDecimalNumbers':
+          'Coordinates must be valid decimal numbers.',
       'confirmDeleteSegment':
           'Are you sure you want to delete segment {displayId}?',
       'confirmKeepSegmentPrivate':
@@ -80,6 +84,8 @@ class AppLocalizations {
       'hideSegmentOnMapAction': 'Hide segment on map',
       'joinTollCam': 'Join TollCam',
       'language': 'Language',
+      'languageLabelEnglish': 'English',
+      'languageLabelSpanish': 'Spanish',
       'languageButton': 'Change language',
       'localSegments': 'Local segments',
       'logIn': 'Log in',
@@ -107,6 +113,8 @@ class AppLocalizations {
       'nonNumericSegmentIdEncountered':
           'Encountered an existing segment with a non-numeric id.',
       'onlyLocalSegmentsCanBeDeleted': 'Only local segments can be deleted.',
+      'onlySegmentsSavedLocallyCanBeShared':
+          'Only segments saved locally can be shared publicly.',
       'openMenu': 'Open menu',
       'osmCopyrightLaunchFailed':
           'Could not open the OpenStreetMap copyright page.',
@@ -139,6 +147,9 @@ class AppLocalizations {
           'Segment {displayId} hidden. Cameras and warnings are disabled.',
       'segmentMetadataUpdateUnavailable':
           'Segment metadata cannot be updated on the web.',
+      'segmentMissingCoordinates':
+          'The saved segment is missing coordinates and cannot be shared publicly.',
+      'segmentNotFoundLocally': 'The segment could not be found locally.',
       'segmentNoLongerUnderReview':
           'Segment {displayId} will no longer be reviewed for public release.',
       'segmentProgressEndKilometers': '{distance} km to segment end',
@@ -148,6 +159,10 @@ class AppLocalizations {
       'segmentProgressStartMeters': '{distance} m to segment start',
       'segmentProgressStartNearby': 'Segment start nearby',
       'segmentSavedLocally': 'Segment saved locally.',
+      'segmentDefaultStartName': '{name} start',
+      'segmentDefaultEndName': '{name} end',
+      'segmentPickerStartMarkerLabel': 'A',
+      'segmentPickerEndMarkerLabel': 'B',
       'segmentSubmittedForPublicReview':
           'Segment {displayId} submitted for public review.',
       'segmentSubmittedForPublicReviewGeneric': 'Segment submitted for public review.',
@@ -174,7 +189,9 @@ class AppLocalizations {
           'Avg speed for the last segment: {value}{unit}',
       'speedDialLimitLabel': 'Limit: {value} {unit}',
       'speedDialNoActiveSegment': 'No active segment',
+      'speedDialPlaceholder': '—',
       'speedDialUnitKmh': 'km/h',
+      'personalSegmentDefaultName': 'Personal segment',
       'syncAddedMany': '{count} segments added',
       'syncAddedOne': '{count} segment added',
       'syncApprovedSummaryPlural':
@@ -197,6 +214,12 @@ class AppLocalizations {
           'Supabase is not configured. Please add credentials to enable sync.',
       'sync': 'Sync',
       'syncNotSupportedOnWeb': 'Syncing toll segments is not supported on the web.',
+      'savingLocalSegmentsNotSupportedOnWeb':
+          'Saving local segments is not supported on the web.',
+      'loadingLocalSegmentsNotSupportedOnWeb':
+          'Loading local segments is not supported on the web.',
+      'deletingLocalSegmentsNotSupportedOnWeb':
+          'Deleting local segments is not supported on the web.',
       'tableMissingModerationColumn':
           'The "{tableName}" table is missing the "{column}" column required for moderation.',
       'tableReturnedNoRows':
@@ -220,6 +243,8 @@ class AppLocalizations {
       'unexpectedErrorSubmittingForModeration':
           'Unexpected error while submitting the segment for moderation.',
       'unexpectedSyncError': 'Unexpected error while syncing toll segments.',
+      'fileSystemOperationsNotSupported':
+          'File system operations are not supported on this platform.',
       'unitKilometersShort': 'km',
       'unitMetersShort': 'm',
       'unknownUserLabel': 'Unknown user',
@@ -237,6 +262,10 @@ class AppLocalizations {
       'averageSpeedResetTooltip': 'Reiniciar promedio',
       'averageSpeedStartTooltip': 'Iniciar promedio',
       'comingSoon': 'Próximamente',
+      'coordinatesMustBeProvided':
+          'Las coordenadas deben proporcionarse en el formato "lat, lon".',
+      'coordinatesMustBeDecimalNumbers':
+          'Las coordenadas deben ser números decimales válidos.',
       'confirmPasswordLabel': 'Confirmar contraseña',
       'continue': 'Continuar',
       'createAccount': 'Crear cuenta',
@@ -248,6 +277,8 @@ class AppLocalizations {
       'fullNameLabel': 'Nombre completo',
       'joinTollCam': 'Únete a TollCam',
       'language': 'Idioma',
+      'languageLabelEnglish': 'Inglés',
+      'languageLabelSpanish': 'Español',
       'languageButton': 'Cambiar idioma',
       'localSegments': 'Segmentos locales',
       'logIn': 'Iniciar sesión',
@@ -280,6 +311,16 @@ class AppLocalizations {
       'segmentProgressStartNearby': 'Inicio del segmento cercano',
       'segments': 'Segmentos',
       'selectLanguage': 'Seleccionar idioma',
+      'segmentDefaultStartName': 'Inicio de {name}',
+      'segmentDefaultEndName': 'Fin de {name}',
+      'segmentPickerStartMarkerLabel': 'A',
+      'segmentPickerEndMarkerLabel': 'B',
+      'segmentMissingCoordinates':
+          'El segmento guardado no tiene coordenadas y no se puede compartir públicamente.',
+      'segmentNotFoundLocally': 'No se pudo encontrar el segmento localmente.',
+      'personalSegmentDefaultName': 'Segmento personal',
+      'onlySegmentsSavedLocallyCanBeShared':
+          'Solo los segmentos guardados localmente pueden compartirse públicamente.',
       'speedDialAverageTitle': 'Velocidad promedio',
       'speedDialCurrentTitle': 'Velocidad',
       'speedDialDebugSummary': 'Segmentos: {count}  r={radius}{unit}',
@@ -287,6 +328,7 @@ class AppLocalizations {
           'Velocidad promedio del último segmento: {value}{unit}',
       'speedDialLimitLabel': 'Límite: {value} {unit}',
       'speedDialNoActiveSegment': 'Sin segmento activo',
+      'speedDialPlaceholder': '—',
       'speedDialUnitKmh': 'km/h',
       'syncAddedMany': '{count} segmentos añadidos',
       'syncAddedOne': '{count} segmento añadido',
@@ -300,6 +342,14 @@ class AppLocalizations {
       'syncRemovedOne': '{count} segmento eliminado',
       'syncTotalSegmentsSummary': '{count} segmentos totales disponibles.',
       'sync': 'Sincronizar',
+      'savingLocalSegmentsNotSupportedOnWeb':
+          'Guardar segmentos locales no es compatible en la web.',
+      'loadingLocalSegmentsNotSupportedOnWeb':
+          'Cargar segmentos locales no es compatible en la web.',
+      'deletingLocalSegmentsNotSupportedOnWeb':
+          'Eliminar segmentos locales no es compatible en la web.',
+      'fileSystemOperationsNotSupported':
+          'Las operaciones del sistema de archivos no son compatibles en esta plataforma.',
       'unitKilometersShort': 'km',
       'unitMetersShort': 'm',
       'unknownUserLabel': 'Usuario desconocido',

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -16,6 +16,45 @@ class AppMessages {
 
   static AppLocalizations get _l => _localizations;
 
+  static String get speedDialCurrentTitle =>
+      _l.translate('speedDialCurrentTitle');
+  static String get speedDialAverageTitle =>
+      _l.translate('speedDialAverageTitle');
+  static String get speedDialUnitKmh => _l.translate('speedDialUnitKmh');
+  static String get speedDialPlaceholder =>
+      _l.translate('speedDialPlaceholder');
+  static String get segmentPickerStartMarkerLabel =>
+      _l.translate('segmentPickerStartMarkerLabel');
+  static String get segmentPickerEndMarkerLabel =>
+      _l.translate('segmentPickerEndMarkerLabel');
+  static String get languageLabelEnglish =>
+      _l.translate('languageLabelEnglish');
+  static String get languageLabelSpanish =>
+      _l.translate('languageLabelSpanish');
+  static String get personalSegmentDefaultName =>
+      _l.translate('personalSegmentDefaultName');
+  static String segmentDefaultStartName(String name) =>
+      _l.translate('segmentDefaultStartName', {'name': name});
+  static String segmentDefaultEndName(String name) =>
+      _l.translate('segmentDefaultEndName', {'name': name});
+  static String get savingLocalSegmentsNotSupportedOnWeb =>
+      _l.translate('savingLocalSegmentsNotSupportedOnWeb');
+  static String get loadingLocalSegmentsNotSupportedOnWeb =>
+      _l.translate('loadingLocalSegmentsNotSupportedOnWeb');
+  static String get deletingLocalSegmentsNotSupportedOnWeb =>
+      _l.translate('deletingLocalSegmentsNotSupportedOnWeb');
+  static String get onlySegmentsSavedLocallyCanBeShared =>
+      _l.translate('onlySegmentsSavedLocallyCanBeShared');
+  static String get segmentMissingCoordinates =>
+      _l.translate('segmentMissingCoordinates');
+  static String get segmentNotFoundLocally =>
+      _l.translate('segmentNotFoundLocally');
+  static String get coordinatesMustBeProvided =>
+      _l.translate('coordinatesMustBeProvided');
+  static String get coordinatesMustBeDecimalNumbers =>
+      _l.translate('coordinatesMustBeDecimalNumbers');
+  static String get fileSystemOperationsNotSupported =>
+      _l.translate('fileSystemOperationsNotSupported');
   static String get segmentSavedLocally =>
       _l.translate('segmentSavedLocally');
   static String get showSegmentOnMapAction =>

--- a/lib/presentation/widgets/avg_speed_dial.dart
+++ b/lib/presentation/widgets/avg_speed_dial.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/presentation/widgets/smooth_number_text.dart';
 import 'package:toll_cam_finder/services/average_speed_est.dart';
@@ -9,18 +10,18 @@ class AverageSpeedDial extends StatelessWidget {
   const AverageSpeedDial({
     super.key,
     required this.controller,
-    this.title = 'Avg Speed',
+    this.title,
     this.decimals = AppConstants.speedDialDefaultDecimals,
-    this.unit = 'km/h',
+    this.unit,
     this.width = AppConstants.speedDialDefaultWidth,
     this.isActive = true,
     this.speedLimitKph,
   });
 
   final AverageSpeedController controller;
-  final String title;
+  final String? title;
   final int decimals;
-  final String unit;
+  final String? unit;
   final double width;
   final bool isActive;
   final double? speedLimitKph;
@@ -31,6 +32,8 @@ class AverageSpeedDial extends StatelessWidget {
     final textTheme = theme.textTheme;
 
     final localizations = AppLocalizations.of(context);
+    final resolvedTitle = title ?? AppMessages.speedDialAverageTitle;
+    final resolvedUnit = unit ?? AppMessages.speedDialUnitKmh;
 
     return AnimatedBuilder(
       animation: controller,
@@ -56,7 +59,7 @@ class AverageSpeedDial extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Text(
-                        title,
+                        resolvedTitle,
                         style: textTheme.titleMedium?.copyWith(
                           fontWeight: FontWeight.w600,
                         ),
@@ -83,7 +86,7 @@ class AverageSpeedDial extends StatelessWidget {
                             padding: const EdgeInsets.only(
                               bottom: AppConstants.speedDialUnitBaselinePadding,
                             ),
-                            child: Text(unit, style: textTheme.titleSmall),
+                            child: Text(resolvedUnit, style: textTheme.titleSmall),
                           ),
                         ],
                       ),
@@ -100,7 +103,7 @@ class AverageSpeedDial extends StatelessWidget {
                                   .toStringAsFixed(
                                     speedLimitKph! % 1 == 0 ? 0 : decimals,
                                   ),
-                              'unit': unit,
+                              'unit': resolvedUnit,
                             },
                           ),
                           textAlign: TextAlign.center,

--- a/lib/presentation/widgets/curretn_speed_dial.dart
+++ b/lib/presentation/widgets/curretn_speed_dial.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/presentation/widgets/smooth_number_text.dart';
 
@@ -8,22 +9,24 @@ class CurrentSpeedDial extends StatelessWidget {
   const CurrentSpeedDial({
     super.key,
     required this.speedKmh,
-    this.title = 'Speed',
+    this.title,
     this.decimals = AppConstants.speedDialDefaultDecimals,
-    this.unit = 'km/h',
+    this.unit,
     this.width = AppConstants.speedDialDefaultWidth,
   });
 
   final double? speedKmh;
-  final String title;
+  final String? title;
   final int decimals;
-  final String unit;
+  final String? unit;
   final double width;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
+    final resolvedTitle = title ?? AppMessages.speedDialCurrentTitle;
+    final resolvedUnit = unit ?? AppMessages.speedDialUnitKmh;
 
     final double? value = (speedKmh != null && speedKmh!.isFinite)
         ? speedKmh!.clamp(0, double.infinity).toDouble()
@@ -46,7 +49,7 @@ class CurrentSpeedDial extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Text(
-                    title,
+                    resolvedTitle,
                     style: textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.w600,
                     ),
@@ -70,7 +73,7 @@ class CurrentSpeedDial extends StatelessWidget {
                       padding: const EdgeInsets.only(
                         bottom: AppConstants.speedDialUnitBaselinePadding,
                       ),
-                      child: Text(unit, style: textTheme.titleSmall),
+                      child: Text(resolvedUnit, style: textTheme.titleSmall),
                     ),
                   ],
                 ),

--- a/lib/presentation/widgets/segment_picker/segment_picker_map.dart
+++ b/lib/presentation/widgets/segment_picker/segment_picker_map.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:http/http.dart' as http;
 import 'package:latlong2/latlong.dart';
 
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/core/spatial/geo.dart';
 import 'package:toll_cam_finder/presentation/widgets/base_tile_layer.dart';
@@ -202,7 +203,9 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
             _updateEndpoint(endpoint, latLng, refreshRoute: false),
         onDragEnd: (latLng) => _updateEndpoint(endpoint, latLng),
         child: SegmentMarker(
-          label: endpoint == SegmentEndpoint.start ? 'A' : 'B',
+          label: endpoint == SegmentEndpoint.start
+              ? AppMessages.segmentPickerStartMarkerLabel
+              : AppMessages.segmentPickerEndMarkerLabel,
           color: color,
         ),
       ),

--- a/lib/presentation/widgets/smooth_number_text.dart
+++ b/lib/presentation/widgets/smooth_number_text.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 
 /// Text widget that animates numeric changes smoothly without the flicker of
@@ -8,7 +9,7 @@ class SmoothNumberText extends StatefulWidget {
     super.key,
     required this.value,
     required this.decimals,
-    this.placeholder = '—',
+    this.placeholder,
     this.style,
     this.duration = const Duration(
       milliseconds: AppConstants.smoothNumberTextAnimationMs,
@@ -23,7 +24,7 @@ class SmoothNumberText extends StatefulWidget {
   final int decimals;
 
   /// Text to render when [value] is `null`.
-  final String placeholder;
+  final String? placeholder;
 
   /// Text style for the rendered value/placeholder.
   final TextStyle? style;
@@ -98,7 +99,8 @@ class _SmoothNumberTextState extends State<SmoothNumberText>
   @override
   Widget build(BuildContext context) {
     if (widget.value == null) {
-      return Text(widget.placeholder, style: widget.style);
+      final placeholder = widget.placeholder ?? AppMessages.speedDialPlaceholder;
+      return Text(placeholder, style: widget.style);
     }
 
     return AnimatedBuilder(

--- a/lib/services/language_controller.dart
+++ b/lib/services/language_controller.dart
@@ -6,13 +6,23 @@ import '../core/app_messages.dart';
 class LanguageOption {
   const LanguageOption({
     required this.locale,
-    required this.label,
+    required this.languageCode,
     this.available = true,
   });
 
   final Locale locale;
-  final String label;
+  final String languageCode;
   final bool available;
+
+  String get label {
+    switch (languageCode) {
+      case 'es':
+        return AppMessages.languageLabelSpanish;
+      case 'en':
+      default:
+        return AppMessages.languageLabelEnglish;
+    }
+  }
 }
 
 class LanguageController extends ChangeNotifier {
@@ -23,12 +33,12 @@ class LanguageController extends ChangeNotifier {
   static const List<LanguageOption> _languageOptions = [
     LanguageOption(
       locale: Locale('en'),
-      label: 'English',
+      languageCode: 'en',
       available: true,
     ),
     LanguageOption(
       locale: Locale('es'),
-      label: 'Español',
+      languageCode: 'es',
       available: true,
     ),
   ];

--- a/lib/services/segments_repository.dart
+++ b/lib/services/segments_repository.dart
@@ -2,6 +2,7 @@ import 'package:csv/csv.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/services/segments_metadata_service.dart';
 import 'package:toll_cam_finder/services/toll_segments_csv_constants.dart';
 import 'package:toll_cam_finder/services/toll_segments_file_system.dart';
@@ -146,7 +147,7 @@ class SegmentsRepository {
         TollSegmentsCsvSchema.localSegmentIdPrefix,
       );
       final resolvedName = name.isEmpty && isLocalOnly
-          ? 'Personal segment'
+          ? AppMessages.personalSegmentDefaultName
           : name;
 
       segments.add(

--- a/lib/services/toll_segments_file_system_stub.dart
+++ b/lib/services/toll_segments_file_system_stub.dart
@@ -1,11 +1,13 @@
+import 'package:toll_cam_finder/core/app_messages.dart';
+
 import 'toll_segments_file_system.dart';
 
 class UnsupportedTollSegmentsFileSystem extends TollSegmentsFileSystem {
   const UnsupportedTollSegmentsFileSystem();
 
   Future<T> _unsupported<T>() {
-    throw const TollSegmentsFileSystemException(
-      'File system operations are not supported on this platform.',
+    throw TollSegmentsFileSystemException(
+      AppMessages.fileSystemOperationsNotSupported,
     );
   }
 


### PR DESCRIPTION
## Summary
- add missing localization keys and accessors for speed dials, language labels, and local segment messages
- replace remaining user-facing literals across widgets and services with AppMessages lookups
- ensure language options, placeholders, and error messages respect the active locale

## Testing
- not run (Flutter/Dart SDK unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e6055b3490832db4d83e075b87412d