### PR TITLE
Use system alert sound for upcoming segment cue

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:latlong2/latlong.dart';
 
 class AppConstants {
@@ -116,6 +117,13 @@ class AppConstants {
   ///react quickly (less smoothing, more jitter); lengthening it keeps motion buttery
   /// smooth but lags further behind abrupt path changes.
   static const double smoothingHalfLifeMs = 400.0;
+
+  /// Distance (in meters) at which the upcoming-segment audio cue is triggered.
+  static const double upcomingSegmentCueDistanceMeters = 500.0;
+
+  /// System sound that plays when a new segment is approaching.
+  static const SystemSoundType upcomingSegmentCueSoundType =
+      SystemSoundType.alert;
 
   /// Sets the distance scale that boosts the smoothing factor when the raw fix
   /// diverges sharply from the smoothed track. Lowering it means even modest

--- a/lib/services/audio/segment_audio_cues.dart
+++ b/lib/services/audio/segment_audio_cues.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'package:toll_cam_finder/core/constants.dart';
+
+/// Plays short audio cues associated with toll segments.
+class SegmentAudioCues {
+  SegmentAudioCues({SystemSoundType? upcomingSegmentSoundType})
+      : _upcomingSegmentSoundType = upcomingSegmentSoundType ??
+            AppConstants.upcomingSegmentCueSoundType;
+
+  final SystemSoundType _upcomingSegmentSoundType;
+
+  bool _disposed = false;
+
+  /// Plays the notification sound that indicates the next segment is nearby.
+  Future<void> playUpcomingSegmentCue() async {
+    if (_disposed) return;
+    try {
+      await SystemSound.play(_upcomingSegmentSoundType);
+    } catch (error, stackTrace) {
+      debugPrint(
+        'SegmentAudioCues: failed to play upcoming segment cue: $error\n$stackTrace',
+      );
+    }
+  }
+
+  /// No-op dispose to preserve the previous API shape.
+  Future<void> dispose() async {
+    _disposed = true;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the bundled audio asset with the built-in system alert sound for the upcoming segment cue
- expose the sound type through constants while removing the extra audioplayers dependency

## Testing
- `flutter pub get` *(fails: flutter is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8a53ee8c0832d8cc5e361398fffad