### PR TITLE
Validate segment inputs before saving segment

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -222,6 +222,7 @@ class AppLocalizations {
       'syncRemovedMany': '{count} segments removed',
       'syncRemovedOne': '{count} segment removed',
       'syncTotalSegmentsSummary': '{count} total segments available.',
+      'segmentNameRequired': 'Segment name is required.',
       'startEndCoordinatesRequired': 'Start and end coordinates are required.',
       'submitSegmentForPublicReviewSubtitle':
           'Submit this segment for public review.',
@@ -337,6 +338,8 @@ class AppLocalizations {
       'recenter': 'Центрирай Екрана',
       'saveLocallyAction': 'Save locally',
       'saveSegment': 'Запази сегмента',
+      'segmentNameRequired': 'Моля, въведете име на сегмента.',
+      'startEndCoordinatesRequired': 'Моля, въведете начални и крайни координати.',
       'segmentDebugDistanceKilometersLeft': '{distance} км оставащи',
       'segmentDebugDistanceMeters': '{distance} м',
       'segmentDebugHeadingDiff': 'Δθ={angle}°',

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -278,6 +278,8 @@ class AppMessages {
   static String get loginAction => _l.translate('loginAction');
   static String get failedToSaveSegmentLocally =>
       _l.translate('failedToSaveSegmentLocally');
+  static String get segmentNameRequired =>
+      _l.translate('segmentNameRequired');
   static String get startEndCoordinatesRequired =>
       _l.translate('startEndCoordinatesRequired');
   static String get loggedInRetrySavePrompt =>

--- a/lib/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart
+++ b/lib/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart
@@ -6,16 +6,19 @@ class SegmentLabeledTextField extends StatelessWidget {
     required this.controller,
     required this.label,
     this.hintText,
+    this.focusNode,
   });
 
   final TextEditingController controller;
   final String label;
   final String? hintText;
+  final FocusNode? focusNode;
 
   @override
   Widget build(BuildContext context) {
     return TextField(
       controller: controller,
+      focusNode: focusNode,
       decoration: InputDecoration(
         labelText: label,
         hintText: hintText,

--- a/lib/presentation/pages/create_segment_page.dart
+++ b/lib/presentation/pages/create_segment_page.dart
@@ -31,6 +31,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
   final TextEditingController _endNameController = TextEditingController();
   final TextEditingController _startController = TextEditingController();
   final TextEditingController _endController = TextEditingController();
+  final FocusNode _nameFocusNode = FocusNode();
   final LocalSegmentsService _localSegmentsService = LocalSegmentsService();
   bool _persistDraftOnDispose = true;
   bool _isNavigatingToLogin = false;
@@ -81,6 +82,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     _endNameController.dispose();
     _startController.dispose();
     _endController.dispose();
+    _nameFocusNode.dispose();
     super.dispose();
   }
 
@@ -192,6 +194,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
                                   controller: _nameController,
                                   label: AppMessages.createSegmentNameLabel,
                                   hintText: AppMessages.createSegmentNameHint,
+                                  focusNode: _nameFocusNode,
                                 ),
                                 SegmentLabeledTextField(
                                   controller: _roadNameController,
@@ -225,6 +228,10 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
   }
 
   Future<void> _onSavePressed() async {
+    if (!_validateRequiredInputs()) {
+      return;
+    }
+
     final visibilityChoice = await showDialog<_SegmentVisibilityChoice>(
       context: context,
       builder: (context) {
@@ -272,6 +279,22 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
         }
         break;
     }
+  }
+
+  bool _validateRequiredInputs() {
+    if (_nameController.text.trim().isEmpty) {
+      _showSnackBar(AppMessages.segmentNameRequired);
+      FocusScope.of(context).requestFocus(_nameFocusNode);
+      return false;
+    }
+
+    if (_startController.text.trim().isEmpty ||
+        _endController.text.trim().isEmpty) {
+      _showSnackBar(AppMessages.startEndCoordinatesRequired);
+      return false;
+    }
+
+    return true;
   }
 
   Future<bool?> _showConfirmationDialog({required String message}) {


### PR DESCRIPTION
## Summary
- validate required fields before showing the visibility dialog on the create segment page
- add localized copy and focus handling to guide users to missing inputs

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ea5ede4448832d9e5de81ee4d05272