### PR TITLE
Improve validation when saving segments

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -43,6 +43,13 @@ class AppLocalizations {
       'createSegmentEndCoordinatesLabel': 'End point',
       'createSegmentEndLabel': 'End',
       'createSegmentEndNameHint': 'End name',
+      'createSegmentMissingFields':
+          'Please provide the following before saving: {fields}.',
+      'createSegmentMissingFieldSegmentName': 'segment name',
+      'createSegmentMissingFieldStartCoordinates': 'start coordinates',
+      'createSegmentMissingFieldEndCoordinates': 'end coordinates',
+      'createSegmentMissingFieldsDelimiter': ', ',
+      'createSegmentMissingFieldsConjunction': 'and',
       'createSegmentMapInstructionBody':
           'Drop or drag markers to adjust the start and end points. Coordinates are filled automatically as you move them.',
       'createSegmentMapInstructionTitle':
@@ -300,10 +307,17 @@ class AppLocalizations {
 'createSegment': 'Създай сегмент',
 'createSegmentDetailsTitle': 'Детайли за сегмента',
 'createSegmentEndCoordinatesHint': '41.8322163,26.1404669',
-'createSegmentEndCoordinatesLabel': 'Крайна точка',
-'createSegmentEndLabel': 'Край',
-'createSegmentEndNameHint': 'Име на края',
-'createSegmentMapInstructionBody':
+      'createSegmentEndCoordinatesLabel': 'Крайна точка',
+      'createSegmentEndLabel': 'Край',
+      'createSegmentEndNameHint': 'Име на края',
+      'createSegmentMissingFields':
+          'Моля, попълни следните полета преди да запазиш: {fields}.',
+      'createSegmentMissingFieldSegmentName': 'име на сегмента',
+      'createSegmentMissingFieldStartCoordinates': 'начални координати',
+      'createSegmentMissingFieldEndCoordinates': 'крайни координати',
+      'createSegmentMissingFieldsDelimiter': ', ',
+      'createSegmentMissingFieldsConjunction': 'и',
+      'createSegmentMapInstructionBody':
 'Постави или премести маркерите, за да коригираш началната и крайната точка. Координатите се попълват автоматично при преместване.',
 'createSegmentMapInstructionTitle': 'Поставете началната и крайната точка на картата',
 'createSegmentNameHint': 'Име на сегмента',

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -203,6 +203,18 @@ class AppMessages {
       _l.translate('createSegmentEndCoordinatesLabel');
   static String get createSegmentEndCoordinatesHint =>
       _l.translate('createSegmentEndCoordinatesHint');
+  static String createSegmentMissingFields(String fields) =>
+      _l.translate('createSegmentMissingFields', {'fields': fields});
+  static String get createSegmentMissingFieldSegmentName =>
+      _l.translate('createSegmentMissingFieldSegmentName');
+  static String get createSegmentMissingFieldStartCoordinates =>
+      _l.translate('createSegmentMissingFieldStartCoordinates');
+  static String get createSegmentMissingFieldEndCoordinates =>
+      _l.translate('createSegmentMissingFieldEndCoordinates');
+  static String get createSegmentMissingFieldsDelimiter =>
+      _l.translate('createSegmentMissingFieldsDelimiter');
+  static String get createSegmentMissingFieldsConjunction =>
+      _l.translate('createSegmentMissingFieldsConjunction');
   static String failedToLoadCameras(String error) =>
       _l.translate('failedToLoadCameras', {'error': error});
   static String get failedToAccessSegmentsMetadataFile =>

--- a/lib/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart
+++ b/lib/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart
@@ -6,16 +6,19 @@ class SegmentLabeledTextField extends StatelessWidget {
     required this.controller,
     required this.label,
     this.hintText,
+    this.focusNode,
   });
 
   final TextEditingController controller;
   final String label;
   final String? hintText;
+  final FocusNode? focusNode;
 
   @override
   Widget build(BuildContext context) {
     return TextField(
       controller: controller,
+      focusNode: focusNode,
       decoration: InputDecoration(
         labelText: label,
         hintText: hintText,


### PR DESCRIPTION
## Summary
- prevent the save flow from continuing when required segment fields are missing
- show a localized message that lists the inputs the user still needs to provide
- wire the segment name field to a focus node so the user can correct it quickly

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea60058300832d8c67f59392aaf184