### PR TITLE
Fix Bulgarian locale registration to restore Cyrillic input

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -6,7 +6,7 @@ class AppLocalizations {
 
   final Locale locale;
 
-  static const supportedLanguageCodes = ['en', 'es'];
+  static const supportedLanguageCodes = ['en', 'bg'];
 
   static const Map<String, Map<String, String>> _localizedStrings = {
     'en': {
@@ -109,7 +109,7 @@ class AppLocalizations {
       'joinTollCam': 'Join TollCam',
       'language': 'Language',
       'languageLabelEnglish': 'English',
-      'languageLabelSpanish': 'Bulgarian',
+      'languageLabelBulgarian': 'Bulgarian',
       'languageButton': 'Change language',
       'localSegments': 'Local segments',
       'logIn': 'Log in',
@@ -283,7 +283,7 @@ class AppLocalizations {
       'yesAction': 'Yes',
       'yourProfile': 'Your profile',
     },
-    'es': {
+    'bg': {
 'appTitle': 'TollCam',
 'chooseSegmentVisibilityQuestion':
 'Искаш ли сегментът да бъде видим публично?',
@@ -332,8 +332,8 @@ class AppLocalizations {
 'fullNameLabel': 'Пълно име',
 'joinTollCam': 'Присъедини се към TollCam',
 'language': 'Език',
-'languageLabelEnglish': 'Английски',
-'languageLabelSpanish': 'Български',
+      'languageLabelEnglish': 'Английски',
+      'languageLabelBulgarian': 'Български',
 'languageButton': 'Смени езика',
 'localSegments': 'Локални сегменти',
 'loginAction': 'Вход',

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -29,8 +29,8 @@ class AppMessages {
       _l.translate('segmentPickerEndMarkerLabel');
   static String get languageLabelEnglish =>
       _l.translate('languageLabelEnglish');
-  static String get languageLabelSpanish =>
-      _l.translate('languageLabelSpanish');
+  static String get languageLabelBulgarian =>
+      _l.translate('languageLabelBulgarian');
   static String get personalSegmentDefaultName =>
       _l.translate('personalSegmentDefaultName');
   static String segmentDefaultStartName(String name) =>

--- a/lib/services/language_controller.dart
+++ b/lib/services/language_controller.dart
@@ -16,8 +16,8 @@ class LanguageOption {
 
   String get label {
     switch (languageCode) {
-      case 'es':
-        return AppMessages.languageLabelSpanish;
+      case 'bg':
+        return AppMessages.languageLabelBulgarian;
       case 'en':
       default:
         return AppMessages.languageLabelEnglish;
@@ -37,8 +37,8 @@ class LanguageController extends ChangeNotifier {
       available: true,
     ),
     LanguageOption(
-      locale: Locale('es'),
-      languageCode: 'es',
+      locale: Locale('bg'),
+      languageCode: 'bg',
       available: true,
     ),
   ];


### PR DESCRIPTION
## Summary
- register Bulgarian translations under the correct `bg` locale so Flutter loads Cyrillic-capable fonts
- update localization helpers and language picker labels to use the Bulgarian language key

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea621e2aac832d961aae3f1150882b