### PR TITLE
Allow Cyrillic input for segment text fields

### DIFF
--- a/lib/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart
+++ b/lib/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class SegmentLabeledTextField extends StatelessWidget {
   const SegmentLabeledTextField({
@@ -14,11 +16,20 @@ class SegmentLabeledTextField extends StatelessWidget {
   final String? hintText;
   final FocusNode? focusNode;
 
+  @visibleForTesting
+  static const RegExp allowedCharactersPattern = RegExp(
+    r'[\p{L}\p{M}\p{N}\p{P}\p{S}\p{Zs}]',
+    unicode: true,
+  );
+
   @override
   Widget build(BuildContext context) {
     return TextField(
       controller: controller,
       focusNode: focusNode,
+      inputFormatters: const [
+        FilteringTextInputFormatter.allow(allowedCharactersPattern),
+      ],
       decoration: InputDecoration(
         labelText: label,
         hintText: hintText,

--- a/test/presentation/pages/create_segment/widgets/segment_labeled_text_field_test.dart
+++ b/test/presentation/pages/create_segment/widgets/segment_labeled_text_field_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:toll_cam_finder/presentation/pages/create_segment/widgets/segment_labeled_text_field.dart';
+
+void main() {
+  group('SegmentLabeledTextField allowedCharactersPattern', () {
+    const formatter = FilteringTextInputFormatter.allow(
+      SegmentLabeledTextField.allowedCharactersPattern,
+    );
+
+    test('retains Cyrillic input', () {
+      const value = TextEditingValue(text: 'Улица Шипка');
+      final result = formatter.formatEditUpdate(TextEditingValue.empty, value);
+
+      expect(result.text, value.text);
+    });
+
+    test('removes unsupported control characters', () {
+      const value = TextEditingValue(text: 'Road 1\nSecond line\t');
+      final result = formatter.formatEditUpdate(TextEditingValue.empty, value);
+
+      expect(result.text, 'Road 1Second line');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow segment and road text fields to accept any printable Unicode characters so Cyrillic names are not filtered out
- add tests to confirm Cyrillic input is preserved and control characters are removed by the formatter

## Testing
- Not run (flutter is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ea6456cd30832db0b88a54da54bd8b