### PR TITLE
Add background tracking mode with notification

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application

--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -154,6 +154,18 @@ class AppConstants {
   /// user is stationary, which wastes battery and heats devices unnecessarily.
   static const int gpsDistanceFilterMeters = 5;
 
+  /// Human readable channel name for the persistent location notification.
+  static const String backgroundNotificationChannelName =
+      'Segment monitoring';
+
+  /// Title shown on the persistent notification while tracking in background.
+  static const String backgroundNotificationTitle =
+      'Toll Cam Finder running';
+
+  /// Message describing why the notification is present while tracking.
+  static const String backgroundNotificationText =
+      'Monitoring toll segments and average speed.';
+
   /// HTTP user-agent package identifier sent to the tile server; replace with a
   /// real app id to stay within OpenStreetMap usage policy.
   static const String userAgentPackageName = 'com.example.toll_cam';


### PR DESCRIPTION
## Summary
- add Android permissions required for background tracking notifications
- define shared notification copy and extend the location service to launch a foreground service when backgrounded
- observe the app lifecycle on the map page to swap location streams, maintain segment/audio updates, and suppress UI work while in background mode

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ea73c2b0c8832d9e1f86c338608057