### PR TITLE
Add background notification when app goes inactive

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="toll_cam_finder"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,10 +43,12 @@
 		</array>
 		<key>CADisableMinimumFrameDurationOnPhone</key>
 		<true />
-		<key>UIApplicationSupportsIndirectInputEvents</key>
-		<true />
-		<key>NSLocationWhenInUseUsageDescription</key>
-		<string>We use your location to show your current position on the map.</string>
+                <key>UIApplicationSupportsIndirectInputEvents</key>
+                <true />
+                <key>NSLocationWhenInUseUsageDescription</key>
+                <string>We use your location to show your current position on the map.</string>
+                <key>NSUserNotificationUsageDescription</key>
+                <string>We send notifications to remind you that the Toll App is active in the background.</string>
 
-	</dict>
+        </dict>
 </plist>

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -6,6 +6,7 @@ import '../services/language_controller.dart';
 import 'app_routes.dart';
 import 'app_theme.dart';
 import 'localization/app_localizations.dart';
+import 'lifecycle_observer.dart';
 
 class TollCamApp extends StatelessWidget {
   const TollCamApp({super.key});
@@ -15,20 +16,22 @@ class TollCamApp extends StatelessWidget {
     return Consumer<LanguageController>(
       builder: (context, languageController, _) {
         final appLocalizations = AppLocalizations(languageController.locale);
-        return MaterialApp(
-          title: appLocalizations.appTitle,
-          theme: buildAppTheme(),
-          initialRoute: AppRoutes.map,
-          routes: AppRoutes.routes,
-          debugShowCheckedModeBanner: false,
-          locale: languageController.locale,
-          supportedLocales: languageController.supportedLocales,
-          localizationsDelegates: const [
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-            AppLocalizationsDelegate(),
-          ],
+        return LifecycleObserver(
+          child: MaterialApp(
+            title: appLocalizations.appTitle,
+            theme: buildAppTheme(),
+            initialRoute: AppRoutes.map,
+            routes: AppRoutes.routes,
+            debugShowCheckedModeBanner: false,
+            locale: languageController.locale,
+            supportedLocales: languageController.supportedLocales,
+            localizationsDelegates: const [
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+              AppLocalizationsDelegate(),
+            ],
+          ),
         );
       },
     );

--- a/lib/app/lifecycle_observer.dart
+++ b/lib/app/lifecycle_observer.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+import 'package:toll_cam_finder/services/background_notification_service.dart';
+
+class LifecycleObserver extends StatefulWidget {
+  const LifecycleObserver({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  State<LifecycleObserver> createState() => _LifecycleObserverState();
+}
+
+class _LifecycleObserverState extends State<LifecycleObserver>
+    with WidgetsBindingObserver {
+  BackgroundNotificationService? _notificationService;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _notificationService ??=
+        Provider.of<BackgroundNotificationService>(context, listen: false);
+    _notificationService?.cancelActiveNotification();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _notificationService?.cancelActiveNotification();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.paused:
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+        _notificationService?.showActiveNotification();
+        break;
+      case AppLifecycleState.resumed:
+        _notificationService?.cancelActiveNotification();
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,11 +7,14 @@ import 'package:toll_cam_finder/services/average_speed_est.dart';
 import 'app/app.dart';
 import 'services/auth_controller.dart';
 import 'services/language_controller.dart';
+import 'services/background_notification_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   SupabaseClient? supabaseClient;
+  final backgroundNotificationService = BackgroundNotificationService();
+  await backgroundNotificationService.initialize();
 
   if (SupabaseConfig.isConfigured) {
     final supabase = await Supabase.initialize(
@@ -36,6 +39,9 @@ void main() async {
         ),
         ChangeNotifierProvider(
           create: (_) => LanguageController(),
+        ),
+        Provider<BackgroundNotificationService>.value(
+          value: backgroundNotificationService,
         ),
       ],
       child: const TollCamApp(),

--- a/lib/services/background_notification_service.dart
+++ b/lib/services/background_notification_service.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+class BackgroundNotificationService {
+  BackgroundNotificationService()
+      : _plugin = FlutterLocalNotificationsPlugin();
+
+  final FlutterLocalNotificationsPlugin _plugin;
+  static const int _notificationId = 1001;
+  static const String _channelId = 'toll_app_background_channel';
+  static const String _channelName = 'Toll App Background Activity';
+
+  Future<void> initialize() async {
+    const initializationSettings = InitializationSettings(
+      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+      iOS: DarwinInitializationSettings(),
+    );
+
+    await _plugin.initialize(initializationSettings);
+
+    await _requestPermissions();
+  }
+
+  Future<void> _requestPermissions() async {
+    await _plugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.requestNotificationsPermission();
+
+    await _plugin
+        .resolvePlatformSpecificImplementation<
+            DarwinFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+  }
+
+  Future<void> showActiveNotification() async {
+    const androidDetails = AndroidNotificationDetails(
+      _channelId,
+      _channelName,
+      channelDescription: 'Notifies that the Toll app is running in the background.',
+      importance: Importance.high,
+      priority: Priority.high,
+      ongoing: true,
+      autoCancel: false,
+    );
+
+    const iosDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
+    );
+
+    const notificationDetails = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
+
+    await _plugin.show(
+      _notificationId,
+      'Toll Cam Finder',
+      'The Toll App is active',
+      notificationDetails,
+    );
+  }
+
+  Future<void> cancelActiveNotification() async {
+    await _plugin.cancel(_notificationId);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   supabase_flutter: ^2.10.1
   uuid: ^4.4.0
   audioplayers: ^6.5.1
+  flutter_local_notifications: ^17.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a background notification service that initializes local notifications and shows an "The Toll App is active" message when the app leaves the foreground
- wrap the root MaterialApp with a lifecycle observer to trigger notifications on pause and clear them on resume
- add the required Android permission, iOS usage description, and dependency wiring for flutter_local_notifications

## Testing
- not run (Flutter and Dart SDKs are unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68eb6244e728832d84888fb25fcefde5