### PR TITLE
Add dynamic background notification updates for segment status

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -184,6 +184,13 @@ class AppLocalizations {
       'segmentProgressStartKilometers': '{distance} km to segment start',
       'segmentProgressStartMeters': '{distance} m to segment start',
       'segmentProgressStartNearby': 'Segment start nearby',
+      'segmentStatusNoNearby': 'No segment nearby',
+      'segmentStatusStartKilometers': '{distance} km to segment start',
+      'segmentStatusStartMeters': '{distance} m to segment start',
+      'segmentStatusStartNearby': 'Segment start nearby',
+      'segmentStatusActiveWithLimit':
+          'Limit {limit} km/h · Avg {average} km/h',
+      'segmentStatusActiveNoLimit': 'Avg {average} km/h on segment',
       'segmentSavedLocally': 'Segment saved locally.',
       'segmentDefaultStartName': '{name} start',
       'segmentDefaultEndName': '{name} end',
@@ -369,6 +376,13 @@ class AppLocalizations {
 '{distance} км до началото на сегмента',
 'segmentProgressStartMeters': '{distance} м до началото на сегмента',
 'segmentProgressStartNearby': 'Началото на сегмента е близо',
+'segmentStatusNoNearby': 'Няма близък сегмент',
+'segmentStatusStartKilometers': '{distance} км до началото на сегмента',
+'segmentStatusStartMeters': '{distance} м до началото на сегмента',
+'segmentStatusStartNearby': 'Началото на сегмента е близо',
+'segmentStatusActiveWithLimit':
+'Ограничение {limit} км/ч · Ср. скорост {average} км/ч',
+'segmentStatusActiveNoLimit': 'Ср. скорост {average} км/ч в сегмента',
 'segments': 'Сегменти',
 'selectLanguage': 'Избери език',
 'signInToSharePubliclyBody':

--- a/lib/services/background_notification_service.dart
+++ b/lib/services/background_notification_service.dart
@@ -8,6 +8,32 @@ class BackgroundNotificationService {
   static const int _notificationId = 1001;
   static const String _channelId = 'toll_app_background_channel';
   static const String _channelName = 'Toll App Background Activity';
+  static const AndroidNotificationDetails _androidDetails =
+      AndroidNotificationDetails(
+    _channelId,
+    _channelName,
+    channelDescription:
+        'Notifies that the Toll app is running in the background.',
+    importance: Importance.high,
+    priority: Priority.high,
+    ongoing: true,
+    autoCancel: false,
+  );
+
+  static const DarwinNotificationDetails _iosDetails =
+      DarwinNotificationDetails(
+    presentAlert: true,
+    presentBadge: true,
+    presentSound: true,
+  );
+
+  static const NotificationDetails _notificationDetails = NotificationDetails(
+    android: _androidDetails,
+    iOS: _iosDetails,
+  );
+
+  bool _isNotificationVisible = false;
+  String _lastStatusMessage = 'The Toll App is active';
 
   Future<void> initialize() async {
     const initializationSettings = InitializationSettings(
@@ -36,37 +62,35 @@ class BackgroundNotificationService {
         );
   }
 
-  Future<void> showActiveNotification() async {
-    const androidDetails = AndroidNotificationDetails(
-      _channelId,
-      _channelName,
-      channelDescription: 'Notifies that the Toll app is running in the background.',
-      importance: Importance.high,
-      priority: Priority.high,
-      ongoing: true,
-      autoCancel: false,
-    );
-
-    const iosDetails = DarwinNotificationDetails(
-      presentAlert: true,
-      presentBadge: true,
-      presentSound: true,
-    );
-
-    const notificationDetails = NotificationDetails(
-      android: androidDetails,
-      iOS: iosDetails,
-    );
+  Future<void> showActiveNotification({String? body}) async {
+    final String message = body ?? _lastStatusMessage;
+    _lastStatusMessage = message;
 
     await _plugin.show(
       _notificationId,
       'Toll Cam Finder',
-      'The Toll App is active',
-      notificationDetails,
+      message,
+      _notificationDetails,
     );
+    _isNotificationVisible = true;
   }
 
   Future<void> cancelActiveNotification() async {
+    _isNotificationVisible = false;
     await _plugin.cancel(_notificationId);
+  }
+
+  Future<void> updateStatus(String body, {String? title}) async {
+    _lastStatusMessage = body;
+    if (!_isNotificationVisible) {
+      return;
+    }
+
+    await _plugin.show(
+      _notificationId,
+      title ?? 'Toll Cam Finder',
+      body,
+      _notificationDetails,
+    );
   }
 }


### PR DESCRIPTION
## Summary
- make the background notification reusable so the status text can be updated in-place
- surface segment tracking data to build the notification message, trigger the 500 m cue, and persist the latest status
- add localized strings for the new notification states in English and Bulgarian

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68eb6950a700832da2d6a03cff06b9b3