### PR TITLE
Improve notification tap handling

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -6,6 +6,7 @@ import '../services/language_controller.dart';
 import 'app_routes.dart';
 import 'app_theme.dart';
 import 'localization/app_localizations.dart';
+import 'navigation/app_navigator.dart';
 import 'lifecycle_observer.dart';
 
 class TollCamApp extends StatelessWidget {
@@ -22,6 +23,7 @@ class TollCamApp extends StatelessWidget {
             theme: buildAppTheme(),
             initialRoute: AppRoutes.map,
             routes: AppRoutes.routes,
+            navigatorKey: AppNavigator.navigatorKey,
             debugShowCheckedModeBanner: false,
             locale: languageController.locale,
             supportedLocales: languageController.supportedLocales,

--- a/lib/app/navigation/app_navigator.dart
+++ b/lib/app/navigation/app_navigator.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+
+import '../app_routes.dart';
+
+/// Provides a global navigator key so services can interact with the
+/// navigation stack when the app is restored from the background.
+class AppNavigator {
+  AppNavigator._();
+
+  static final GlobalKey<NavigatorState> navigatorKey =
+      GlobalKey<NavigatorState>();
+
+  /// Ensures the map route is visible when the app is resumed from the
+  /// background via a notification tap.
+  static void bringToForeground() {
+    final navigator = navigatorKey.currentState;
+    if (navigator == null) return;
+
+    navigator.pushNamedAndRemoveUntil(AppRoutes.map, (route) => false);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:toll_cam_finder/core/supabase_config.dart';
 import 'package:toll_cam_finder/services/average_speed_est.dart';
 
 import 'app/app.dart';
+import 'app/navigation/app_navigator.dart';
 import 'services/auth_controller.dart';
 import 'services/language_controller.dart';
 import 'services/background_notification_service.dart';
@@ -14,7 +15,9 @@ void main() async {
 
   SupabaseClient? supabaseClient;
   final backgroundNotificationService = BackgroundNotificationService();
-  await backgroundNotificationService.initialize();
+  await backgroundNotificationService.initialize(
+    onNotificationTap: AppNavigator.bringToForeground,
+  );
 
   if (SupabaseConfig.isConfigured) {
     final supabase = await Supabase.initialize(

--- a/lib/services/background_notification_service.dart
+++ b/lib/services/background_notification_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 class BackgroundNotificationService {
@@ -8,16 +9,30 @@ class BackgroundNotificationService {
   static const int _notificationId = 1001;
   static const String _channelId = 'toll_app_background_channel';
   static const String _channelName = 'Toll App Background Activity';
+  static const String _defaultPayload = 'resume-app';
 
-  Future<void> initialize() async {
+  VoidCallback? _onNotificationTap;
+
+  Future<void> initialize({VoidCallback? onNotificationTap}) async {
+    _onNotificationTap = onNotificationTap;
     const initializationSettings = InitializationSettings(
       android: AndroidInitializationSettings('@mipmap/ic_launcher'),
       iOS: DarwinInitializationSettings(),
     );
 
-    await _plugin.initialize(initializationSettings);
+    await _plugin.initialize(
+      initializationSettings,
+      onDidReceiveNotificationResponse: _handleNotificationResponse,
+    );
 
     await _requestPermissions();
+  }
+
+  void _handleNotificationResponse(NotificationResponse response) {
+    if (response.id != _notificationId) return;
+
+    cancelActiveNotification();
+    _onNotificationTap?.call();
   }
 
   Future<void> _requestPermissions() async {
@@ -63,6 +78,7 @@ class BackgroundNotificationService {
       'Toll Cam Finder',
       'The Toll App is active',
       notificationDetails,
+      payload: _defaultPayload,
     );
   }
 


### PR DESCRIPTION
## Summary
- add a global navigator key so services can manipulate the navigation stack
- register a notification tap handler that cancels the ongoing notification and restores the map route when the reminder is tapped
- expose the navigator key through the app widget tree so the background notification service can route correctly

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb6ce94f3c832d918217f794ea611b