### PR TITLE
Enable background location tracking

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -23,7 +23,15 @@ class LocationService {
       settings = AndroidSettings(
         accuracy: LocationAccuracy.high,
         distanceFilter: AppConstants.gpsDistanceFilterMeters,
-        intervalDuration: Duration(milliseconds: AppConstants.gpsSampleIntervalMs),
+        intervalDuration:
+            Duration(milliseconds: AppConstants.gpsSampleIntervalMs),
+        foregroundNotificationConfig: const ForegroundNotificationConfig(
+          notificationTitle: 'Toll Cam Finder is active',
+          notificationText:
+              'Monitoring toll segments while the app is in the background.',
+          enableWakeLock: true,
+          setOngoing: true,
+        ),
       );
     } else if (Platform.isIOS || Platform.isMacOS) {
       settings = AppleSettings(

--- a/lib/services/permission_service.dart
+++ b/lib/services/permission_service.dart
@@ -7,6 +7,9 @@ class PermissionService {
     if (perm == LocationPermission.denied) {
       perm = await Geolocator.requestPermission();
     }
+    if (perm == LocationPermission.whileInUse) {
+      perm = await Geolocator.requestPermission();
+    }
     return perm == LocationPermission.always ||
         perm == LocationPermission.whileInUse;
   }


### PR DESCRIPTION
## Summary
- keep the Android location stream alive in the background by providing a foreground notification configuration
- add the Android permissions required to run the location stream and notification while the app is backgrounded
- request upgraded background location permission when the user initially grants only in-use access

## Testing
- `flutter analyze` *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb73c90960832db1510844d46cecb0