### PR TITLE
Update background notification with segment status

### DIFF
--- a/lib/services/notification_permission_service.dart
+++ b/lib/services/notification_permission_service.dart
@@ -54,4 +54,26 @@ class NotificationPermissionService {
       // Ignored: opening settings is a best-effort operation.
     }
   }
+
+  Future<void> updateForegroundNotification({
+    required String title,
+    required String text,
+    required String iconName,
+    required String iconType,
+  }) async {
+    if (!Platform.isAndroid) {
+      return;
+    }
+
+    try {
+      await _channel.invokeMethod<void>('updateForegroundNotification', {
+        'title': title,
+        'text': text,
+        'iconName': iconName,
+        'iconType': iconType,
+      });
+    } on PlatformException {
+      // Ignore failures: the foreground notification is a best-effort status.
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- reuse the provider-managed average speed controller and remember the latest segment tracker event so background samples keep accumulating
- surface segment proximity or average-speed status text through the foreground service notification and reduce the warning chime to 500 m
- extend the Android notification channel handler so Dart can update the geolocator foreground notification

## Testing
- not run (environment-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eb9af74aa4832dae5e00b14b24be08