### PR TITLE
Fix average speed tracking during stops

### DIFF
--- a/lib/services/average_speed_est.dart
+++ b/lib/services/average_speed_est.dart
@@ -1,37 +1,119 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 /// Tracks average speed (same unit as fed samples).
 class AverageSpeedController extends ChangeNotifier {
+  static const int _millisecondsPerHour = 1000 * 60 * 60;
+
   bool _isRunning = false;
-  int _sampleCount = 0;
-  double _sum = 0.0;
+  double _distanceKm = 0.0;
+  double _lastSpeedKph = 0.0;
+  DateTime? _lastSampleAt;
   DateTime? _startedAt;
+  Timer? _ticker;
 
   bool get isRunning => _isRunning;
   DateTime? get startedAt => _startedAt;
-  int get sampleCount => _sampleCount;
-  double get average => (_isRunning && _sampleCount > 0) ? _sum / _sampleCount : 0.0;
+
+  double get average {
+    if (!_isRunning || _startedAt == null) {
+      return 0.0;
+    }
+
+    final DateTime now = DateTime.now();
+    final double elapsedHours = _elapsedHours(_startedAt!, now);
+    if (elapsedHours <= 0) {
+      return 0.0;
+    }
+
+    final double totalDistanceKm =
+        _distanceKm + _distanceSinceLastSample(now: now, speedKph: _lastSpeedKph);
+    if (totalDistanceKm <= 0) {
+      return 0.0;
+    }
+
+    return totalDistanceKm / elapsedHours;
+  }
 
   void start() {
     _isRunning = true;
-    _sampleCount = 0;
-    _sum = 0.0;
-    _startedAt = DateTime.now();
+    _distanceKm = 0.0;
+    _lastSpeedKph = 0.0;
+    final DateTime now = DateTime.now();
+    _startedAt = now;
+    _lastSampleAt = now;
+    _startTicker();
     notifyListeners();
   }
 
   void reset() {
     _isRunning = false;
-    _sampleCount = 0;
-    _sum = 0.0;
+    _distanceKm = 0.0;
+    _lastSpeedKph = 0.0;
+    _lastSampleAt = null;
     _startedAt = null;
+    _stopTicker();
     notifyListeners();
   }
 
-  void addSample(double speed) {
+  void addSample(double speed, {DateTime? timestamp}) {
     if (!_isRunning) return;
-    _sum += speed;
-    _sampleCount++;
+    final double sanitizedSpeed =
+        (speed.isFinite && speed >= 0) ? speed : 0.0;
+    final DateTime now = timestamp ?? DateTime.now();
+
+    if (_lastSampleAt != null) {
+      final double deltaHours = _elapsedHours(_lastSampleAt!, now);
+      if (deltaHours > 0) {
+        _distanceKm += _lastSpeedKph * deltaHours;
+      }
+    }
+
+    _lastSampleAt = now;
+    _lastSpeedKph = sanitizedSpeed;
     notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _stopTicker();
+    super.dispose();
+  }
+
+  double _distanceSinceLastSample({required DateTime now, required double speedKph}) {
+    if (_lastSampleAt == null) {
+      return 0.0;
+    }
+
+    final double deltaHours = _elapsedHours(_lastSampleAt!, now);
+    if (deltaHours <= 0) {
+      return 0.0;
+    }
+
+    return speedKph * deltaHours;
+  }
+
+  double _elapsedHours(DateTime from, DateTime to) {
+    final int deltaMillis = to.difference(from).inMilliseconds;
+    if (deltaMillis <= 0) {
+      return 0.0;
+    }
+
+    return deltaMillis / _millisecondsPerHour;
+  }
+
+  void _startTicker() {
+    _ticker?.cancel();
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (_isRunning) {
+        notifyListeners();
+      }
+    });
+  }
+
+  void _stopTicker() {
+    _ticker?.cancel();
+    _ticker = null;
   }
 }


### PR DESCRIPTION
## Summary
- replace the sample-count based average with a time-weighted calculation that integrates distance travelled
- keep the UI updating while stationary by running a periodic ticker while averaging is active
- sanitize incoming speed samples to avoid negative or non-finite values disrupting the average

## Testing
- Not run (Flutter/Dart tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ebb73de8a4832db016f7a8dae26bc9