### PR TITLE
Remove unused compass integration

### DIFF
--- a/lib/presentation/pages/map_page_options.dart
+++ b/lib/presentation/pages/map_page_options.dart
@@ -161,7 +161,6 @@ Future<void> _refreshSegmentsData() async {
     showMetadataErrors: true,
     userLatLng: _userLatLng,
     speedKmh: _speedKmh,
-    compassHeading: _compassHeading,
   );
 
   _segmentsMetadata = result.metadata;
@@ -204,7 +203,6 @@ Future<void> _performSync() async {
       ignoredSegmentIds: _segmentsMetadata.deactivatedSegmentIds,
       userLatLng: _userLatLng,
       speedKmh: _speedKmh,
-      compassHeading: _compassHeading,
     );
   } finally {
     if (mounted) {

--- a/lib/services/map/map_segments_service.dart
+++ b/lib/services/map/map_segments_service.dart
@@ -137,7 +137,6 @@ class MapSegmentsService {
     required bool showMetadataErrors,
     required LatLng? userLatLng,
     required double? speedKmh,
-    required double? compassHeading,
   }) async {
     final metadataResult =
         await loadSegmentsMetadata(showErrors: showMetadataErrors);
@@ -160,7 +159,6 @@ class MapSegmentsService {
         previous: null,
         rawHeading: null,
         speedKmh: speedKmh,
-        compassHeading: compassHeading,
       );
     }
 
@@ -177,7 +175,6 @@ class MapSegmentsService {
     required Set<String> ignoredSegmentIds,
     required LatLng? userLatLng,
     required double? speedKmh,
-    required double? compassHeading,
   }) async {
     if (client == null) {
       return SegmentsSyncResult(
@@ -203,7 +200,6 @@ class MapSegmentsService {
           previous: null,
           rawHeading: null,
           speedKmh: speedKmh,
-          compassHeading: compassHeading,
         );
       }
 

--- a/lib/services/segment_tracker.dart
+++ b/lib/services/segment_tracker.dart
@@ -64,7 +64,6 @@ class SegmentTracker {
   final Set<String> _fetchFailures = <String>{};
   final Set<String> _fetching = <String>{};
   final List<GeoPoint> _headingHistory = <GeoPoint>[];
-  double? _lastCompassHeadingDeg;
   double? _smoothedHeadingDeg;
   final Set<String> _ignoredSegmentIds = <String>{};
 
@@ -110,7 +109,6 @@ void updateIgnoredSegments(Set<String> ignoredIds) {
     LatLng? previous,
     double? rawHeading,
     double? speedKmh,
-    double? compassHeading,
   }) {
     if (!_isReady) {
       return SegmentTrackerEvent(
@@ -128,7 +126,6 @@ void updateIgnoredSegments(Set<String> ignoredIds) {
       previous,
       rawHeading,
       speedKmh,
-      compassHeading,
     );
 
     final List<SegmentGeometry> candidates = _index.candidatesNearLatLng(
@@ -211,7 +208,6 @@ void updateIgnoredSegments(Set<String> ignoredIds) {
     _fetchFailures.clear();
     _fetching.clear();
     _headingHistory.clear();
-    _lastCompassHeadingDeg = null;
     _smoothedHeadingDeg = null;
     _latestDebugData = const SegmentTrackerDebugData.empty();
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,14 +254,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_compass:
-    dependency: "direct main"
-    description:
-      name: flutter_compass
-      sha256: "1b4d7e6c95a675ec8482b5c9c9ccf1ebf0ced3dbec59dce28ad609da953de850"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_map: ^8.2.1
-  flutter_compass: ^0.8.1
   geolocator: ^14.0.2
   latlong2: ^0.9.1
   provider: ^6.1.5+1


### PR DESCRIPTION
## Summary
- remove the compass subscription and heading plumbing from the map page and related services
- simplify the segment tracker heading resolver to rely solely on positional history
- drop the unused flutter_compass dependency from the project configuration

## Testing
- not run (Flutter/Dart SDK not available in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68ebcac31364832dbbf1e6886bc68ef2