### PR TITLE
Rework average speed tracking to use distance and time

### DIFF
--- a/lib/services/average_speed_est.dart
+++ b/lib/services/average_speed_est.dart
@@ -3,35 +3,117 @@ import 'package:flutter/foundation.dart';
 /// Tracks average speed (same unit as fed samples).
 class AverageSpeedController extends ChangeNotifier {
   bool _isRunning = false;
-  int _sampleCount = 0;
-  double _sum = 0.0;
+  double _distanceMeters = 0.0;
   DateTime? _startedAt;
+  DateTime? _lastSampleAt;
 
   bool get isRunning => _isRunning;
   DateTime? get startedAt => _startedAt;
-  int get sampleCount => _sampleCount;
-  double get average => (_isRunning && _sampleCount > 0) ? _sum / _sampleCount : 0.0;
+  double get distanceMeters => _distanceMeters;
 
-  void start() {
+  /// Duration elapsed between [startedAt] and the most recent sample.
+  Duration? get elapsed {
+    if (_startedAt == null || _lastSampleAt == null) {
+      return null;
+    }
+    final Duration diff = _lastSampleAt!.difference(_startedAt!);
+    if (diff.isNegative) {
+      return Duration.zero;
+    }
+    return diff;
+  }
+
+  double get average {
+    if (!_isRunning) {
+      return 0.0;
+    }
+    final Duration? elapsedDuration = elapsed;
+    if (elapsedDuration == null || elapsedDuration <= Duration.zero) {
+      return 0.0;
+    }
+    final double elapsedHours =
+        elapsedDuration.inMilliseconds / Duration.millisecondsPerSecond / Duration.secondsPerHour;
+    if (elapsedHours <= 0) {
+      return 0.0;
+    }
+    final double distanceKm = _distanceMeters / 1000.0;
+    return distanceKm / elapsedHours;
+  }
+
+  void start({DateTime? startedAt}) {
     _isRunning = true;
-    _sampleCount = 0;
-    _sum = 0.0;
-    _startedAt = DateTime.now();
+    _distanceMeters = 0.0;
+    _startedAt = startedAt ?? DateTime.now();
+    _lastSampleAt = _startedAt;
     notifyListeners();
   }
 
   void reset() {
     _isRunning = false;
-    _sampleCount = 0;
-    _sum = 0.0;
+    _distanceMeters = 0.0;
     _startedAt = null;
+    _lastSampleAt = null;
     notifyListeners();
   }
 
-  void addSample(double speed) {
-    if (!_isRunning) return;
-    _sum += speed;
-    _sampleCount++;
+  void recordProgress({
+    required double distanceDeltaMeters,
+    required DateTime timestamp,
+  }) {
+    if (!_isRunning) {
+      return;
+    }
+
+    if (_startedAt == null) {
+      _startedAt = timestamp;
+    }
+
+    final DateTime clampedTimestamp = timestamp.isBefore(_startedAt!) ? _startedAt! : timestamp;
+    final DateTime? previous = _lastSampleAt;
+    final Duration? delta = previous != null ? clampedTimestamp.difference(previous) : null;
+
+    final double sanitizedDistance =
+        (distanceDeltaMeters.isFinite && distanceDeltaMeters > 0) ? distanceDeltaMeters : 0.0;
+
+    if (sanitizedDistance == 0.0 && (delta == null || delta <= Duration.zero)) {
+      _lastSampleAt = clampedTimestamp;
+      return;
+    }
+
+    _distanceMeters += sanitizedDistance;
+    _lastSampleAt = clampedTimestamp;
     notifyListeners();
   }
+
+  double avgSpeedDone({
+    required double segmentLengthMeters,
+    Duration? segmentDuration,
+  }) {
+    if (!segmentLengthMeters.isFinite || segmentLengthMeters <= 0) {
+      return 0.0;
+    }
+
+    final Duration? duration = segmentDuration ?? elapsed;
+    if (duration == null || duration <= Duration.zero) {
+      return 0.0;
+    }
+
+    final double elapsedHours =
+        duration.inMilliseconds / Duration.millisecondsPerSecond / Duration.secondsPerHour;
+    if (elapsedHours <= 0) {
+      return 0.0;
+    }
+
+    final double distanceKm = segmentLengthMeters / 1000.0;
+    return distanceKm / elapsedHours;
+  }
+
+  double avg_speed_done({
+    required double segmentLengthMeters,
+    Duration? segmentDuration,
+  }) =>
+      avgSpeedDone(
+        segmentLengthMeters: segmentLengthMeters,
+        segmentDuration: segmentDuration,
+      );
 }

--- a/lib/services/segment_tracker/segment_tracker_models.dart
+++ b/lib/services/segment_tracker/segment_tracker_models.dart
@@ -9,6 +9,8 @@ class SegmentTrackerEvent {
     required this.endedSegment,
     required this.activeSegmentId,
     required this.activeSegmentSpeedLimitKph,
+    required this.activeSegmentLengthMeters,
+    required this.completedSegmentLengthMeters,
     required this.debugData,
   });
 
@@ -23,6 +25,12 @@ class SegmentTrackerEvent {
 
   /// Maximum allowed average speed (km/h) for the active segment, if known.
   final double? activeSegmentSpeedLimitKph;
+
+  /// Length of the currently active segment in meters, if known.
+  final double? activeSegmentLengthMeters;
+
+  /// Length of the segment that just completed in meters, if known.
+  final double? completedSegmentLengthMeters;
 
   /// Snapshot of the debug data associated with the update.
   final SegmentTrackerDebugData debugData;


### PR DESCRIPTION
## Summary
- refactor AverageSpeedController to accumulate travelled distance over time and expose avgSpeedDone/avg_speed_done for final segment averages
- update map page handling to feed distance samples, reset per-segment state, and announce true averages when a segment completes
- extend SegmentTracker events with segment length metadata so completion averages can use authoritative distances

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ed2014e1d8832dba08d7edf15c33e4