### PR TITLE
Add guidance audio mute controls

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -113,6 +113,12 @@ class AppLocalizations {
       'languageLabelEnglish': 'English',
       'languageLabelBulgarian': 'Bulgarian',
       'languageButton': 'Change language',
+      'audioModeTitle': 'Guidance audio mode',
+      'audioModeForegroundMuted':
+          'Mute in app (background guidance, start/end dings only)',
+      'audioModeBackgroundMuted':
+          'Mute in background (in-app guidance, start/end dings only)',
+      'audioModeAbsoluteMute': 'Absolute mute (no sounds)',
       'localSegments': 'Local segments',
       'logIn': 'Log in',
       'logOut': 'Log out',
@@ -412,7 +418,13 @@ class AppLocalizations {
 'syncRemovedMany': '{count} сегмента изтрити',
 'syncRemovedOne': '{count} сегмент изтрит',
 'syncTotalSegmentsSummary': 'Общо налични сегменти: {count}.',
-'sync': 'Синхронизирай',
+      'sync': 'Синхронизирай',
+      'audioModeTitle': 'Режим на аудио насоките',
+      'audioModeForegroundMuted':
+          'Заглушено в приложението (активно на заден план, само сигнал при старт/край)',
+      'audioModeBackgroundMuted':
+          'Заглушено на заден план (активно в приложението, само сигнал при старт/край)',
+      'audioModeAbsoluteMute': 'Пълно заглушаване (без звук)',
 'savingLocalSegmentsNotSupportedOnWeb':
 'Запазването на локални сегменти не се поддържа в уеб версията.',
 'loadingLocalSegmentsNotSupportedOnWeb':
@@ -477,6 +489,12 @@ class AppLocalizations {
   String get noLocalSegments => _value('noLocalSegments');
   String get recenter => _value('recenter');
   String get languageButton => _value('languageButton');
+  String get audioModeTitle => _value('audioModeTitle');
+  String get audioModeForegroundMuted =>
+      _value('audioModeForegroundMuted');
+  String get audioModeBackgroundMuted =>
+      _value('audioModeBackgroundMuted');
+  String get audioModeAbsoluteMute => _value('audioModeAbsoluteMute');
   String get welcomeTitle => _value('welcomeTitle');
   String get joinTollCam => _value('joinTollCam');
   String get emailLabel => _value('emailLabel');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:toll_cam_finder/services/average_speed_est.dart';
 import 'app/app.dart';
 import 'services/auth_controller.dart';
 import 'services/language_controller.dart';
+import 'services/guidance_audio_controller.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -36,6 +37,9 @@ void main() async {
         ),
         ChangeNotifierProvider(
           create: (_) => LanguageController(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => GuidanceAudioController(),
         ),
       ],
       child: const TollCamApp(),

--- a/lib/presentation/pages/map_page.dart
+++ b/lib/presentation/pages/map_page.dart
@@ -26,6 +26,7 @@ import '../../services/language_controller.dart';
 import '../../services/location_service.dart';
 import '../../services/notification_permission_service.dart';
 import '../../services/permission_service.dart';
+import '../../services/guidance_audio_controller.dart';
 import '../../services/map/camera_polling_service.dart';
 import '../../services/map/foreground_notification_service.dart';
 import '../../services/map/map_sync_message_service.dart';
@@ -69,6 +70,13 @@ class _MapPageState extends State<MapPage>
   final MapSyncMessageService _syncMessageService =
       const MapSyncMessageService();
   late final MapSegmentsService _segmentsService;
+  late final GuidanceAudioController _audioController;
+  AppLifecycleState _appLifecycleState = AppLifecycleState.resumed;
+  GuidanceAudioPolicy _audioPolicy = const GuidanceAudioPolicy(
+    allowSpeech: true,
+    allowAlertTones: true,
+    allowBoundaryTones: true,
+  );
   // User + map state
   LatLng _center = AppConstants.initialCenter;
   LatLng? _userLatLng;
@@ -118,9 +126,14 @@ class _MapPageState extends State<MapPage>
 
     WidgetsBinding.instance.addObserver(this);
 
+    _appLifecycleState =
+        WidgetsBinding.instance.lifecycleState ?? AppLifecycleState.resumed;
+
     _avgCtrl = context.read<AverageSpeedController>();
     _blueDotAnimator = BlueDotAnimator(vsync: this, onTick: _onBlueDotTick);
     _segmentGuidanceController = SegmentGuidanceController();
+    _audioController = context.read<GuidanceAudioController>();
+    _audioController.addListener(_updateAudioPolicy);
     _segmentsService = MapSegmentsService(
       metadataService: _metadataService,
       segmentTracker: _segmentTracker,
@@ -136,6 +149,7 @@ class _MapPageState extends State<MapPage>
     _mapEvtSub = _mapController.mapEventStream.listen(_onMapEvent);
     unawaited(_initLocation());
     unawaited(_initSegmentsIndex());
+    _updateAudioPolicy();
   }
 
   @override
@@ -146,6 +160,7 @@ class _MapPageState extends State<MapPage>
     _segmentTracker.dispose();
     unawaited(_segmentGuidanceController.dispose());
     unawaited(_upcomingSegmentCueService.dispose());
+    _audioController.removeListener(_updateAudioPolicy);
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -153,12 +168,14 @@ class _MapPageState extends State<MapPage>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
+    _appLifecycleState = state;
     final bool shouldEnableForeground = state != AppLifecycleState.resumed;
     _setForegroundLocationMode(shouldEnableForeground);
     if (state == AppLifecycleState.resumed &&
         _didRequestNotificationPermission) {
       unawaited(_ensureNotificationPermission());
     }
+    _updateAudioPolicy();
   }
 
   Future<void> _initLocation() async {
@@ -199,6 +216,17 @@ class _MapPageState extends State<MapPage>
           useForegroundNotification: _useForegroundLocationService,
         )
         .listen(_handlePositionUpdate);
+  }
+
+  void _updateAudioPolicy() {
+    final GuidanceAudioPolicy newPolicy =
+        _audioController.policyFor(_appLifecycleState);
+    if (newPolicy == _audioPolicy) {
+      return;
+    }
+    _audioPolicy = newPolicy;
+    _segmentGuidanceController.updateAudioPolicy(newPolicy);
+    _upcomingSegmentCueService.updateAudioPolicy(newPolicy);
   }
 
   void _setForegroundLocationMode(bool enable) {

--- a/lib/services/guidance_audio_controller.dart
+++ b/lib/services/guidance_audio_controller.dart
@@ -1,0 +1,121 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+@immutable
+class GuidanceAudioPolicy {
+  const GuidanceAudioPolicy({
+    required this.allowSpeech,
+    required this.allowAlertTones,
+    required this.allowBoundaryTones,
+  });
+
+  final bool allowSpeech;
+  final bool allowAlertTones;
+  final bool allowBoundaryTones;
+
+  bool canPlayTone({required bool isBoundary}) {
+    return isBoundary ? allowBoundaryTones : allowAlertTones;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GuidanceAudioPolicy &&
+        other.allowSpeech == allowSpeech &&
+        other.allowAlertTones == allowAlertTones &&
+        other.allowBoundaryTones == allowBoundaryTones;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        allowSpeech,
+        allowAlertTones,
+        allowBoundaryTones,
+      );
+}
+
+enum GuidanceAudioMode {
+  muteForeground,
+  muteBackground,
+  absoluteMute,
+}
+
+class GuidanceAudioController extends ChangeNotifier {
+  GuidanceAudioController() {
+    unawaited(_loadSavedMode());
+  }
+
+  static const String _preferenceKey = 'guidance_audio_mode';
+
+  static const GuidanceAudioPolicy _fullAccessPolicy = GuidanceAudioPolicy(
+    allowSpeech: true,
+    allowAlertTones: true,
+    allowBoundaryTones: true,
+  );
+
+  static const GuidanceAudioPolicy _mutedWithBoundaryPolicy = GuidanceAudioPolicy(
+    allowSpeech: false,
+    allowAlertTones: false,
+    allowBoundaryTones: true,
+  );
+
+  static const GuidanceAudioPolicy _absoluteMutePolicy = GuidanceAudioPolicy(
+    allowSpeech: false,
+    allowAlertTones: false,
+    allowBoundaryTones: false,
+  );
+
+  GuidanceAudioMode _mode = GuidanceAudioMode.muteForeground;
+
+  GuidanceAudioMode get mode => _mode;
+
+  GuidanceAudioPolicy policyFor(AppLifecycleState? lifecycleState) {
+    final AppLifecycleState effectiveState =
+        lifecycleState ?? AppLifecycleState.resumed;
+    final bool isForeground = effectiveState == AppLifecycleState.resumed;
+
+    switch (_mode) {
+      case GuidanceAudioMode.muteForeground:
+        return isForeground ? _mutedWithBoundaryPolicy : _fullAccessPolicy;
+      case GuidanceAudioMode.muteBackground:
+        return isForeground ? _fullAccessPolicy : _mutedWithBoundaryPolicy;
+      case GuidanceAudioMode.absoluteMute:
+        return _absoluteMutePolicy;
+    }
+  }
+
+  void setMode(GuidanceAudioMode mode) {
+    if (_mode == mode) {
+      return;
+    }
+    _mode = mode;
+    notifyListeners();
+    unawaited(_persistMode());
+  }
+
+  Future<void> _loadSavedMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final saved = prefs.getString(_preferenceKey);
+    if (saved == null) {
+      return;
+    }
+
+    for (final option in GuidanceAudioMode.values) {
+      if (option.name == saved) {
+        if (_mode != option) {
+          _mode = option;
+          notifyListeners();
+        }
+        return;
+      }
+    }
+  }
+
+  Future<void> _persistMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_preferenceKey, _mode.name);
+  }
+}


### PR DESCRIPTION
## Summary
- add a persistent guidance audio controller with configurable mute modes
- expose the audio mode selector in the map drawer with localized labels
- update guidance and cue services to honor the selected audio policy

## Testing
- not run (Flutter SDK unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68efe99d912c832d8f9c8b36e91fec62