### PR TITLE
Use segment debug data for guidance banner

### DIFF
--- a/lib/presentation/pages/map/widgets/map_controls_panel.dart
+++ b/lib/presentation/pages/map/widgets/map_controls_panel.dart
@@ -6,7 +6,7 @@ import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/presentation/widgets/avg_speed_dial.dart';
 import 'package:toll_cam_finder/presentation/widgets/curretn_speed_dial.dart';
 import 'package:toll_cam_finder/services/average_speed_est.dart';
-import 'package:toll_cam_finder/services/segment_guidance_controller.dart';
+import 'package:toll_cam_finder/services/segment_tracker.dart';
 
 import 'segment_guidance_banner.dart';
 
@@ -19,7 +19,7 @@ class MapControlsPanel extends StatelessWidget {
     this.lastSegmentAvgKmh,
     this.segmentSpeedLimitKph,
     this.segmentProgressLabel,
-    this.segmentGuidance,
+    this.segmentDebugPath,
     required this.showDebugBadge,
     required this.segmentCount,
     required this.segmentRadiusMeters,
@@ -31,7 +31,7 @@ class MapControlsPanel extends StatelessWidget {
   final double? lastSegmentAvgKmh;
   final double? segmentSpeedLimitKph;
   final String? segmentProgressLabel;
-  final SegmentGuidanceUiModel? segmentGuidance;
+  final SegmentDebugPath? segmentDebugPath;
   final bool showDebugBadge;
   final int segmentCount;
   final double segmentRadiusMeters;
@@ -57,8 +57,8 @@ class MapControlsPanel extends StatelessWidget {
           speedLimitKph:
               hasActiveSegment ? segmentSpeedLimitKph : null,
         ),
-        if (segmentGuidance != null)
-          SegmentGuidanceBanner(guidance: segmentGuidance!),
+        if (segmentDebugPath != null)
+          SegmentGuidanceBanner(path: segmentDebugPath!),
         if (segmentProgressLabel != null)
           Container(
             margin: const EdgeInsets.only(top: 8),

--- a/lib/presentation/pages/map/widgets/segment_guidance_banner.dart
+++ b/lib/presentation/pages/map/widgets/segment_guidance_banner.dart
@@ -1,20 +1,49 @@
 import 'package:flutter/material.dart';
 
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
 import 'package:toll_cam_finder/core/constants.dart';
-import 'package:toll_cam_finder/services/segment_guidance_controller.dart';
+import 'package:toll_cam_finder/services/segment_tracker.dart';
 
 class SegmentGuidanceBanner extends StatelessWidget {
   const SegmentGuidanceBanner({
     super.key,
-    required this.guidance,
+    required this.path,
     this.margin,
   });
 
-  final SegmentGuidanceUiModel guidance;
+  final SegmentDebugPath path;
   final EdgeInsetsGeometry? margin;
 
   @override
   Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context);
+    final String distanceText = localizations.translate(
+      'segmentDebugDistanceMeters',
+      {'distance': path.distanceMeters.toStringAsFixed(1)},
+    );
+
+    String? remainingDistanceText;
+    final double remainingMeters = path.remainingDistanceMeters;
+    if (remainingMeters.isFinite) {
+      final String remainingKm = (remainingMeters / 1000).toStringAsFixed(2);
+      remainingDistanceText = localizations.translate(
+        'segmentDebugDistanceKilometersLeft',
+        {'distance': remainingKm},
+      );
+    }
+
+    final List<String> tags = <String>[
+      path.isDetailed
+          ? localizations.translate('segmentDebugTagDetailed')
+          : localizations.translate('segmentDebugTagApprox'),
+      if (path.startHit)
+        localizations.translate('segmentDebugTagStart'),
+      if (path.endHit) localizations.translate('segmentDebugTagEnd'),
+    ];
+    final String? tagsText = tags.isEmpty
+        ? null
+        : tags.join(localizations.translate('segmentDebugTagSeparator'));
+
     return Container(
       margin: margin ?? const EdgeInsets.only(top: 8),
       padding: const EdgeInsets.symmetric(
@@ -30,7 +59,7 @@ class SegmentGuidanceBanner extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(
-            guidance.line1,
+            path.id,
             style: const TextStyle(
               color: Colors.white,
               fontSize: 12,
@@ -39,17 +68,28 @@ class SegmentGuidanceBanner extends StatelessWidget {
           ),
           const SizedBox(height: 2),
           Text(
-            guidance.line2,
+            distanceText,
             style: const TextStyle(
               color: Colors.white70,
               fontSize: 11,
               fontWeight: FontWeight.w500,
             ),
           ),
-          if (guidance.line3 != null) ...[
+          if (remainingDistanceText != null) ...[
             const SizedBox(height: 2),
             Text(
-              guidance.line3!,
+              remainingDistanceText,
+              style: const TextStyle(
+                color: Colors.white70,
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+          if (tagsText != null) ...[
+            const SizedBox(height: 2),
+            Text(
+              tagsText,
               style: const TextStyle(
                 color: Colors.white70,
                 fontSize: 11,


### PR DESCRIPTION
## Summary
- display the active segment's debug path details in the map guidance banner
- pass the resolved debug path through the map controls instead of the guidance UI model
- keep guidance controller audio updates while dropping the obsolete UI state bookkeeping

## Testing
- not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68efeca8898c832db3327f45f370e149