### PR TITLE
Add full guidance audio mode option

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -114,6 +114,8 @@ class AppLocalizations {
       'languageLabelBulgarian': 'Bulgarian',
       'languageButton': 'Change language',
       'audioModeTitle': 'Guidance audio mode',
+      'audioModeFullGuidance':
+          'Play all guidance sounds (foreground and background)',
       'audioModeForegroundMuted':
           'Mute in app (background guidance, start/end dings only)',
       'audioModeBackgroundMuted':
@@ -436,6 +438,8 @@ class AppLocalizations {
 'syncTotalSegmentsSummary': 'Общо налични сегменти: {count}.',
       'sync': 'Синхронизирай',
       'audioModeTitle': 'Режим на аудио насоките',
+      'audioModeFullGuidance':
+          'Всички аудио насоки (в приложението и на заден план)',
       'audioModeForegroundMuted':
           'Заглушено в приложението (активно на заден план, само сигнал при старт/край)',
       'audioModeBackgroundMuted':
@@ -506,6 +510,7 @@ class AppLocalizations {
   String get recenter => _value('recenter');
   String get languageButton => _value('languageButton');
   String get audioModeTitle => _value('audioModeTitle');
+  String get audioModeFullGuidance => _value('audioModeFullGuidance');
   String get audioModeForegroundMuted =>
       _value('audioModeForegroundMuted');
   String get audioModeBackgroundMuted =>

--- a/lib/presentation/pages/map/map_options_drawer.dart
+++ b/lib/presentation/pages/map/map_options_drawer.dart
@@ -64,6 +64,8 @@ extension _MapPageDrawer on _MapPageState {
     AppLocalizations localizations,
   ) {
     switch (mode) {
+      case GuidanceAudioMode.fullGuidance:
+        return localizations.audioModeFullGuidance;
       case GuidanceAudioMode.muteForeground:
         return localizations.audioModeForegroundMuted;
       case GuidanceAudioMode.muteBackground:

--- a/lib/services/guidance_audio_controller.dart
+++ b/lib/services/guidance_audio_controller.dart
@@ -37,6 +37,7 @@ class GuidanceAudioPolicy {
 }
 
 enum GuidanceAudioMode {
+  fullGuidance,
   muteForeground,
   muteBackground,
   absoluteMute,
@@ -67,7 +68,7 @@ class GuidanceAudioController extends ChangeNotifier {
     allowBoundaryTones: false,
   );
 
-  GuidanceAudioMode _mode = GuidanceAudioMode.muteForeground;
+  GuidanceAudioMode _mode = GuidanceAudioMode.fullGuidance;
 
   GuidanceAudioMode get mode => _mode;
 
@@ -77,6 +78,8 @@ class GuidanceAudioController extends ChangeNotifier {
     final bool isForeground = effectiveState == AppLifecycleState.resumed;
 
     switch (_mode) {
+      case GuidanceAudioMode.fullGuidance:
+        return _fullAccessPolicy;
       case GuidanceAudioMode.muteForeground:
         return isForeground ? _mutedWithBoundaryPolicy : _fullAccessPolicy;
       case GuidanceAudioMode.muteBackground:


### PR DESCRIPTION
## Summary
- add a full guidance audio mode that plays all guidance sounds
- expose the new option in the map options drawer and localizations

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f26d2d42a4832da4f08425f4b7c8b0