### PR TITLE
Adjust segment metrics layout orientation

### DIFF
--- a/lib/presentation/pages/map/widgets/map_controls_panel.dart
+++ b/lib/presentation/pages/map/widgets/map_controls_panel.dart
@@ -47,7 +47,8 @@ class MapControlsPanel extends StatelessWidget {
     final Widget panelCard = _buildPanelCard(
       colorScheme: colorScheme,
       maxWidth: panelMaxWidth,
-      stackMetricsVertically: placeLeft,
+      stackMetricsVertically: !placeLeft,
+      forceSingleRow: placeLeft,
     );
 
     if (placeLeft) {
@@ -94,6 +95,7 @@ class MapControlsPanel extends StatelessWidget {
     required ColorScheme colorScheme,
     required double maxWidth,
     required bool stackMetricsVertically,
+    required bool forceSingleRow,
   }) {
     return ConstrainedBox(
       constraints: BoxConstraints(maxWidth: maxWidth),
@@ -123,6 +125,7 @@ class MapControlsPanel extends StatelessWidget {
               distanceToSegmentEndMeters:
                   segmentDebugPath?.remainingDistanceMeters,
               stackMetricsVertically: stackMetricsVertically,
+              forceSingleRow: forceSingleRow,
             ),
           ),
         ),
@@ -140,6 +143,7 @@ class _SegmentMetricsCard extends StatelessWidget {
     required this.distanceToSegmentStartMeters,
     required this.distanceToSegmentEndMeters,
     required this.stackMetricsVertically,
+    required this.forceSingleRow,
   });
 
   final double? currentSpeedKmh;
@@ -149,6 +153,7 @@ class _SegmentMetricsCard extends StatelessWidget {
   final double? distanceToSegmentStartMeters;
   final double? distanceToSegmentEndMeters;
   final bool stackMetricsVertically;
+  final bool forceSingleRow;
 
   @override
   Widget build(BuildContext context) {
@@ -262,6 +267,20 @@ class _SegmentMetricsCard extends StatelessWidget {
                     ),
                     if (row + 2 < orderedMetrics.length)
                       const SizedBox(height: spacing),
+                  ],
+                ],
+              );
+            }
+
+            if (forceSingleRow) {
+              return Row(
+                children: [
+                  for (int i = 0; i < metrics.length; i++) ...[
+                    Expanded(
+                      child: _MetricTile(data: metrics[i]),
+                    ),
+                    if (i + 1 < metrics.length)
+                      const SizedBox(width: spacing),
                   ],
                 ],
               );


### PR DESCRIPTION
## Summary
- flip the map controls placement logic so portrait stacks segment metrics in a 2x2 grid
- add a single-row layout path to show the metrics horizontally when the panel is on the left
- update the metrics card to accept the new layout hints

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f28f27ab2c832db1d12f0ed6d13179