### PR TITLE
Adjust landscape metrics panel width

### DIFF
--- a/lib/presentation/pages/map/widgets/map_controls_panel.dart
+++ b/lib/presentation/pages/map/widgets/map_controls_panel.dart
@@ -97,9 +97,7 @@ class MapControlsPanel extends StatelessWidget {
     required bool stackMetricsVertically,
     required bool forceSingleRow,
   }) {
-    return ConstrainedBox(
-      constraints: BoxConstraints(maxWidth: maxWidth),
-      child: ClipRRect(
+    final Widget content = ClipRRect(
         borderRadius: BorderRadius.circular(22),
         child: BackdropFilter(
           filter: ImageFilter.blur(sigmaX: 0.5, sigmaY: 0.5),
@@ -131,6 +129,13 @@ class MapControlsPanel extends StatelessWidget {
         ),
       ),
     );
+
+    final Widget constrainedContent = ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: maxWidth),
+      child: forceSingleRow ? IntrinsicWidth(child: content) : content,
+    );
+
+    return constrainedContent;
   }
 }
 
@@ -275,12 +280,10 @@ class _SegmentMetricsCard extends StatelessWidget {
             if (forceSingleRow) {
               return Column(
                 mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   for (int i = 0; i < metrics.length; i++) ...[
-                     SizedBox(
-                      width: double.infinity,
-                      child: _MetricTile(data: metrics[i]),
-                    ),
+                    _MetricTile(data: metrics[i]),
                     if (i + 1 < metrics.length)
                       const SizedBox(height: spacing),
                   ],


### PR DESCRIPTION
## Summary
- ensure the landscape map controls panel sizes itself to the content instead of consuming half of the screen
- let the single-column metric tiles keep their intrinsic width so they no longer stretch unnecessarily

## Testing
- Not run (environment missing required tooling)

------
https://chatgpt.com/codex/tasks/task_e_68f295ce98c8832d9ac7a8f17fe1bb45