### PR TITLE
Add OSM speed limit overlay

### DIFF
--- a/lib/presentation/pages/map/widgets/speed_limit_sign.dart
+++ b/lib/presentation/pages/map/widgets/speed_limit_sign.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+class SpeedLimitSign extends StatelessWidget {
+  const SpeedLimitSign({super.key, this.speedLimit});
+
+  final String? speedLimit;
+
+  @override
+  Widget build(BuildContext context) {
+    final displayText = speedLimit ?? '-';
+    final textTheme = Theme.of(context).textTheme;
+
+    return IgnorePointer(
+      child: Container(
+        width: 72,
+        height: 72,
+        decoration: BoxDecoration(
+          color: Colors.white,
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.red.shade700, width: 6),
+          boxShadow: const [
+            BoxShadow(
+              color: Colors.black26,
+              blurRadius: 6,
+              offset: Offset(0, 3),
+            ),
+          ],
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          displayText,
+          textAlign: TextAlign.center,
+          style: textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: Colors.black87,
+              ) ??
+              const TextStyle(
+                fontSize: 28,
+                fontWeight: FontWeight.w700,
+                color: Colors.black87,
+              ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/map/osm_speed_limit_service.dart
+++ b/lib/services/map/osm_speed_limit_service.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:latlong2/latlong.dart';
+
+/// Retrieves speed limit information for the road surrounding a coordinate
+/// using the OpenStreetMap Overpass API.
+class OsmSpeedLimitService {
+  OsmSpeedLimitService({http.Client? client})
+      : _client = client ?? http.Client(),
+        _ownsClient = client == null;
+
+  static const String _endpoint = 'https://overpass-api.de/api/interpreter';
+  static const Duration _timeout = Duration(seconds: 10);
+
+  final http.Client _client;
+  final bool _ownsClient;
+
+  /// Returns the speed limit in km/h for the given [location].
+  ///
+  /// Returns `null` when no speed limit could be determined.
+  Future<String?> fetchSpeedLimit(LatLng location) async {
+    final query = '''
+[out:json];
+way(around:40,${location.latitude},${location.longitude})["highway"]["maxspeed"];
+out tags limit 1;
+''';
+
+    final uri = Uri.parse('$_endpoint?data=${Uri.encodeComponent(query)}');
+    final response = await _client
+        .get(uri, headers: {'User-Agent': 'toll_cam_finder/1.0'})
+        .timeout(_timeout);
+
+    if (response.statusCode != 200) {
+      return null;
+    }
+
+    final Map<String, dynamic> decoded =
+        jsonDecode(response.body) as Map<String, dynamic>;
+    final elements = decoded['elements'];
+    if (elements is! List || elements.isEmpty) {
+      return null;
+    }
+
+    for (final element in elements) {
+      if (element is! Map<String, dynamic>) continue;
+      final tags = element['tags'];
+      if (tags is! Map<String, dynamic>) continue;
+      final raw = tags['maxspeed'];
+      if (raw is String) {
+        final parsed = _parseMaxSpeed(raw);
+        if (parsed != null) {
+          return parsed;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  void dispose() {
+    if (_ownsClient) {
+      _client.close();
+    }
+  }
+
+  String? _parseMaxSpeed(String raw) {
+    final normalized = raw.trim().toLowerCase();
+    if (normalized.isEmpty || normalized == 'none' || normalized == 'signals') {
+      return null;
+    }
+
+    final primary = normalized.split(';').first.trim();
+    final match = RegExp(r'([0-9]+(?:\.[0-9]+)?)').firstMatch(primary);
+    if (match == null) {
+      return null;
+    }
+
+    final value = double.tryParse(match.group(1)!);
+    if (value == null) {
+      return null;
+    }
+
+    double inKmh = value;
+    if (primary.contains('mph')) {
+      inKmh = value * 1.60934;
+    }
+
+    return inKmh.round().toString();
+  }
+}


### PR DESCRIPTION
## Summary
- introduce an OSM speed limit service that queries the Overpass API and parses maxspeed values
- surface the road speed limit in a circular sign widget positioned at the top-left of the map view
- keep the sign updated with throttled location-based lookups and dispose of the service with the page

## Testing
- Not run (Flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f342a095d4832d8ae706464bbdf9fa