### PR TITLE
Improve map controls responsiveness on wide layouts

### DIFF
--- a/lib/presentation/pages/map/widgets/map_controls_panel.dart
+++ b/lib/presentation/pages/map/widgets/map_controls_panel.dart
@@ -277,16 +277,24 @@ class _SegmentMetricsCard extends StatelessWidget {
             if (forceSingleRow) {
               final mediaQuery = MediaQuery.of(context);
               final double screenWidth = mediaQuery.size.width;
-              final double maxTileWidth = math.min(width, screenWidth * 0.25);
-              final double minTileWidth = math.min(maxTileWidth, 160);
+              final double screenHeight = mediaQuery.size.height;
+              final double maxTileWidth = math.min(width, screenWidth * 0.28);
+              final double minTileWidth = math.min(maxTileWidth, screenWidth * 0.24);
 
-              const double panelVerticalPadding = 14 + 12;
               final double? boundedHeight = maxAvailableHeight;
-              const double baseTileHeight = 128;
-              const double comfortableMinScale = 0.55;
-              const double absoluteMinScale = 0.35;
-              double visualScale = 1.0;
+              final double panelVerticalPadding =
+                  (mediaQuery.viewPadding.top + mediaQuery.viewPadding.bottom) * 0.15 +
+                      28;
 
+              final double preferredTileHeight = () {
+                final double widthDrivenHeight = maxTileWidth * 0.78;
+                final double heightDriven = screenHeight * 0.22;
+                final double fallbackHeight = 128;
+                final double raw = math.max(widthDrivenHeight, heightDriven);
+                return raw.isFinite && raw > 0 ? raw : fallbackHeight;
+              }();
+
+              double visualScale = 1.0;
               if (boundedHeight != null && boundedHeight.isFinite) {
                 final double availableForTiles = math.max(
                   0,
@@ -294,26 +302,22 @@ class _SegmentMetricsCard extends StatelessWidget {
                 );
                 if (metrics.isNotEmpty && availableForTiles > 0) {
                   final double rawScale =
-                      availableForTiles / (baseTileHeight * metrics.length);
-                  if (rawScale >= comfortableMinScale) {
-                    visualScale = rawScale.clamp(comfortableMinScale, 1.0);
-                  } else if (rawScale >= absoluteMinScale) {
-                    visualScale = rawScale;
-                  } else if (rawScale > 0) {
-                    visualScale = rawScale;
-                  } else {
-                    visualScale = absoluteMinScale;
-                  }
+                      availableForTiles / (preferredTileHeight * metrics.length);
+                  visualScale = rawScale.clamp(0.35, 1.0).toDouble();
                 } else {
-                  visualScale = comfortableMinScale;
+                  visualScale = 0.45;
                 }
               }
-              visualScale = (visualScale.clamp(0.0, 1.0) as double);
-              if (visualScale == 0) visualScale = absoluteMinScale;
 
-              final double resolvedTileHeight = baseTileHeight * visualScale;
-              final bool enforceFixedHeight =
-                  boundedHeight != null && boundedHeight.isFinite;
+              final double widthScale = maxTileWidth > 0
+                  ? (maxTileWidth / (screenWidth * 0.28)).clamp(0.35, 1.0).toDouble()
+                  : 0.6;
+              visualScale = math.min(visualScale, widthScale);
+
+              final double resolvedTileHeight =
+                  (preferredTileHeight * visualScale)
+                      .clamp(80, screenHeight * 0.32)
+                      .toDouble();
 
               return IntrinsicWidth(
                 child: Column(
@@ -326,14 +330,11 @@ class _SegmentMetricsCard extends StatelessWidget {
                           minWidth: minTileWidth,
                           maxWidth: maxTileWidth,
                           minHeight: resolvedTileHeight,
-                          maxHeight: enforceFixedHeight
-                              ? resolvedTileHeight
-                              : double.infinity,
                         ),
                         child: _MetricTile(
                           data: metrics[i],
                           visualScale: visualScale,
-                          dense: false, // keep original sizing in rail
+                          dense: false,
                         ),
                       ),
                       if (i + 1 < metrics.length)
@@ -578,46 +579,61 @@ class _MetricTile extends StatelessWidget {
     // When dense=true (2×2), match the screenshot typography closely.
     final bool preset = dense;
 
-    final double scale = visualScale.clamp(0.2, 1.0);
+    final double layoutScale = visualScale.clamp(0.2, 1.0).toDouble();
+    final double textScaleFactor = MediaQuery.textScaleFactorOf(context);
+    final double typographicScale =
+        (visualScale * textScaleFactor).clamp(0.3, 1.1).toDouble();
 
-    final TextStyle labelStyle = (preset
-            ? const TextStyle(
-                fontSize: 11,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0.9,
-              )
-            : (theme.textTheme.labelMedium ??
-                theme.textTheme.labelSmall ??
-                const TextStyle(fontSize: 12)))
-        .copyWith(color: colorScheme.onSurfaceVariant);
+    final TextStyle labelBase = preset
+        ? const TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.9,
+          )
+        : (theme.textTheme.labelMedium ??
+            theme.textTheme.labelSmall ??
+            const TextStyle(fontSize: 12, fontWeight: FontWeight.w600));
+    final TextStyle labelStyle = labelBase.copyWith(
+      color: colorScheme.onSurfaceVariant,
+      fontSize: (labelBase.fontSize ?? 12) *
+          typographicScale.clamp(0.7, 1.0).toDouble(),
+    );
 
-    final TextStyle valueStyle = (preset
-            ? const TextStyle(
-                fontSize: 42, // bold large number like screenshot
-                fontWeight: FontWeight.w800,
-                height: 1.0,
-              )
-            : (theme.textTheme.displaySmall ??
-                theme.textTheme.headlineMedium ??
-                const TextStyle(fontSize: 36, fontWeight: FontWeight.w700)))
-        .copyWith(color: colorScheme.onSurface)
-        .copyWith(fontSize: (preset ? 42 : (valueStyleFontSizeFallback(36))) * scale);
+    final TextStyle valueBase = preset
+        ? const TextStyle(
+            fontSize: 42,
+            fontWeight: FontWeight.w800,
+            height: 1.0,
+          )
+        : (theme.textTheme.displaySmall ??
+            theme.textTheme.headlineMedium ??
+            const TextStyle(fontSize: 40, fontWeight: FontWeight.w700, height: 1.0));
+    final double baseValueFontSize = valueBase.fontSize ?? 40;
+    final TextStyle valueStyle = valueBase.copyWith(
+      color: colorScheme.onSurface,
+      fontSize: baseValueFontSize * typographicScale,
+    );
 
     // Units smaller and medium weight
-    final TextStyle unitStyle = (preset
-            ? const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-                height: 1.0,
-              )
-            : (theme.textTheme.titleSmall ??
-                const TextStyle(fontSize: 18, fontWeight: FontWeight.w600)))
-        .copyWith(color: colorScheme.onSurface)
-        .copyWith(fontSize: (preset ? 16 : (unitStyleFontSizeFallback(18))) * scale);
+    final TextStyle unitBase = preset
+        ? const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            height: 1.0,
+          )
+        : (theme.textTheme.titleSmall ??
+            const TextStyle(fontSize: 18, fontWeight: FontWeight.w600));
+    final double baseUnitFontSize = unitBase.fontSize ?? 18;
+    final TextStyle unitStyle = unitBase.copyWith(
+      color: colorScheme.onSurface,
+      fontSize:
+          baseUnitFontSize * typographicScale.clamp(0.6, 1.05).toDouble(),
+    );
 
-    final double verticalPadding = lerpDouble(preset ? 8 : 8, preset ? 10 : 14, scale)!;
+    final double verticalPadding =
+        lerpDouble(preset ? 8 : 8, preset ? 12 : 16, layoutScale)!;
     final double horizontalPadding =
-        lerpDouble(preset ? 10 : 12, preset ? 14 : 18, scale)!;
+        lerpDouble(preset ? 10 : 12, preset ? 16 : 20, layoutScale)!;
 
     return Container(
       padding: EdgeInsets.symmetric(
@@ -634,7 +650,8 @@ class _MetricTile extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Text(data.label.toUpperCase(), style: labelStyle),
-          SizedBox(height: lerpDouble(preset ? 6 : 6, preset ? 8 : 10, scale)!),
+          SizedBox(
+              height: lerpDouble(preset ? 6 : 6, preset ? 10 : 12, layoutScale)!),
           Row(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.baseline,
@@ -642,7 +659,7 @@ class _MetricTile extends StatelessWidget {
             children: [
               Text(data.value.value, style: valueStyle),
               if (data.value.unit != null) ...[
-                const SizedBox(width: 6),
+                SizedBox(width: lerpDouble(4, 8, layoutScale)!),
                 Text(data.value.unit!, style: unitStyle),
               ],
             ],
@@ -652,7 +669,4 @@ class _MetricTile extends StatelessWidget {
     );
   }
 
-  // helpers because we need a number even if theme fonts are null
-  double valueStyleFontSizeFallback(double fallback) => fallback;
-  double unitStyleFontSizeFallback(double fallback) => fallback;
 }


### PR DESCRIPTION
## Summary
- adapt the left-rail map control layout to derive tile dimensions from the available screen size and avoid overflow
- scale typography and spacing dynamically so horizontal mode matches the readability of the vertical layout

## Testing
- not run (flutter unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f35291b60c832dab54c94e1c2f4b91