### PR TITLE
Add heading-follow toggle for map view

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -161,6 +161,8 @@ class AppLocalizations {
       'publicSharingUnavailable':
           'Public segment sharing is currently unavailable.',
       'publicSharingUnavailableShort': 'Public sharing is not available.',
+      'faceTravelDirection': 'Face Travel Direction',
+      'northUp': 'North Up',
       'recenter': 'Recenter',
       'retryAction': 'Retry',
       'saveLocallyAction': 'Save locally',
@@ -370,6 +372,8 @@ class AppLocalizations {
 'passwordLabel': 'Парола',
 'profile': 'Профил',
 'profileSubtitle': 'Управлявай акаунта и настройките си в TollCam.',
+'faceTravelDirection': 'По посока на движение',
+'northUp': 'Север нагоре',
 'recenter': 'Центрирай Екрана',
 'saveLocallyAction': 'Запази локално',
 'saveSegment': 'Запази сегмента',
@@ -507,6 +511,8 @@ class AppLocalizations {
   String get saveSegment => _value('saveSegment');
   String get noSegmentsAvailable => _value('noSegmentsAvailable');
   String get noLocalSegments => _value('noLocalSegments');
+  String get faceTravelDirection => _value('faceTravelDirection');
+  String get northUp => _value('northUp');
   String get recenter => _value('recenter');
   String get languageButton => _value('languageButton');
   String get audioModeTitle => _value('audioModeTitle');

--- a/lib/presentation/pages/map/widgets/map_fab_column.dart
+++ b/lib/presentation/pages/map/widgets/map_fab_column.dart
@@ -7,11 +7,15 @@ class MapFabColumn extends StatelessWidget {
   const MapFabColumn({
     super.key,
     required this.followUser,
+    required this.followHeading,
+    required this.onToggleHeading,
     required this.onResetView,
     required this.avgController,
   });
 
   final bool followUser;
+  final bool followHeading;
+  final VoidCallback onToggleHeading;
   final VoidCallback onResetView;
   final AverageSpeedController avgController;
 
@@ -21,6 +25,19 @@ class MapFabColumn extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
+        FloatingActionButton.extended(
+          heroTag: 'heading_btn',
+          onPressed: onToggleHeading,
+          icon: Icon(
+            followHeading ? Icons.explore : Icons.navigation,
+          ),
+          label: Text(
+            followHeading
+                ? AppLocalizations.of(context).northUp
+                : AppLocalizations.of(context).faceTravelDirection,
+          ),
+        ),
+        const SizedBox(height: 12),
         FloatingActionButton.extended(
           heroTag: 'recenter_btn',
           onPressed: onResetView,


### PR DESCRIPTION
## Summary
- add a map floating action button to toggle between heading-up and north-up orientations
- track geolocator heading updates to rotate the map when following the user
- localize labels for the new orientation toggle control

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f38b1cbf8c832db0537310facc0cf6