### PR TITLE
Refine segment metrics card styling

### DIFF
--- a/lib/presentation/pages/map/widgets/map_controls/map_controls_panel_card.dart
+++ b/lib/presentation/pages/map/widgets/map_controls/map_controls_panel_card.dart
@@ -39,44 +39,78 @@ class MapControlsPanelCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bool isDark = colorScheme.brightness == Brightness.dark;
+    final BorderRadius borderRadius = BorderRadius.circular(28);
+
+    final Color primaryOverlay = Color.lerp(
+          colorScheme.surface,
+          Colors.white,
+          isDark ? 0.35 : 0.85,
+        )!
+        .withOpacity(isDark ? 0.65 : 0.92);
+    final Color secondaryOverlay = Color.lerp(
+          colorScheme.surface,
+          Colors.white,
+          isDark ? 0.25 : 0.75,
+        )!
+        .withOpacity(isDark ? 0.58 : 0.85);
+    final Color borderColor = Color.lerp(
+          Colors.white,
+          colorScheme.onSurface,
+          isDark ? 0.65 : 0.1,
+        )!
+        .withOpacity(isDark ? 0.32 : 0.45);
+
     return ConstrainedBox(
       constraints: BoxConstraints(
         maxWidth: maxWidth,
         maxHeight: maxHeight ?? double.infinity,
       ),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(22),
+        borderRadius: borderRadius,
         child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
-          child: Container(
+          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+          child: DecoratedBox(
             decoration: BoxDecoration(
-              color: colorScheme.surface.withOpacity(0.88),
-              borderRadius: BorderRadius.circular(22),
+              borderRadius: borderRadius,
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  primaryOverlay,
+                  secondaryOverlay,
+                ],
+              ),
               border: Border.all(
-                color: Colors.white.withOpacity(0.35),
-                width: 1,
+                color: borderColor,
+                width: 1.2,
               ),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.08),
-                  blurRadius: 28,
-                  offset: const Offset(0, 12),
+                  color: Colors.black.withOpacity(isDark ? 0.36 : 0.12),
+                  blurRadius: 34,
+                  offset: const Offset(0, 18),
                 ),
               ],
             ),
-            padding: const EdgeInsets.fromLTRB(1, 1, 1, 1),
-            child: SegmentMetricsCard(
-              currentSpeedKmh: speedKmh,
-              avgController: avgController,
-              hasActiveSegment: hasActiveSegment,
-              speedLimitKph: segmentSpeedLimitKph,
-              distanceToSegmentStartMeters: distanceToSegmentStartMeters,
-              distanceToSegmentEndMeters:
-                  segmentDebugPath?.remainingDistanceMeters,
-              stackMetricsVertically: stackMetricsVertically,
-              forceSingleRow: forceSingleRow,
-              maxAvailableHeight: maxHeight,
-              isLandscape: isLandscape,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 6,
+                vertical: 4,
+              ),
+              child: SegmentMetricsCard(
+                currentSpeedKmh: speedKmh,
+                avgController: avgController,
+                hasActiveSegment: hasActiveSegment,
+                speedLimitKph: segmentSpeedLimitKph,
+                distanceToSegmentStartMeters: distanceToSegmentStartMeters,
+                distanceToSegmentEndMeters:
+                    segmentDebugPath?.remainingDistanceMeters,
+                stackMetricsVertically: stackMetricsVertically,
+                forceSingleRow: forceSingleRow,
+                maxAvailableHeight: maxHeight,
+                isLandscape: isLandscape,
+              ),
             ),
           ),
         ),

--- a/lib/presentation/pages/map/widgets/map_controls/segment_metrics_card.dart
+++ b/lib/presentation/pages/map/widgets/map_controls/segment_metrics_card.dart
@@ -444,10 +444,14 @@ class _MetricTile extends StatelessWidget {
         : (theme.textTheme.labelMedium ??
             theme.textTheme.labelSmall ??
             const TextStyle(fontSize: 12, fontWeight: FontWeight.w600));
+    final bool isDark = colorScheme.brightness == Brightness.dark;
     final TextStyle labelStyle = labelBase.copyWith(
-      color: colorScheme.onSurfaceVariant,
+      color: preset
+          ? colorScheme.onSurface.withOpacity(isDark ? 0.72 : 0.58)
+          : colorScheme.onSurfaceVariant.withOpacity(isDark ? 0.95 : 0.82),
       fontSize: (labelBase.fontSize ?? 12) *
           typographicScale.clamp(0.7, 1.0).toDouble(),
+      letterSpacing: preset ? 0.9 : 0.6,
     );
 
     final TextStyle valueBase = preset
@@ -485,15 +489,29 @@ class _MetricTile extends StatelessWidget {
     final double horizontalPadding =
         lerpDouble(preset ? 10 : 12, preset ? 16 : 20, layoutScale)!;
 
+    final bool showBackground = !preset;
+    final BoxDecoration? decoration;
+    if (showBackground) {
+      final Color baseColor = Color.lerp(
+            colorScheme.surface,
+            Colors.white,
+            isDark ? 0.15 : 0.6,
+          )!
+          .withOpacity(isDark ? 0.24 : 0.42);
+      decoration = BoxDecoration(
+        color: baseColor,
+        borderRadius: BorderRadius.circular(20),
+      );
+    } else {
+      decoration = null;
+    }
+
     return Container(
       padding: EdgeInsets.symmetric(
         vertical: verticalPadding,
         horizontal: horizontalPadding,
       ),
-      decoration: BoxDecoration(
-        color: colorScheme.surface.withOpacity(0.06),
-        borderRadius: BorderRadius.circular(16),
-      ),
+      decoration: decoration,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.max,


### PR DESCRIPTION
## Summary
- refresh the map controls card with a glassmorphic gradient and softer edges so it feels embedded over the map
- tune metric tiles to rely on the shared card background with theme-aware label colors for improved legibility

## Testing
- Not run (Flutter SDK is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68f48724b730832da65953c8163241d4