### PR TITLE
Apply refreshed dark UI palette across map experience

### DIFF
--- a/lib/app/app_theme.dart
+++ b/lib/app/app_theme.dart
@@ -1,9 +1,54 @@
 import 'package:flutter/material.dart';
 
+import 'package:toll_cam_finder/core/app_colors.dart';
+
 ThemeData buildAppTheme() {
+  const colorScheme = ColorScheme.dark(
+    primary: AppColors.primary,
+    onPrimary: Colors.white,
+    secondary: AppColors.success,
+    onSecondary: Colors.white,
+    tertiary: AppColors.warning,
+    onTertiary: AppColors.background,
+    error: AppColors.danger,
+    onError: Colors.white,
+    background: AppColors.background,
+    onBackground: AppColors.onDark,
+    surface: AppColors.surface,
+    onSurface: AppColors.onDark,
+    surfaceTint: Colors.transparent,
+    outline: AppColors.divider,
+    outlineVariant: AppColors.divider,
+  );
+
+  final floatingActionButtonTheme = FloatingActionButtonThemeData(
+    backgroundColor: AppColors.surface.withOpacity(0.7),
+    foregroundColor: AppColors.onDark,
+    elevation: 0,
+    highlightElevation: 0,
+    shape: const CircleBorder(
+      side: BorderSide(color: AppColors.divider, width: 1),
+    ),
+  );
+
   return ThemeData(
-    colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
     useMaterial3: true,
-    appBarTheme: const AppBarTheme(centerTitle: true),
+    colorScheme: colorScheme,
+    scaffoldBackgroundColor: AppColors.background,
+    appBarTheme: const AppBarTheme(
+      centerTitle: true,
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      foregroundColor: AppColors.onDark,
+      surfaceTintColor: Colors.transparent,
+    ),
+    floatingActionButtonTheme: floatingActionButtonTheme,
+    dividerColor: AppColors.divider,
+    snackBarTheme: const SnackBarThemeData(
+      backgroundColor: AppColors.toastBackground,
+      contentTextStyle: TextStyle(color: AppColors.onDark),
+      actionTextColor: AppColors.primary,
+      behavior: SnackBarBehavior.floating,
+    ),
   );
 }

--- a/lib/core/app_colors.dart
+++ b/lib/core/app_colors.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+/// Centralized color palette for the Toll Cam Finder UI.
+class AppColors {
+  AppColors._();
+
+  static const Color primary = Color(0xFF3B82F6);
+  static const Color success = Color(0xFF22C55E);
+  static const Color warning = Color(0xFFF59E0B);
+  static const Color danger = Color(0xFFEF4444);
+
+  static const Color background = Color(0xFF0B1220);
+  static const Color surface = Color(0xFF0F172A);
+  static const Color onDark = Color(0xFFF8FAFC);
+  static const Color secondaryText = Color(0xFF94A3B8);
+  static const Color divider = Color(0xFF334155);
+  static const Color unavailable = Color(0xFF64748B);
+
+  static const Color mapScrim = Color(0x800B1220);
+  static const Color toastBackground = Color(0xE6111827);
+}

--- a/lib/features/map/presentation/pages/map/widgets/map_controls/map_controls_panel_card.dart
+++ b/lib/features/map/presentation/pages/map/widgets/map_controls/map_controls_panel_card.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
+import 'package:toll_cam_finder/core/app_colors.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
 import 'package:toll_cam_finder/features/segments/domain/tracking/segment_tracker.dart';
 
@@ -39,27 +40,11 @@ class MapControlsPanelCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark = colorScheme.brightness == Brightness.dark;
     final BorderRadius borderRadius = BorderRadius.circular(28);
-
-    final Color primaryOverlay = Color.lerp(
-          colorScheme.surface,
-          Colors.white,
-          isDark ? 0.35 : 0.85,
-        )!
-        .withOpacity(isDark ? 0.65 : 0.92);
-    final Color secondaryOverlay = Color.lerp(
-          colorScheme.surface,
-          Colors.white,
-          isDark ? 0.25 : 0.75,
-        )!
-        .withOpacity(isDark ? 0.58 : 0.85);
-    final Color borderColor = Color.lerp(
-          Colors.white,
-          colorScheme.onSurface,
-          isDark ? 0.65 : 0.1,
-        )!
-        .withOpacity(isDark ? 0.32 : 0.45);
+    final bool isDark = colorScheme.brightness == Brightness.dark;
+    final Color backgroundColor = AppColors.surface.withOpacity(0.72);
+    final Color borderColor = AppColors.divider.withOpacity(isDark ? 1 : 0.9);
+    final Color shadowColor = Colors.black.withOpacity(isDark ? 0.42 : 0.25);
 
     return ConstrainedBox(
       constraints: BoxConstraints(
@@ -72,28 +57,21 @@ class MapControlsPanelCard extends StatelessWidget {
           filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
           child: DecoratedBox(
             decoration: BoxDecoration(
-             borderRadius: borderRadius,
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [
-                  primaryOverlay,
-                  secondaryOverlay,
-                ],
-              ),
+              borderRadius: borderRadius,
+              color: backgroundColor,
               border: Border.all(
                 color: borderColor,
-                width: 1.2,
+                width: 1,
               ),
               boxShadow: [
                 BoxShadow(
-                   color: Colors.black.withOpacity(isDark ? 0.36 : 0.12),
+                  color: shadowColor,
                   blurRadius: 34,
                   offset: const Offset(0, 18),
                 ),
               ],
             ),
-             child: Padding(
+            child: Padding(
               padding: const EdgeInsets.symmetric(
                 horizontal: 6,
                 vertical: 4,

--- a/lib/features/map/presentation/pages/map/widgets/map_controls/segment_metrics_card.dart
+++ b/lib/features/map/presentation/pages/map/widgets/map_controls/segment_metrics_card.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 
 import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+import 'package:toll_cam_finder/core/app_colors.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
 
 class SegmentMetricsCard extends StatelessWidget {
@@ -66,17 +67,20 @@ class SegmentMetricsCard extends StatelessWidget {
         );
         final _MetricValue averageSpeed = averagingActive
             ? _formatSpeed(avgController.average, speedUnit)
-            : const _MetricValue(value: '-', unit: null);
+            : const _MetricValue(value: _MetricValue.missingValue, unit: null);
         final _MetricValue limitSpeed = _formatSpeed(
           speedLimitKph,
           speedUnit,
         );
         final _MetricValue safeSpeedFormatted = safeSpeed != null
             ? _formatSpeed(safeSpeed, speedUnit)
-            : const _MetricValue(value: '-', unit: null);
+            : const _MetricValue(value: _MetricValue.missingValue, unit: null);
 
         final bool showSafeSpeed =
             averagingActive && safeSpeedFormatted.hasValue;
+
+        final Color? currentSpeedColor =
+            _resolveCurrentSpeedColor(currentSpeedKmh, speedLimitKph);
 
         final String distanceLabelKey = hasActiveSegment
             ? 'segmentMetricsDistanceToEnd'
@@ -95,20 +99,26 @@ class SegmentMetricsCard extends StatelessWidget {
           _MetricTileData(
             label: localizations.translate('segmentMetricsCurrentSpeed'),
             value: currentSpeed,
+            valueColor: currentSpeedColor,
+            unitColor: AppColors.secondaryText,
           ),
           _MetricTileData(
             label: localizations.translate('segmentMetricsAverageSpeed'),
             value: averageSpeed,
+            unitColor: AppColors.secondaryText,
           ),
           _MetricTileData(
             label: showSafeSpeed
                 ? localizations.translate('segmentMetricsSafeSpeed')
                 : localizations.translate('segmentMetricsSpeedLimit'),
             value: showSafeSpeed ? safeSpeedFormatted : limitSpeed,
+            unitColor: AppColors.secondaryText,
           ),
           _MetricTileData(
             label: distanceLabel,
             value: distanceValue,
+            valueColor: AppColors.onDark,
+            unitColor: AppColors.secondaryText,
           ),
         ];
 
@@ -282,19 +292,27 @@ class _SingleColumnMetrics extends StatelessWidget {
 class _MetricValue {
   const _MetricValue({required this.value, this.unit});
 
+  static const String missingValue = '–';
+
   final String value;
   final String? unit;
 
-  bool get hasValue => unit != null && value != '-';
-
-  String get label => hasValue ? '$value $unit' : value;
+  bool get hasValue => unit != null && value != missingValue;
+  bool get isUnavailable => value == missingValue;
 }
 
 class _MetricTileData {
-  const _MetricTileData({required this.label, required this.value});
+  const _MetricTileData({
+    required this.label,
+    required this.value,
+    this.valueColor,
+    this.unitColor,
+  });
 
   final String label;
   final _MetricValue value;
+  final Color? valueColor;
+  final Color? unitColor;
 }
 
 class _TwoByTwoMetricsGrid extends StatelessWidget {
@@ -305,8 +323,7 @@ class _TwoByTwoMetricsGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final dividerColor =
-        Theme.of(context).colorScheme.onSurface.withOpacity(0.12);
+    final Color dividerColor = AppColors.divider.withOpacity(0.9);
 
     const cellGap = 16.0;
 
@@ -422,10 +439,9 @@ class _MetricTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
+    final ThemeData theme = Theme.of(context);
     final bool preset = dense;
+    final bool isDark = theme.brightness == Brightness.dark;
 
     final double layoutScale = visualScale.clamp(0.2, 1.0).toDouble();
     final double textScaleFactor = MediaQuery.textScaleFactorOf(context);
@@ -444,13 +460,11 @@ class _MetricTile extends StatelessWidget {
         : (theme.textTheme.labelMedium ??
             theme.textTheme.labelSmall ??
             const TextStyle(fontSize: 12, fontWeight: FontWeight.w600));
-                final bool isDark = colorScheme.brightness == Brightness.dark;
     final TextStyle labelStyle = labelBase.copyWith(
-color: preset
-          ? colorScheme.onSurface.withOpacity(isDark ? 0.72 : 0.58)
-          : colorScheme.onSurfaceVariant.withOpacity(isDark ? 0.95 : 0.82),      fontSize: (labelBase.fontSize ?? 12) *
+      color: AppColors.secondaryText,
+      fontSize: (labelBase.fontSize ?? 12) *
           typographicScale.clamp(0.7, 1.0).toDouble(),
-                letterSpacing: preset ? 0.9 : 0.6,
+      letterSpacing: preset ? 0.9 : 0.6,
     );
 
     final TextStyle valueBase = preset
@@ -463,8 +477,11 @@ color: preset
             theme.textTheme.headlineMedium ??
             const TextStyle(fontSize: 40, fontWeight: FontWeight.w700, height: 1.0));
     final double baseValueFontSize = valueBase.fontSize ?? 40;
+    final Color valueColor = data.value.isUnavailable
+        ? AppColors.unavailable
+        : (data.valueColor ?? AppColors.onDark);
     final TextStyle valueStyle = valueBase.copyWith(
-      color: colorScheme.onSurface,
+      color: valueColor,
       fontSize: baseValueFontSize * typographicScale,
     );
 
@@ -477,8 +494,11 @@ color: preset
         : (theme.textTheme.titleSmall ??
             const TextStyle(fontSize: 18, fontWeight: FontWeight.w600));
     final double baseUnitFontSize = unitBase.fontSize ?? 18;
+    final Color unitColor = data.value.isUnavailable
+        ? AppColors.unavailable
+        : (data.unitColor ?? AppColors.secondaryText);
     final TextStyle unitStyle = unitBase.copyWith(
-      color: colorScheme.onSurface,
+      color: unitColor,
       fontSize: baseUnitFontSize *
           typographicScale.clamp(0.6, isLandscape ? 1.2 : 1.05).toDouble(),
     );
@@ -488,18 +508,17 @@ color: preset
     final double horizontalPadding =
         lerpDouble(preset ? 10 : 12, preset ? 16 : 20, layoutScale)!;
 
-final bool showBackground = !preset;
+    final bool showBackground = !preset;
     final BoxDecoration? decoration;
     if (showBackground) {
-      final Color baseColor = Color.lerp(
-            colorScheme.surface,
-            Colors.white,
-            isDark ? 0.15 : 0.6,
-          )!
-          .withOpacity(isDark ? 0.24 : 0.42);
+      final Color baseColor = AppColors.surface.withOpacity(isDark ? 0.55 : 0.6);
       decoration = BoxDecoration(
         color: baseColor,
         borderRadius: BorderRadius.circular(20),
+        border: Border.all(
+          color: AppColors.divider.withOpacity(isDark ? 0.9 : 0.75),
+          width: 1,
+        ),
       );
     } else {
       decoration = null;
@@ -537,6 +556,29 @@ final bool showBackground = !preset;
   }
 }
 
+Color? _resolveCurrentSpeedColor(double? currentSpeedKmh, double? limitKph) {
+  final double? current = _sanitizeSpeedValue(currentSpeedKmh);
+  final double? limit = _sanitizeSpeedValue(limitKph);
+  if (current == null || limit == null || limit <= 0) {
+    return null;
+  }
+
+  final double ratio = current / limit;
+  if (ratio <= 0.8) {
+    return AppColors.success;
+  }
+  if (ratio < 1.0) {
+    return AppColors.warning;
+  }
+  return AppColors.danger;
+}
+
+double? _sanitizeSpeedValue(double? value) {
+  if (value == null || !value.isFinite) return null;
+  if (value < 0) return 0;
+  return value;
+}
+
 double? _sanitizeDistance(double? meters) {
   if (meters == null || !meters.isFinite) return null;
   return meters < 0 ? 0 : meters;
@@ -571,7 +613,7 @@ double? _estimateSafeSpeed({
 
 _MetricValue _formatSpeed(double? speedKph, String unit) {
   if (speedKph == null || !speedKph.isFinite) {
-    return const _MetricValue(value: '-', unit: null);
+    return const _MetricValue(value: _MetricValue.missingValue, unit: null);
   }
   final double clamped = speedKph.clamp(0, double.infinity).toDouble();
   final bool useDecimals = clamped < 10;
@@ -584,7 +626,7 @@ _MetricValue _formatDistance(
   double? meters,
 ) {
   if (meters == null || !meters.isFinite) {
-    return const _MetricValue(value: '-', unit: null);
+    return const _MetricValue(value: _MetricValue.missingValue, unit: null);
   }
   if (meters >= 1000) {
     final double km = meters / 1000.0;

--- a/lib/features/map/presentation/pages/map/widgets/map_fab_column.dart
+++ b/lib/features/map/presentation/pages/map/widgets/map_fab_column.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+import 'package:toll_cam_finder/core/app_colors.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
 
 class MapFabColumn extends StatelessWidget {
@@ -23,33 +24,33 @@ class MapFabColumn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context);
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        _AnimatedFabSlot(
-          visible: !followHeading,
-          child: FloatingActionButton.small(
-            heroTag: 'heading_btn',
-            onPressed: onToggleHeading,
-            tooltip: followHeading
-                ? AppLocalizations.of(context).northUp
-                : AppLocalizations.of(context).faceTravelDirection,
-            child: _CompassNeedle(
-              followHeading: followHeading,
-              headingDegrees: headingDegrees,
-            ),
+        _MapMiniFab(
+          heroTag: 'heading_btn',
+          tooltip: followHeading
+              ? localizations.northUp
+              : localizations.faceTravelDirection,
+          active: followHeading,
+          onPressed: onToggleHeading,
+          child: _CompassNeedle(
+            followHeading: followHeading,
+            headingDegrees: headingDegrees,
+            color: followHeading ? Colors.white : AppColors.onDark,
           ),
         ),
-        _AnimatedFabSlot(
-          visible: !followUser,
-          child: FloatingActionButton.small(
-            heroTag: 'recenter_btn',
-            onPressed: onResetView,
-            tooltip: AppLocalizations.of(context).recenter,
-            child: Icon(
-              followUser ? Icons.my_location : Icons.my_location_outlined,
-            ),
+        const SizedBox(height: 12),
+        _MapMiniFab(
+          heroTag: 'recenter_btn',
+          tooltip: localizations.recenter,
+          active: followUser,
+          onPressed: onResetView,
+          child: Icon(
+            followUser ? Icons.my_location : Icons.my_location_outlined,
+            color: followUser ? Colors.white : AppColors.onDark,
           ),
         ),
       ],
@@ -61,18 +62,15 @@ class _CompassNeedle extends StatelessWidget {
   const _CompassNeedle({
     required this.followHeading,
     required this.headingDegrees,
+    required this.color,
   });
 
   final bool followHeading;
   final double? headingDegrees;
+  final Color color;
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final Color indicatorColor =
-        theme.floatingActionButtonTheme.foregroundColor ??
-        theme.colorScheme.onPrimary;
-
     final bool shouldRotate = followHeading && headingDegrees != null;
     final double rotationTurns = shouldRotate
         ? (headingDegrees! % 360) / 360
@@ -88,7 +86,7 @@ class _CompassNeedle extends StatelessWidget {
             turns: rotationTurns,
             duration: const Duration(milliseconds: 250),
             curve: Curves.easeOutCubic,
-            child: Icon(Icons.navigation, size: 22, color: indicatorColor),
+            child: Icon(Icons.navigation, size: 22, color: color),
           ),
           AnimatedOpacity(
             opacity: followHeading ? 0 : 1,
@@ -96,7 +94,7 @@ class _CompassNeedle extends StatelessWidget {
             child: Icon(
               Icons.lock,
               size: 12,
-              color: indicatorColor.withOpacity(0.7),
+              color: color.withOpacity(0.7),
             ),
           ),
         ],
@@ -105,47 +103,49 @@ class _CompassNeedle extends StatelessWidget {
   }
 }
 
-class _AnimatedFabSlot extends StatelessWidget {
-  const _AnimatedFabSlot({
-    required this.visible,
+class _MapMiniFab extends StatelessWidget {
+  const _MapMiniFab({
+    required this.heroTag,
+    required this.tooltip,
+    required this.onPressed,
     required this.child,
+    required this.active,
   });
 
-  final bool visible;
+  final String heroTag;
+  final String tooltip;
+  final VoidCallback onPressed;
   final Widget child;
+  final bool active;
 
   @override
   Widget build(BuildContext context) {
-    return AbsorbPointer(
-      absorbing: !visible,
-      child: AnimatedSwitcher(
-        duration: const Duration(milliseconds: 250),
-        switchInCurve: Curves.easeOutCubic,
-        switchOutCurve: Curves.easeInCubic,
-        transitionBuilder: (Widget child, Animation<double> animation) {
-          return FadeTransition(
-            opacity: animation,
-            child: SizeTransition(
-              sizeFactor: animation,
-              axisAlignment: -1,
-              child: Align(
-                alignment: Alignment.centerRight,
-                child: child,
-              ),
-            ),
-          );
-        },
-        child: visible
-            ? Column(
-                key: const ValueKey<bool>(true),
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  child,
-                  const SizedBox(height: 12),
-                ],
-              )
-            : const SizedBox.shrink(key: ValueKey<bool>(false)),
+    final Color backgroundColor =
+        active ? AppColors.primary : AppColors.surface.withOpacity(0.7);
+    final Color borderColor = active ? Colors.transparent : AppColors.divider;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.35),
+            blurRadius: 24,
+            offset: const Offset(0, 12),
+          ),
+        ],
+      ),
+      child: FloatingActionButton.small(
+        heroTag: heroTag,
+        onPressed: onPressed,
+        tooltip: tooltip,
+        elevation: 0,
+        highlightElevation: 0,
+        backgroundColor: backgroundColor,
+        shape: CircleBorder(
+          side: BorderSide(color: borderColor, width: 1),
+        ),
+        child: child,
       ),
     );
   }

--- a/lib/features/map/presentation/pages/map/widgets/speed_limit_sign.dart
+++ b/lib/features/map/presentation/pages/map/widgets/speed_limit_sign.dart
@@ -1,28 +1,39 @@
 import 'package:flutter/material.dart';
 
+import 'package:toll_cam_finder/core/app_colors.dart';
+
 class SpeedLimitSign extends StatelessWidget {
-  const SpeedLimitSign({super.key, this.speedLimit});
+  const SpeedLimitSign({super.key, this.speedLimit, this.currentSpeedKmh});
 
   final String? speedLimit;
+  final double? currentSpeedKmh;
 
   @override
   Widget build(BuildContext context) {
-    final displayText = speedLimit ?? '-';
-    final textTheme = Theme.of(context).textTheme;
+    final String trimmed = speedLimit?.trim() ?? '';
+    final String displayText = trimmed.isEmpty ? '–' : trimmed;
+    final double? limitValue = double.tryParse(trimmed);
+    final double? current = currentSpeedKmh;
+    final bool isOverspeed =
+        limitValue != null && current != null && limitValue > 0 && current >= limitValue;
+
+    final Color fillColor = isOverspeed ? AppColors.danger : Colors.white;
+    final double borderWidth = isOverspeed ? 0 : 6;
+    final Color textColor = isOverspeed ? Colors.white : AppColors.background;
 
     return IgnorePointer(
       child: Container(
         width: 72,
         height: 72,
         decoration: BoxDecoration(
-          color: Colors.white,
+          color: fillColor,
           shape: BoxShape.circle,
-          border: Border.all(color: Colors.red.shade700, width: 6),
-          boxShadow: const [
+          border: Border.all(color: AppColors.danger, width: borderWidth),
+          boxShadow: [
             BoxShadow(
-              color: Colors.black26,
-              blurRadius: 6,
-              offset: Offset(0, 3),
+              color: Colors.black.withOpacity(0.35),
+              blurRadius: 18,
+              offset: const Offset(0, 10),
             ),
           ],
         ),
@@ -30,15 +41,11 @@ class SpeedLimitSign extends StatelessWidget {
         child: Text(
           displayText,
           textAlign: TextAlign.center,
-          style: textTheme.headlineSmall?.copyWith(
-                fontWeight: FontWeight.w700,
-                color: Colors.black87,
-              ) ??
-              const TextStyle(
-                fontSize: 28,
-                fontWeight: FontWeight.w700,
-                color: Colors.black87,
-              ),
+          style: const TextStyle(
+            fontSize: 28,
+            fontWeight: FontWeight.w700,
+            letterSpacing: -0.5,
+          ).copyWith(color: textColor),
         ),
       ),
     );

--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -8,6 +8,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 
+import 'package:toll_cam_finder/core/app_colors.dart';
 import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/app/app_routes.dart';
@@ -775,12 +776,36 @@ class _MapPageState extends State<MapPage>
             TollCamerasOverlay(cameras: cameraState),
           ],
         ),
+        Positioned(
+          left: 0,
+          right: 0,
+          top: 0,
+          child: IgnorePointer(
+            ignoring: true,
+            child: DecoratedBox(
+              decoration: const BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    AppColors.mapScrim,
+                    Colors.transparent,
+                  ],
+                ),
+              ),
+              child: const SizedBox(height: 160),
+            ),
+          ),
+        ),
         SafeArea(
           child: Align(
             alignment: Alignment.topLeft,
             child: Padding(
               padding: const EdgeInsets.only(top: 16, left: 16),
-              child: SpeedLimitSign(speedLimit: _osmSpeedLimitKph),
+              child: SpeedLimitSign(
+                speedLimit: _osmSpeedLimitKph,
+                currentSpeedKmh: _speedKmh,
+              ),
             ),
           ),
         ),
@@ -791,13 +816,35 @@ class _MapPageState extends State<MapPage>
               padding: const EdgeInsets.only(top: 16, right: 16),
               child: Builder(
                 builder: (context) {
-                  return Material(
-                    color: Colors.black54,
-                    shape: const CircleBorder(),
-                    child: IconButton(
-                      onPressed: () => Scaffold.of(context).openEndDrawer(),
-                      icon: const Icon(Icons.menu, color: Colors.white),
-                      tooltip: AppLocalizations.of(context).openMenu,
+                  final ScaffoldState? scaffoldState = Scaffold.maybeOf(context);
+                  final bool isDrawerOpen = scaffoldState?.isEndDrawerOpen ?? false;
+                  final Color backgroundColor =
+                      isDrawerOpen ? AppColors.primary : AppColors.surface.withOpacity(0.7);
+                  final Color iconColor = isDrawerOpen ? Colors.white : AppColors.onDark;
+                  final BorderSide borderSide = BorderSide(
+                    color: isDrawerOpen ? Colors.transparent : AppColors.divider,
+                    width: 1,
+                  );
+
+                  return DecoratedBox(
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.35),
+                          blurRadius: 24,
+                          offset: const Offset(0, 12),
+                        ),
+                      ],
+                    ),
+                    child: Material(
+                      color: backgroundColor,
+                      shape: CircleBorder(side: borderSide),
+                      child: IconButton(
+                        onPressed: () => Scaffold.of(context).openEndDrawer(),
+                        icon: Icon(Icons.menu, color: iconColor),
+                        tooltip: AppLocalizations.of(context).openMenu,
+                      ),
                     ),
                   );
                 },

--- a/lib/features/map/presentation/widgets/base_tile_layer.dart
+++ b/lib/features/map/presentation/widgets/base_tile_layer.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:toll_cam_finder/core/app_colors.dart';
 import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -88,26 +89,36 @@ class _OsmAttributionText extends StatelessWidget {
   Widget build(BuildContext context) {
     final baseStyle = TextStyle(
       fontSize: AppConstants.mapAttributionFontSize,
-      color: Colors.black.withOpacity(AppConstants.mapAttributionBaseOpacity),
+      color: AppColors.secondaryText,
       height: AppConstants.mapAttributionLineHeight,
     );
     final linkStyle = baseStyle.copyWith(
-      color: Theme.of(context).colorScheme.primary,
+      color: AppColors.secondaryText,
       decoration: TextDecoration.underline,
-      fontWeight: FontWeight.w500,
+      fontWeight: FontWeight.w600,
     );
 
-    return RichText(
-      text: TextSpan(
-        style: baseStyle,
-        children: [
-          const TextSpan(text: 'Map data from '),
-          TextSpan(
-            text: 'OpenStreetMap',
-            style: linkStyle,
-            recognizer: TapGestureRecognizer()..onTap = onLinkTap,
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.surface.withOpacity(0.6),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: AppColors.divider, width: 1),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: RichText(
+          text: TextSpan(
+            style: baseStyle,
+            children: [
+              const TextSpan(text: 'Map data from '),
+              TextSpan(
+                text: 'OpenStreetMap',
+                style: linkStyle,
+                recognizer: TapGestureRecognizer()..onTap = onLinkTap,
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add a centralized AppColors palette and update the global theme, surfaces, and snackbar styling to the new dark scheme
- restyle map overlays including the top scrim, menu button, mini FABs, speed limit badge, and attribution pill to match the refreshed palette
- refresh the segment metrics card visuals with the new typography, divider color, and semantic speed coloring rules

## Testing
- not run (flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f4ca6e71b8832d8d91919e835c0833