### PR TITLE
Refine TollSignal splash screen integration

### DIFF
--- a/lib/bootstrap/toll_signal_bootstrap.dart
+++ b/lib/bootstrap/toll_signal_bootstrap.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:toll_cam_finder/app/app.dart';
+import 'package:toll_cam_finder/core/supabase_config.dart';
+import 'package:toll_cam_finder/features/auth/application/auth_controller.dart';
+import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
+import 'package:toll_cam_finder/features/map/domain/controllers/guidance_audio_controller.dart';
+import 'package:toll_cam_finder/shared/services/language_controller.dart';
+import 'package:toll_cam_finder/shared/services/theme_controller.dart';
+import 'package:toll_cam_finder/splash/toll_signal_splash.dart';
+
+Future<SupabaseClient?> initializeApp() async {
+  SupabaseClient? supabaseClient;
+
+  if (SupabaseConfig.isConfigured) {
+    final supabase = await Supabase.initialize(
+      url: SupabaseConfig.supabaseUrl,
+      anonKey: SupabaseConfig.supabaseAnonKey,
+    );
+    supabaseClient = supabase.client;
+  } else {
+    debugPrint(
+      'Supabase credentials missing. Authentication features are disabled.',
+    );
+  }
+
+  return supabaseClient;
+}
+
+class TollSignalBootstrap extends StatefulWidget {
+  const TollSignalBootstrap({super.key});
+
+  @override
+  State<TollSignalBootstrap> createState() => _TollSignalBootstrapState();
+}
+
+class _TollSignalBootstrapState extends State<TollSignalBootstrap> {
+  SupabaseClient? _supabaseClient;
+  bool _isReady = false;
+  bool _isInitializing = false;
+
+  Future<void> _handleReady() async {
+    if (_isInitializing || _isReady) {
+      return;
+    }
+
+    setState(() {
+      _isInitializing = true;
+    });
+
+    try {
+      final client = await initializeApp();
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _supabaseClient = client;
+        _isReady = true;
+        _isInitializing = false;
+      });
+    } catch (error, stackTrace) {
+      debugPrint('Failed to initialize TollSignal: $error\n$stackTrace');
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _isInitializing = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isReady) {
+      return MaterialApp(
+        title: 'TollSignal',
+        theme: ThemeData(brightness: Brightness.light, useMaterial3: true),
+        darkTheme: ThemeData(brightness: Brightness.dark, useMaterial3: true),
+        debugShowCheckedModeBanner: false,
+        home: TollSignalSplash(
+          title: 'TollSignal',
+          tagline: "Know what's ahead.",
+          onReady: _handleReady,
+        ),
+      );
+    }
+
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) => AverageSpeedController(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => AuthController(client: _supabaseClient),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => LanguageController(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => GuidanceAudioController(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => ThemeController(),
+        ),
+      ],
+      child: const TollCamApp(),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,51 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:toll_cam_finder/app/app.dart';
-import 'package:toll_cam_finder/core/supabase_config.dart';
-import 'package:toll_cam_finder/features/auth/application/auth_controller.dart';
-import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
-import 'package:toll_cam_finder/features/map/domain/controllers/guidance_audio_controller.dart';
-import 'package:toll_cam_finder/shared/services/language_controller.dart';
-import 'package:toll_cam_finder/shared/services/theme_controller.dart';
+import 'package:toll_cam_finder/bootstrap/toll_signal_bootstrap.dart';
 
-void main() async {
+void main() {
   WidgetsFlutterBinding.ensureInitialized();
-
-  SupabaseClient? supabaseClient;
-
-  if (SupabaseConfig.isConfigured) {
-    final supabase = await Supabase.initialize(
-      url: SupabaseConfig.supabaseUrl,
-      anonKey: SupabaseConfig.supabaseAnonKey,
-    );
-    supabaseClient = supabase.client;
-  } else {
-    debugPrint(
-      'Supabase credentials missing. Authentication features are disabled.',
-    );
-  }
-
-  runApp(
-    MultiProvider(
-      providers: [
-        ChangeNotifierProvider(
-          create: (_) => AverageSpeedController(),
-        ),
-        ChangeNotifierProvider(
-          create: (_) => AuthController(client: supabaseClient),
-        ),
-        ChangeNotifierProvider(
-          create: (_) => LanguageController(),
-        ),
-        ChangeNotifierProvider(
-          create: (_) => GuidanceAudioController(),
-        ),
-        ChangeNotifierProvider(
-          create: (_) => ThemeController(),
-        ),
-      ],
-      child: const TollCamApp(),
-    ),
-  );
+  runApp(const TollSignalBootstrap());
 }

--- a/lib/splash/toll_signal_splash.dart
+++ b/lib/splash/toll_signal_splash.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+
+class TollSignalSplash extends StatefulWidget {
+  final String title;
+  final String tagline;
+  final Future<void> Function() onReady; // called immediately on build
+  final bool useBrandYellowBackground; // true: native-like yellow; false: dark gradient
+
+  const TollSignalSplash({
+    super.key,
+    required this.onReady,
+    this.title = 'TollSignal',
+    this.tagline = "Know what's ahead.",
+    this.useBrandYellowBackground = false,
+  });
+
+  @override
+  State<TollSignalSplash> createState() => _TollSignalSplashState();
+}
+
+class _TollSignalSplashState extends State<TollSignalSplash>
+    with TickerProviderStateMixin {
+  late final AnimationController _pulse1;
+  late final AnimationController _pulse2;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulse1 = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1600),
+    )..repeat();
+    _pulse2 = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1600),
+    )
+      ..forward(from: 0.25)
+      ..repeat();
+
+    // Kick off initialization work immediately
+    WidgetsBinding.instance.addPostFrameCallback((_) => widget.onReady());
+  }
+
+  @override
+  void dispose() {
+    _pulse1.dispose();
+    _pulse2.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const brandYellow = Color(0xFFFFC400);
+    const asphalt = Color(0xFF0B1117);
+    const night = Color(0xFF06090D);
+    const teal = Color(0xFF2FD3FF);
+    const amber = Color(0xFFFFC043);
+
+    final bool dark =
+        MediaQuery.of(context).platformBrightness == Brightness.dark;
+
+    final BoxDecoration background =
+        widget.useBrandYellowBackground && !dark
+            ? const BoxDecoration(color: brandYellow)
+            : const BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [night, asphalt],
+                ),
+              );
+
+    return Scaffold(
+      body: Container(
+        decoration: background,
+        alignment: Alignment.center,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // Animated radar-like pulses + your icon in the center
+            SizedBox(
+              width: 220,
+              height: 220,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  AnimatedBuilder(
+                    animation: Listenable.merge([_pulse1, _pulse2]),
+                    builder: (context, _) {
+                      return CustomPaint(
+                        size: const Size.square(220),
+                        painter: _PulsePainter(
+                          p1: _pulse1.value,
+                          p2: _pulse2.value,
+                          pulseColor: teal.withOpacity(0.35),
+                          ringColor: amber.withOpacity(0.55),
+                        ),
+                      );
+                    },
+                  ),
+                  // Your provided app icon. Ship the PNG with your app at the path
+                  // below; if it's missing locally (e.g. binary omitted from source
+                  // control) we fall back to a neutral glyph so the splash still
+                  // renders gracefully.
+                  Image.asset(
+                    'assets/branding/tollsignal_icon.png',
+                    width: 140,
+                    fit: BoxFit.contain,
+                    errorBuilder: (context, _, __) => const Icon(
+                      Icons.navigation,
+                      size: 96,
+                      color: Colors.white,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 22),
+            Text(
+              widget.title,
+              style: const TextStyle(
+                fontSize: 26,
+                fontWeight: FontWeight.w600,
+                color: Colors.white,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              widget.tagline,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 14,
+                color: Colors.white.withOpacity(0.8),
+              ),
+            ),
+            const SizedBox(height: 32),
+            Opacity(
+              opacity: 0.7,
+              child: Text(
+                'Preparing verified toll segments…',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.white.withOpacity(0.7),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PulsePainter extends CustomPainter {
+  final double p1; // 0..1
+  final double p2; // 0..1
+  final Color pulseColor;
+  final Color ringColor;
+
+  _PulsePainter({
+    required this.p1,
+    required this.p2,
+    required this.pulseColor,
+    required this.ringColor,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final base = size.shortestSide * 0.36;
+
+    void drawPulse(double t) {
+      final radius = base * (1 + t * 0.9);
+      final alpha = (1 - t).clamp(0.0, 1.0);
+      final paint = Paint()
+        ..color = pulseColor.withOpacity(0.45 * alpha)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = base * 0.06 * (1 - t);
+      canvas.drawCircle(center, radius, paint);
+    }
+
+    drawPulse(p1);
+    drawPulse(p2);
+
+    final ringPaint1 = Paint()
+      ..color = ringColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = base * 0.028;
+    final ringPaint2 = Paint()
+      ..color = ringColor.withOpacity(0.35)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = base * 0.022;
+
+    canvas.drawCircle(center, base * 1.15, ringPaint1);
+    canvas.drawCircle(center, base * 1.45, ringPaint2);
+  }
+
+  @override
+  bool shouldRepaint(covariant _PulsePainter oldDelegate) {
+    return oldDelegate.p1 != p1 || oldDelegate.p2 != p2;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,9 +30,21 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+  flutter_native_splash: ^2.4.1
 
 flutter:
   uses-material-design: true
   assets:
     - assets/data/toll_segments.csv
     - assets/data/ding_sound.mp3
+    - assets/branding/tollsignal_icon.png
+
+flutter_native_splash:
+  color: "#FFC400"
+  image: assets/branding/tollsignal_icon.png
+  android_12:
+    color: "#FFC400"
+    image: assets/branding/tollsignal_icon.png
+  android: true
+  ios: true
+  web: false


### PR DESCRIPTION
## Summary
- show an animated TollSignal splash screen while async app setup finishes
- host the TollSignal splash bootstrap flow in a dedicated file and fall back gracefully when the icon asset is absent
- configure flutter_native_splash without the optional wordmark branding

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f4d23d392c832da7a61d0375795fe8