### PR TITLE
Highlight segment average speed when above limit

### DIFF
--- a/lib/features/map/presentation/pages/map/widgets/map_controls/segment_metrics_card.dart
+++ b/lib/features/map/presentation/pages/map/widgets/map_controls/segment_metrics_card.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:toll_cam_finder/app/localization/app_localizations.dart';
 import 'package:toll_cam_finder/core/app_colors.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
+import 'package:toll_cam_finder/features/map/presentation/widgets/speed_limit_colors.dart';
 
 class SegmentMetricsCard extends StatelessWidget {
   const SegmentMetricsCard({
@@ -80,11 +81,13 @@ class SegmentMetricsCard extends StatelessWidget {
         final bool showSafeSpeed =
             averagingActive && safeSpeedFormatted.hasValue;
 
-        final Color? currentSpeedColor = _resolveCurrentSpeedColor(
-          palette,
-          currentSpeedKmh,
-          speedLimitKph,
-        );
+        final Color? averageSpeedColor = averagingActive
+            ? resolveSpeedLimitColor(
+                palette,
+                avgController.average,
+                speedLimitKph,
+              )
+            : null;
 
         final String distanceLabelKey = hasActiveSegment
             ? 'segmentMetricsDistanceToEnd'
@@ -103,12 +106,12 @@ class SegmentMetricsCard extends StatelessWidget {
           _MetricTileData(
             label: localizations.translate('segmentMetricsCurrentSpeed'),
             value: currentSpeed,
-            valueColor: currentSpeedColor,
             unitColor: palette.secondaryText,
           ),
           _MetricTileData(
             label: localizations.translate('segmentMetricsAverageSpeed'),
             value: averageSpeed,
+            valueColor: averageSpeedColor,
             unitColor: palette.secondaryText,
           ),
           _MetricTileData(
@@ -563,33 +566,6 @@ class _MetricTile extends StatelessWidget {
       ),
     );
   }
-}
-
-Color? _resolveCurrentSpeedColor(
-  AppPalette palette,
-  double? currentSpeedKmh,
-  double? limitKph,
-) {
-  final double? current = _sanitizeSpeedValue(currentSpeedKmh);
-  final double? limit = _sanitizeSpeedValue(limitKph);
-  if (current == null || limit == null || limit <= 0) {
-    return null;
-  }
-
-  final double ratio = current / limit;
-  if (ratio <= 0.8) {
-    return palette.success;
-  }
-  if (ratio < 1.0) {
-    return palette.warning;
-  }
-  return palette.danger;
-}
-
-double? _sanitizeSpeedValue(double? value) {
-  if (value == null || !value.isFinite) return null;
-  if (value < 0) return 0;
-  return value;
 }
 
 double? _sanitizeDistance(double? meters) {

--- a/lib/features/map/presentation/widgets/avg_speed_dial.dart
+++ b/lib/features/map/presentation/widgets/avg_speed_dial.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+import 'package:toll_cam_finder/core/app_colors.dart';
 import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
+import 'package:toll_cam_finder/features/map/presentation/widgets/speed_limit_colors.dart';
 
 /// "Average speed" dial styled to match CurrentSpeedDial.
 class AverageSpeedDial extends StatelessWidget {
@@ -29,6 +31,7 @@ class AverageSpeedDial extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
+    final AppPalette palette = AppColors.of(context);
 
     final localizations = AppLocalizations.of(context);
     final resolvedTitle = title ?? AppMessages.speedDialAverageTitle;
@@ -39,6 +42,12 @@ class AverageSpeedDial extends StatelessWidget {
       builder: (context, _) {
         final avgRaw = controller.average;
         final avg = avgRaw.isFinite ? avgRaw : 0.0;
+        final double? avgForColor = avgRaw.isFinite ? avgRaw : null;
+        final Color? avgColor = resolveSpeedLimitColor(
+          palette,
+          avgForColor,
+          speedLimitKph,
+        );
 
         return SizedBox(
           width: width,
@@ -77,7 +86,10 @@ class AverageSpeedDial extends StatelessWidget {
                         children: [
                           Text(
                             avg.toStringAsFixed(decimals),
-                            style: textTheme.displaySmall,
+                            style: avgColor == null
+                                ? textTheme.displaySmall
+                                : (textTheme.displaySmall ?? const TextStyle())
+                                    .copyWith(color: avgColor),
                           ),
                           const SizedBox(width: AppConstants.speedDialValueUnitSpacing),
                           Padding(

--- a/lib/features/map/presentation/widgets/speed_limit_colors.dart
+++ b/lib/features/map/presentation/widgets/speed_limit_colors.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:toll_cam_finder/core/app_colors.dart';
+
+Color? resolveSpeedLimitColor(
+  AppPalette palette,
+  double? speedKph,
+  double? limitKph,
+) {
+  final double? speed = _sanitizeSpeedValue(speedKph);
+  final double? limit = _sanitizeSpeedValue(limitKph);
+  if (speed == null || limit == null || limit <= 0) {
+    return null;
+  }
+
+  final double ratio = speed / limit;
+  if (ratio <= 0.8) {
+    return palette.success;
+  }
+  if (ratio < 1.0) {
+    return palette.warning;
+  }
+  return palette.danger;
+}
+
+double? _sanitizeSpeedValue(double? value) {
+  if (value == null || !value.isFinite) return null;
+  if (value < 0) return 0;
+  return value;
+}
+


### PR DESCRIPTION
## Summary
- move speed limit highlighting to the segment average speed value
- share the limit-based color resolution logic between widgets and apply it to the average speed dial

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f4f369afe4832d955a9a09535ad06b