### PR TITLE
Log OSM requests in debug builds

### DIFF
--- a/lib/features/segments/domain/tracking/osrm_path_fetcher.dart
+++ b/lib/features/segments/domain/tracking/osrm_path_fetcher.dart
@@ -19,6 +19,16 @@ Future<List<GeoPoint>?> fetchOsrmRoute({
     '?overview=full&geometries=geojson',
   );
 
+  const logLabel = '[OSM Routing]';
+  final logMessage =
+      '$logLabel Requesting route from ${start.lat.toStringAsFixed(6)}, '
+      '${start.lon.toStringAsFixed(6)} '
+      'to ${end.lat.toStringAsFixed(6)}, ${end.lon.toStringAsFixed(6)}';
+  onDebug?.call(logMessage);
+  if (kDebugMode) {
+    debugPrint(logMessage);
+  }
+
   try {
     final response = await client.get(uri, headers: const {
       'User-Agent': 'toll_cam_finder/segment-tracker',
@@ -26,7 +36,12 @@ Future<List<GeoPoint>?> fetchOsrmRoute({
     });
 
     if (response.statusCode != 200) {
-      onDebug?.call('status ${response.statusCode} for ${uri.path}');
+      final statusMessage =
+          '$logLabel Non-200 response (${response.statusCode}) for ${uri.path}';
+      onDebug?.call(statusMessage);
+      if (kDebugMode) {
+        debugPrint(statusMessage);
+      }
       return null;
     }
 
@@ -80,8 +95,10 @@ Future<List<GeoPoint>?> fetchOsrmRoute({
 
     return path;
   } catch (e) {
+    final failureMessage = '$logLabel Failed to fetch enhanced path: $e';
+    onDebug?.call(failureMessage);
     if (kDebugMode) {
-      onDebug?.call('failed to fetch enhanced path: $e');
+      debugPrint(failureMessage);
     }
     return null;
   }


### PR DESCRIPTION
## Summary
- add debug logging around OpenStreetMap Overpass speed-limit requests
- log OSRM routing requests and error conditions with distinct labels for easier tracing

## Testing
- not run (not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68f5c6e755d0832da62f9bce1e5ae7a3