### PR TITLE
Log OpenStreetMap tile requests in debug builds

### DIFF
--- a/lib/features/map/presentation/widgets/base_tile_layer.dart
+++ b/lib/features/map/presentation/widgets/base_tile_layer.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -69,6 +70,7 @@ class BaseTileLayer extends StatelessWidget {
         TileLayer(
           urlTemplate: AppConstants.mapURL,
           userAgentPackageName: AppConstants.userAgentPackageName,
+          tileProvider: _loggingTileProvider,
         ),
         Positioned(
           left: attributionLeft,
@@ -116,6 +118,31 @@ class _OsmAttributionText extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+final _LoggingNetworkTileProvider _loggingTileProvider =
+    _LoggingNetworkTileProvider();
+
+class _LoggingNetworkTileProvider extends NetworkTileProvider {
+  _LoggingNetworkTileProvider();
+
+  @override
+  ImageProvider getImageWithCancelLoadingSupport(
+    TileCoordinates coordinates,
+    TileLayer options,
+    Future<void> cancelLoading,
+  ) {
+    if (kDebugMode) {
+      final url = getTileUrl(coordinates, options);
+      debugPrint('Requesting OpenStreetMap tile: $url');
+    }
+
+    return super.getImageWithCancelLoadingSupport(
+      coordinates,
+      options,
+      cancelLoading,
     );
   }
 }


### PR DESCRIPTION
## Summary
- add a custom tile provider that logs each OpenStreetMap tile request when debugging
- wire the provider into the shared base tile layer so the message shows for all OSM tiles

## Testing
- not run (Flutter SDK is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68f5d24d8908832d81c76895131f585e