### PR TITLE
Localize segment status badges

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -185,6 +185,11 @@ class AppLocalizations {
       'segmentDeleted': 'Segment {displayId} deleted.',
       'segmentHidden':
           'Segment {displayId} hidden. Cameras and warnings are disabled.',
+      'segmentBadgeHidden': 'Hidden',
+      'segmentBadgeLocal': 'Local',
+      'segmentBadgeReview': 'In review',
+      'segmentLocationStartLabel': 'Start',
+      'segmentLocationEndLabel': 'End',
       'segmentMetadataUpdateUnavailable':
           'Segment metadata cannot be updated on the web.',
       'segmentMissingCoordinates':
@@ -415,8 +420,13 @@ class AppLocalizations {
 'segmentPickerEndMarkerLabel': 'B',
 'segmentMissingCoordinates':
 'Запазеният сегмент няма координати и не може да бъде споделен публично.',
-'segmentHidden':
-'Сегмент {displayId} е скрит. Камерите и предупрежденията са изключени.',
+      'segmentHidden':
+          'Сегмент {displayId} е скрит. Камерите и предупрежденията са изключени.',
+      'segmentBadgeHidden': 'Скрит',
+      'segmentBadgeLocal': 'Локален',
+      'segmentBadgeReview': 'В преглед',
+      'segmentLocationStartLabel': 'Начало',
+      'segmentLocationEndLabel': 'Край',
 'segmentVisible':
 'Сегмент {displayId} отново е видим. Камерите и предупрежденията са възстановени.',
 'segmentVisibilityDisableSubtitle':

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -65,6 +65,16 @@ class AppMessages {
       _l.translate('segmentVisibilityRestoreSubtitle');
   static String get segmentVisibilityDisableSubtitle =>
       _l.translate('segmentVisibilityDisableSubtitle');
+  static String get segmentBadgeHidden =>
+      _l.translate('segmentBadgeHidden');
+  static String get segmentBadgeLocal =>
+      _l.translate('segmentBadgeLocal');
+  static String get segmentBadgeReview =>
+      _l.translate('segmentBadgeReview');
+  static String get segmentLocationStartLabel =>
+      _l.translate('segmentLocationStartLabel');
+  static String get segmentLocationEndLabel =>
+      _l.translate('segmentLocationEndLabel');
   static String segmentHidden(String displayId) =>
       _l.translate('segmentHidden', {'displayId': displayId});
   static String segmentVisible(String displayId) =>

--- a/lib/features/segments/presentation/widgets/add_segment/segment_card.dart
+++ b/lib/features/segments/presentation/widgets/add_segment/segment_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:toll_cam_finder/core/app_messages.dart';
 import 'package:toll_cam_finder/features/segments/services/segments_repository.dart';
 
 class SegmentCard extends StatelessWidget {
@@ -51,7 +52,7 @@ class SegmentCard extends StatelessWidget {
                 children: [
                   Expanded(
                     child: _SegmentLocation(
-                      title: 'Start',
+                      title: AppMessages.segmentLocationStartLabel,
                       value: segment.startDisplayName,
                       fallback: segment.startCoordinates,
                     ),
@@ -59,7 +60,7 @@ class SegmentCard extends StatelessWidget {
                   const SizedBox(width: 16),
                   Expanded(
                     child: _SegmentLocation(
-                      title: 'End',
+                      title: AppMessages.segmentLocationEndLabel,
                       value: segment.endDisplayName,
                       fallback: segment.endCoordinates,
                     ),
@@ -91,7 +92,7 @@ class _DeactivatedBadge extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
       ),
       child: Text(
-        'Hidden',
+        AppMessages.segmentBadgeHidden,
         style: theme.textTheme.labelSmall?.copyWith(
           color: theme.colorScheme.onErrorContainer,
         ),
@@ -113,7 +114,7 @@ class _LocalBadge extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
       ),
       child: Text(
-        'Local',
+        AppMessages.segmentBadgeLocal,
         style: theme.textTheme.labelSmall?.copyWith(
           color: theme.colorScheme.onSecondaryContainer,
         ),
@@ -135,7 +136,7 @@ class _ReviewBadge extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
       ),
       child: Text(
-        'Review',
+        AppMessages.segmentBadgeReview,
         style: theme.textTheme.labelSmall?.copyWith(
           color: theme.colorScheme.onTertiaryContainer,
         ),


### PR DESCRIPTION
## Summary
- add localized strings for segment badges and location labels in English and Bulgarian
- expose new localized helpers and apply them to the segment card UI

## Testing
- flutter test *(fails: Flutter SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f5d1e08b24832da57514820d0e7894