### PR TITLE
Ensure user segments receive sequential identifiers

### DIFF
--- a/lib/features/segments/services/remote_segments_service.dart
+++ b/lib/features/segments/services/remote_segments_service.dart
@@ -47,21 +47,38 @@ class RemoteSegmentsService {
       );
     }
 
-    final pendingId = await _computeNextRemoteId(client);
+    var pendingId = await _computeNextRemoteId(client);
 
     try {
-      await client.from(tableName).insert(<String, dynamic>{
-        'id': pendingId,
-        _nameColumn: draft.name,
-        _roadColumn: draft.roadName,
-        'Start name': draft.startDisplayName,
-        'End name': draft.endDisplayName,
-        'Start': draft.startCoordinates,
-        'End': draft.endCoordinates,
-        'speed_limit_kph': draft.speedLimitKph,
-        _moderationStatusColumn: _pendingStatus,
-        _addedByUserColumn: addedByUserId,
-      });
+      while (true) {
+        try {
+          await client.from(tableName).insert(<String, dynamic>{
+            'id': pendingId,
+            _nameColumn: draft.name,
+            _roadColumn: draft.roadName,
+            'Start name': draft.startDisplayName,
+            'End name': draft.endDisplayName,
+            'Start': draft.startCoordinates,
+            'End': draft.endCoordinates,
+            'speed_limit_kph': draft.speedLimitKph,
+            _moderationStatusColumn: _pendingStatus,
+            _addedByUserColumn: addedByUserId,
+          });
+          break;
+        } on PostgrestException catch (error) {
+          if (_isIdConflict(error)) {
+            pendingId += 1;
+            if (pendingId > _smallIntMax) {
+              throw RemoteSegmentsServiceException(
+                AppMessages.unableToAssignNewSegmentId,
+                cause: error,
+              );
+            }
+            continue;
+          }
+          rethrow;
+        }
+      }
     } on SocketException catch (error) {
       throw RemoteSegmentsServiceException(
         AppMessages.noConnectionUnableToSubmitForModeration,
@@ -75,6 +92,9 @@ class RemoteSegmentsService {
         cause: error,
       );
     } catch (error, stackTrace) {
+      if (error is RemoteSegmentsServiceException) {
+        rethrow;
+      }
       throw RemoteSegmentsServiceException(
         AppMessages.unexpectedErrorSubmittingForModeration,
         cause: error,
@@ -258,6 +278,26 @@ class RemoteSegmentsService {
     }
 
     return nextId;
+  }
+
+  bool _isIdConflict(PostgrestException error) {
+    final code = error.code?.toUpperCase();
+    if (code != '23505') {
+      return false;
+    }
+
+    final message = (error.message ?? '').toLowerCase();
+    if (message.contains('id')) {
+      return true;
+    }
+
+    final details = error.details?.toLowerCase() ?? '';
+    if (details.contains('id')) {
+      return true;
+    }
+
+    final hint = error.hint?.toLowerCase() ?? '';
+    return hint.contains('id');
   }
 
   int _parseId(dynamic value) {

--- a/lib/features/segments/services/segment_id_generator.dart
+++ b/lib/features/segments/services/segment_id_generator.dart
@@ -1,17 +1,47 @@
-import 'package:uuid/uuid.dart';
-
 import 'toll_segments_csv_constants.dart';
 
 /// Generates unique identifiers for user-created segments that are stored locally.
 class SegmentIdGenerator {
   SegmentIdGenerator._();
 
-  static const Uuid _uuid = Uuid();
-
   /// Generates an identifier suitable for storing local-only segments.
-  static String generateLocalId() {
-    final timestamp = DateTime.now().toUtc().microsecondsSinceEpoch.toRadixString(36);
-    final uniqueComponent = _uuid.v7().replaceAll('-', '');
-    return '${TollSegmentsCsvSchema.localSegmentIdPrefix}$timestamp-$uniqueComponent';
+  ///
+  /// The identifier is derived from the highest numeric identifier present
+  /// either in the locally stored custom segments or in the remote dataset and
+  /// incremented by one. When neither source contains numeric identifiers the
+  /// sequence starts at `1`.
+  static String generateLocalId({
+    required Iterable<String> existingLocalIds,
+    required Iterable<String> remoteIds,
+  }) {
+    final prefix = TollSegmentsCsvSchema.localSegmentIdPrefix;
+    final maxRemoteId = _highestNumericId(remoteIds);
+    final maxLocalId = _highestNumericId(existingLocalIds.map(_stripLocalPrefix));
+    final nextId = (maxRemoteId > maxLocalId ? maxRemoteId : maxLocalId) + 1;
+    return '$prefix$nextId';
+  }
+
+  static String _stripLocalPrefix(String id) {
+    final prefix = TollSegmentsCsvSchema.localSegmentIdPrefix;
+    if (id.startsWith(prefix)) {
+      return id.substring(prefix.length);
+    }
+    return id;
+  }
+
+  static int _highestNumericId(Iterable<String> ids) {
+    var maxId = 0;
+    for (final raw in ids) {
+      final normalized = raw.trim();
+      if (normalized.isEmpty) {
+        continue;
+      }
+
+      final parsed = int.tryParse(normalized);
+      if (parsed != null && parsed > maxId) {
+        maxId = parsed;
+      }
+    }
+    return maxId;
   }
 }

--- a/lib/features/segments/services/toll_segments_data_store.dart
+++ b/lib/features/segments/services/toll_segments_data_store.dart
@@ -25,6 +25,17 @@ class TollSegmentsDataStore {
     );
   }
 
+  /// Ensures the remote rows are loaded into memory and returns a copy.
+  Future<List<List<String>>> ensureRemoteRows({
+    String assetPath = kTollSegmentsAssetPath,
+  }) async {
+    final rows = await _ensureRemoteRows(assetPath: assetPath);
+    return List<List<String>>.from(
+      rows.map((row) => List<String>.from(row)),
+      growable: false,
+    );
+  }
+
   /// Clears the cached remote rows.
   void clear() {
     _remoteRows = null;

--- a/test/services/segment_id_generator_test.dart
+++ b/test/services/segment_id_generator_test.dart
@@ -3,14 +3,39 @@ import 'package:toll_cam_finder/features/segments/services/segment_id_generator.
 import 'package:toll_cam_finder/features/segments/services/toll_segments_csv_constants.dart';
 
 void main() {
-  test('generateLocalId returns unique values with expected prefix', () {
-    final prefix = TollSegmentsCsvSchema.localSegmentIdPrefix;
-    final generated = <String>{};
+  test('generateLocalId starts after the highest remote identifier', () {
+    final id = SegmentIdGenerator.generateLocalId(
+      existingLocalIds: const <String>[],
+      remoteIds: const <String>['12', '7', '99'],
+    );
 
-    for (var i = 0; i < 500; i++) {
-      final id = SegmentIdGenerator.generateLocalId();
-      expect(id.startsWith(prefix), isTrue, reason: 'Local ID should start with prefix.');
-      expect(generated.add(id), isTrue, reason: 'Local IDs must be unique.');
+    expect(id, '${TollSegmentsCsvSchema.localSegmentIdPrefix}100');
+  });
+
+  test('generateLocalId increments when local identifiers exist', () {
+    final generated = <String>[];
+
+    for (var i = 0; i < 3; i++) {
+      final id = SegmentIdGenerator.generateLocalId(
+        existingLocalIds: generated,
+        remoteIds: const <String>['5'],
+      );
+      generated.add(id);
     }
+
+    expect(generated, <String>[
+      '${TollSegmentsCsvSchema.localSegmentIdPrefix}6',
+      '${TollSegmentsCsvSchema.localSegmentIdPrefix}7',
+      '${TollSegmentsCsvSchema.localSegmentIdPrefix}8',
+    ]);
+  });
+
+  test('generateLocalId ignores non-numeric identifiers', () {
+    final id = SegmentIdGenerator.generateLocalId(
+      existingLocalIds: const <String>['${TollSegmentsCsvSchema.localSegmentIdPrefix}foo-123'],
+      remoteIds: const <String>['abc', ''],
+    );
+
+    expect(id, '${TollSegmentsCsvSchema.localSegmentIdPrefix}1');
   });
 }


### PR DESCRIPTION
## Summary
- generate local segment identifiers by incrementing the highest numeric id from Supabase data and existing local entries
- expose cached remote rows from the toll segments data store so the generator can discover the latest ids
- retry Supabase submissions with the next id when an insert hits a conflict
- update segment id generator tests to cover the new sequential behaviour

## Testing
- Unable to run `flutter test test/services/segment_id_generator_test.dart` *(Flutter SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f717714650832daabc4d243bcb332c