### PR TITLE
Add segments-only mode page with offline fallback

### DIFF
--- a/lib/app/app_routes.dart
+++ b/lib/app/app_routes.dart
@@ -3,6 +3,7 @@ import 'package:toll_cam_finder/features/auth/presentation/pages/login_page.dart
 import 'package:toll_cam_finder/features/auth/presentation/pages/profile_page.dart';
 import 'package:toll_cam_finder/features/auth/presentation/pages/sign_up_page.dart';
 import 'package:toll_cam_finder/features/map/presentation/pages/map_page.dart';
+import 'package:toll_cam_finder/features/map/presentation/pages/segments_only_page.dart';
 import 'package:toll_cam_finder/features/segments/presentation/pages/create_segment_page.dart';
 import 'package:toll_cam_finder/features/segments/presentation/pages/segments_page.dart';
 
@@ -15,6 +16,7 @@ class AppRoutes {
   static const String segments = '/segments';
   static const String localSegments = '/segments/local';
   static const String createSegment = '/segments/create';
+  static const String segmentsOnly = '/segments-only';
 
   static Map<String, WidgetBuilder> get routes => {
     map: (_) => const MapPage(),
@@ -24,5 +26,6 @@ class AppRoutes {
     segments: (_) => const SegmentsPage(),
     localSegments: (_) => const LocalSegmentsPage(),
     createSegment: (_) => const CreateSegmentPage(),
+    segmentsOnly: (_) => const SegmentsOnlyPage(),
   };
 }

--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -218,6 +218,14 @@ class AppLocalizations {
       'segmentVisible':
           'Segment {displayId} is visible again. Cameras and warnings restored.',
       'segments': 'Segments',
+      'segmentsOnlyModeTitle': 'Segments-only mode',
+      'segmentsOnlyModeButton': 'Segments-only mode',
+      'segmentsOnlyModeManualMessage':
+          'You are viewing segments-only mode. Use this screen to monitor your segment metrics without the map. Tap the back button to return to the map.',
+      'segmentsOnlyModeOsmBlockedMessage':
+          "Don't worry, we are still observing for segments and average speed, but as this is a free app, we rely on free map providers, which are currently experiencing a shortage. We are sorry for the inconvenience and we are working on the issue.",
+      'segmentsOnlyModeReminder':
+          'Segments and averages continue to update while this view is open.',
       'selectLanguage': 'Select language',
       'shareSegmentPubliclyAction': 'Share segment publicly',
       'showSegmentOnMapAction': 'Show segment on map',
@@ -410,6 +418,14 @@ class AppLocalizations {
 'segmentProgressStartMeters': '{distance} м до началото на сегмента',
 'segmentProgressStartNearby': 'Началото на сегмента е близо',
 'segments': 'Сегменти',
+'segmentsOnlyModeTitle': 'Режим само сегменти',
+'segmentsOnlyModeButton': 'Режим само сегменти',
+'segmentsOnlyModeManualMessage':
+'В момента използвате режим само сегменти. Използвайте този екран, за да следите показателите без картата. Натиснете бутона назад, за да се върнете към картата.',
+'segmentsOnlyModeOsmBlockedMessage':
+'Не се притеснявайте, все още наблюдаваме сегментите и средната скорост, но тъй като приложението е безплатно, разчитаме на безплатни доставчици на карти, които в момента изпитват затруднения. Извиняваме се за неудобството и работим по отстраняването на проблема.',
+'segmentsOnlyModeReminder':
+'Сегментите и средната скорост продължават да се обновяват, докато този екран е отворен.',
 'selectLanguage': 'Избери език',
 'signInToSharePubliclyBody':
 'Трябва да си влязъл в акаунта си, за да изпратиш публичен сегмент. Искаш ли да влезеш или вместо това да запазиш сегмента локално?',
@@ -523,6 +539,14 @@ class AppLocalizations {
   String get appTitle => _value('appTitle');
   String get sync => _value('sync');
   String get segments => _value('segments');
+  String get segmentsOnlyModeTitle => _value('segmentsOnlyModeTitle');
+  String get segmentsOnlyModeButton => _value('segmentsOnlyModeButton');
+  String get segmentsOnlyModeManualMessage =>
+      _value('segmentsOnlyModeManualMessage');
+  String get segmentsOnlyModeOsmBlockedMessage =>
+      _value('segmentsOnlyModeOsmBlockedMessage');
+  String get segmentsOnlyModeReminder =>
+      _value('segmentsOnlyModeReminder');
   String get language => _value('language');
   String get profile => _value('profile');
   String get selectLanguage => _value('selectLanguage');

--- a/lib/features/map/domain/controllers/segments_only_mode_controller.dart
+++ b/lib/features/map/domain/controllers/segments_only_mode_controller.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:toll_cam_finder/features/segments/domain/tracking/segment_tracker_models.dart';
+
+enum SegmentsOnlyModeReason { manual, osmUnavailable }
+
+class SegmentsOnlyModeController extends ChangeNotifier {
+  double? _currentSpeedKmh;
+  bool _hasActiveSegment = false;
+  double? _segmentSpeedLimitKph;
+  SegmentDebugPath? _segmentDebugPath;
+  double? _distanceToSegmentStartMeters;
+  SegmentsOnlyModeReason? _reason;
+  bool _isActive = false;
+
+  double? get currentSpeedKmh => _currentSpeedKmh;
+  bool get hasActiveSegment => _hasActiveSegment;
+  double? get segmentSpeedLimitKph => _segmentSpeedLimitKph;
+  SegmentDebugPath? get segmentDebugPath => _segmentDebugPath;
+  double? get distanceToSegmentStartMeters => _distanceToSegmentStartMeters;
+  SegmentsOnlyModeReason? get reason => _reason;
+  bool get isActive => _isActive;
+
+  void updateMetrics({
+    required double? currentSpeedKmh,
+    required bool hasActiveSegment,
+    required double? segmentSpeedLimitKph,
+    required SegmentDebugPath? segmentDebugPath,
+    required double? distanceToSegmentStartMeters,
+  }) {
+    bool changed = false;
+
+    if (_currentSpeedKmh != currentSpeedKmh) {
+      _currentSpeedKmh = currentSpeedKmh;
+      changed = true;
+    }
+
+    if (_hasActiveSegment != hasActiveSegment) {
+      _hasActiveSegment = hasActiveSegment;
+      changed = true;
+    }
+
+    if (_segmentSpeedLimitKph != segmentSpeedLimitKph) {
+      _segmentSpeedLimitKph = segmentSpeedLimitKph;
+      changed = true;
+    }
+
+    if (!identical(_segmentDebugPath, segmentDebugPath)) {
+      _segmentDebugPath = segmentDebugPath;
+      changed = true;
+    }
+
+    if (_distanceToSegmentStartMeters != distanceToSegmentStartMeters) {
+      _distanceToSegmentStartMeters = distanceToSegmentStartMeters;
+      changed = true;
+    }
+
+    if (changed) {
+      notifyListeners();
+    }
+  }
+
+  void enterMode(SegmentsOnlyModeReason reason) {
+    final bool changed = !_isActive || _reason != reason;
+    _isActive = true;
+    _reason = reason;
+    if (changed) {
+      notifyListeners();
+    }
+  }
+
+  void exitMode() {
+    if (!_isActive && _reason == null) {
+      return;
+    }
+    _isActive = false;
+    _reason = null;
+    notifyListeners();
+  }
+}

--- a/lib/features/map/presentation/pages/map/map_options_drawer.dart
+++ b/lib/features/map/presentation/pages/map/map_options_drawer.dart
@@ -42,6 +42,11 @@ extension _MapPageDrawer on _MapPageState {
               onTap: _onSegmentsSelected,
             ),
             ListTile(
+              leading: const Icon(Icons.speed_outlined),
+              title: Text(localizations.segmentsOnlyModeButton),
+              onTap: _onSegmentsOnlyModeSelected,
+            ),
+            ListTile(
               leading: const Icon(Icons.volume_up_outlined),
               title: Text(localizations.audioModeTitle),
               subtitle: Text(
@@ -223,6 +228,14 @@ extension _MapPageDrawer on _MapPageState {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       unawaited(_openSegmentsPage());
+    });
+  }
+
+  void _onSegmentsOnlyModeSelected() {
+    Navigator.of(context).pop();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_openSegmentsOnlyPage(SegmentsOnlyModeReason.manual));
     });
   }
 

--- a/lib/features/map/presentation/pages/segments_only_page.dart
+++ b/lib/features/map/presentation/pages/segments_only_page.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
+import 'package:toll_cam_finder/features/map/domain/controllers/segments_only_mode_controller.dart';
+import 'package:toll_cam_finder/features/map/presentation/pages/map/widgets/map_controls/map_controls_panel_card.dart';
+
+class SegmentsOnlyPage extends StatelessWidget {
+  const SegmentsOnlyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final mediaQuery = MediaQuery.of(context);
+
+    final segmentsController = context.watch<SegmentsOnlyModeController>();
+    final avgController = context.watch<AverageSpeedController>();
+
+    final reason = segmentsController.reason ?? SegmentsOnlyModeReason.manual;
+    final String message;
+    switch (reason) {
+      case SegmentsOnlyModeReason.manual:
+        message = localizations.segmentsOnlyModeManualMessage;
+        break;
+      case SegmentsOnlyModeReason.osmUnavailable:
+        message = localizations.segmentsOnlyModeOsmBlockedMessage;
+        break;
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(localizations.segmentsOnlyModeTitle),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return SingleChildScrollView(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text(
+                        message,
+                        style: theme.textTheme.bodyLarge,
+                      ),
+                      const SizedBox(height: 24),
+                      MapControlsPanelCard(
+                        colorScheme: theme.colorScheme,
+                        speedKmh: segmentsController.currentSpeedKmh,
+                        avgController: avgController,
+                        hasActiveSegment: segmentsController.hasActiveSegment,
+                        segmentSpeedLimitKph:
+                            segmentsController.segmentSpeedLimitKph,
+                        segmentDebugPath: segmentsController.segmentDebugPath,
+                        distanceToSegmentStartMeters:
+                            segmentsController.distanceToSegmentStartMeters,
+                        maxWidth: constraints.maxWidth,
+                        maxHeight: null,
+                        stackMetricsVertically: constraints.maxWidth < 480,
+                        forceSingleRow: false,
+                        isLandscape:
+                            mediaQuery.orientation == Orientation.landscape,
+                      ),
+                      const SizedBox(height: 24),
+                      Text(
+                        localizations.segmentsOnlyModeReminder,
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:toll_cam_finder/core/supabase_config.dart';
 import 'package:toll_cam_finder/features/auth/application/auth_controller.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/guidance_audio_controller.dart';
+import 'package:toll_cam_finder/features/map/domain/controllers/segments_only_mode_controller.dart';
 import 'package:toll_cam_finder/shared/services/language_controller.dart';
 import 'package:toll_cam_finder/shared/services/theme_controller.dart';
 import 'package:toll_cam_finder/shared/audio/navigation_audio_context.dart';
@@ -35,6 +36,9 @@ void main() async {
       providers: [
         ChangeNotifierProvider(
           create: (_) => AverageSpeedController(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => SegmentsOnlyModeController(),
         ),
         ChangeNotifierProvider(
           create: (_) => AuthController(client: supabaseClient),


### PR DESCRIPTION
## Summary
- add a segments-only page that reuses the segment metrics card so users can focus on segment data without the map
- share live segment metrics through a dedicated controller and expose a drawer shortcut to enter the new mode manually
- fall back to the segments-only page automatically when OSM requests fail and localize the supporting copy in English and Bulgarian

## Testing
- `flutter test` *(fails: Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fc8bda1ccc832d9f91b7a32cb45442