### PR TITLE
Improve offline sync error handling

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -19,6 +19,7 @@ class AppLocalizations {
       'averageSpeedResetTooltip': 'Reset Avg',
       'averageSpeedStartTooltip': 'Start Avg',
       'cancelAction': 'Cancel',
+      'okAction': 'OK',
       'chooseSegmentVisibilityQuestion':
           'Do you want the segment to be publically visible?',
       'comingSoon': 'Coming soon',
@@ -264,6 +265,8 @@ class AppLocalizations {
       'syncRemovedMany': '{count} segments removed',
       'syncRemovedOne': '{count} segment removed',
       'syncTotalSegmentsSummary': '{count} total segments available.',
+      'syncRequiresInternetConnection':
+          'Synchronizing toll segments requires an internet connection.',
       'startEndCoordinatesRequired': 'Start and end coordinates are required.',
       'submitSegmentForPublicReviewSubtitle':
           'Submit this segment for public review.',
@@ -356,6 +359,8 @@ class AppLocalizations {
       'createSegmentMissingFieldEndCoordinates': 'крайни координати',
       'createSegmentMissingFieldsDelimiter': ', ',
       'createSegmentMissingFieldsConjunction': 'и',
+      'cancelAction': 'Отказ',
+      'okAction': 'Добре',
       'deleteAction': 'Изтрий',
       'deleteSegmentAction': 'Изтрий сегмента',
       'deleteSegmentConfirmationTitle': 'Изтриване на сегмента',
@@ -486,8 +491,10 @@ class AppLocalizations {
 'syncNoChangesDetected': 'Няма открити промени.',
 'syncRemovedMany': '{count} сегмента изтрити',
 'syncRemovedOne': '{count} сегмент изтрит',
-'syncTotalSegmentsSummary': 'Общо налични сегменти: {count}.',
+      'syncTotalSegmentsSummary': 'Общо налични сегменти: {count}.',
       'sync': 'Синхронизирай',
+      'syncRequiresInternetConnection':
+          'Синхронизирането на сегменти изисква интернет връзка.',
       'audioModeTitle': 'Режим на аудио насоките',
       'audioModeFullGuidance':
           'Всички аудио насоки (в приложението и на заден план)',

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -178,6 +178,7 @@ class AppMessages {
   static String get retryAction => _l.translate('retryAction');
   static String get yesAction => _l.translate('yesAction');
   static String get noAction => _l.translate('noAction');
+  static String get okAction => _l.translate('okAction');
   static String get cancelAction => _l.translate('cancelAction');
   static String get deleteAction => _l.translate('deleteAction');
   static String get mapHintPlacePointA =>
@@ -317,6 +318,8 @@ class AppMessages {
       );
   static String get supabaseNotConfiguredForSync =>
       _l.translate('supabaseNotConfiguredForSync');
+  static String get syncRequiresInternetConnection =>
+      _l.translate('syncRequiresInternetConnection');
   static String get unexpectedSyncError =>
       _l.translate('unexpectedSyncError');
 

--- a/lib/features/map/presentation/pages/map/map_options_drawer.dart
+++ b/lib/features/map/presentation/pages/map/map_options_drawer.dart
@@ -310,7 +310,27 @@ extension _MapPageDrawer on _MapPageState {
     }
 
     if (result.message != null) {
-      messenger.showSnackBar(SnackBar(content: Text(result.message!)));
+      if (!result.isSuccess &&
+          result.message == AppMessages.syncRequiresInternetConnection) {
+        await showDialog<void>(
+          context: context,
+          builder: (context) {
+            final localizations = AppLocalizations.of(context);
+            return AlertDialog(
+              title: Text(localizations.sync),
+              content: Text(AppMessages.syncRequiresInternetConnection),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: Text(AppMessages.okAction),
+                ),
+              ],
+            );
+          },
+        );
+      } else {
+        messenger.showSnackBar(SnackBar(content: Text(result.message!)));
+      }
     }
 
     if (!result.isSuccess) {

--- a/lib/features/segments/services/toll_segments_sync_service.dart
+++ b/lib/features/segments/services/toll_segments_sync_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io' show SocketException;
 
 import 'package:csv/csv.dart';
 import 'package:flutter/foundation.dart';
@@ -67,6 +68,11 @@ class TollSegmentsSyncService {
       return diff;
     } on TollSegmentsSyncException {
       rethrow;
+    } on SocketException catch (error) {
+      throw TollSegmentsSyncException(
+        AppMessages.syncRequiresInternetConnection,
+        cause: error,
+      );
     } on PostgrestException catch (error) {
       throw TollSegmentsSyncException(
         AppMessages.failedToDownloadTollSegments(error.message),


### PR DESCRIPTION
## Summary
- add localized strings and message helper for the internet-required sync dialog
- surface socket exceptions from the sync service as a user-friendly offline error
- show an alert dialog during sync when the device is offline instead of a generic snackbar

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fc920a4114832da5b6de1e2445a887