### PR TITLE
Delay offline fallback redirect until connectivity loss persists

### DIFF
--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -120,7 +120,8 @@ class _MapPageState extends State<MapPage>
   DateTime? _lastSpeedLimitQueryAt;
   String? _osmSpeedLimitKph;
   bool _segmentsOnlyPageOpen = false;
-  bool _hasNotifiedOsmUnavailable = false;
+  Timer? _offlineRedirectTimer;
+  Timer? _osmUnavailableRedirectTimer;
   bool _hasConnectivity = true;
 
   SegmentTrackerDebugData _segmentDebugData =
@@ -195,6 +196,8 @@ class _MapPageState extends State<MapPage>
     unawaited(_upcomingSegmentCueService.dispose());
     _osmSpeedLimitService.dispose();
     _audioController.removeListener(_updateAudioPolicy);
+    _offlineRedirectTimer?.cancel();
+    _osmUnavailableRedirectTimer?.cancel();
     _segmentsOnlyModeController.exitMode();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
@@ -267,14 +270,14 @@ class _MapPageState extends State<MapPage>
 
     if (!isConnected) {
       _segmentsOnlyModeController.enterMode(SegmentsOnlyModeReason.offline);
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        unawaited(_openSegmentsOnlyPage(SegmentsOnlyModeReason.offline));
-      });
-    } else if (_segmentsOnlyModeController.reason ==
-            SegmentsOnlyModeReason.offline &&
-        !_segmentsOnlyPageOpen) {
-      _segmentsOnlyModeController.exitMode();
+      _scheduleSegmentsOnlyRedirect(SegmentsOnlyModeReason.offline);
+    } else {
+      _cancelSegmentsOnlyRedirectTimer(SegmentsOnlyModeReason.offline);
+      if (_segmentsOnlyModeController.reason ==
+              SegmentsOnlyModeReason.offline &&
+          !_segmentsOnlyPageOpen) {
+        _segmentsOnlyModeController.exitMode();
+      }
     }
   }
 
@@ -297,6 +300,60 @@ class _MapPageState extends State<MapPage>
     _audioPolicy = newPolicy;
     _segmentGuidanceController.updateAudioPolicy(newPolicy);
     _upcomingSegmentCueService.updateAudioPolicy(newPolicy);
+  }
+
+  void _scheduleSegmentsOnlyRedirect(SegmentsOnlyModeReason reason) {
+    if (reason == SegmentsOnlyModeReason.manual) {
+      return;
+    }
+
+    final Timer? existing = _redirectTimerFor(reason);
+    if (existing?.isActive ?? false) {
+      return;
+    }
+
+    final Timer timer = Timer(const Duration(seconds: 3), () {
+      _setRedirectTimer(reason, null);
+      if (!mounted) {
+        return;
+      }
+      if (_segmentsOnlyModeController.reason != reason) {
+        return;
+      }
+      unawaited(_openSegmentsOnlyPage(reason));
+    });
+
+    _setRedirectTimer(reason, timer);
+  }
+
+  void _cancelSegmentsOnlyRedirectTimer(SegmentsOnlyModeReason reason) {
+    final Timer? existing = _redirectTimerFor(reason);
+    existing?.cancel();
+    _setRedirectTimer(reason, null);
+  }
+
+  Timer? _redirectTimerFor(SegmentsOnlyModeReason reason) {
+    switch (reason) {
+      case SegmentsOnlyModeReason.offline:
+        return _offlineRedirectTimer;
+      case SegmentsOnlyModeReason.osmUnavailable:
+        return _osmUnavailableRedirectTimer;
+      case SegmentsOnlyModeReason.manual:
+        return null;
+    }
+  }
+
+  void _setRedirectTimer(SegmentsOnlyModeReason reason, Timer? timer) {
+    switch (reason) {
+      case SegmentsOnlyModeReason.offline:
+        _offlineRedirectTimer = timer;
+        break;
+      case SegmentsOnlyModeReason.osmUnavailable:
+        _osmUnavailableRedirectTimer = timer;
+        break;
+      case SegmentsOnlyModeReason.manual:
+        break;
+    }
   }
 
   void _setForegroundLocationMode(bool enable) {
@@ -455,22 +512,23 @@ class _MapPageState extends State<MapPage>
       setState(() {
         _osmSpeedLimitKph = result;
       });
-      _hasNotifiedOsmUnavailable = false;
+      _cancelSegmentsOnlyRedirectTimer(
+        SegmentsOnlyModeReason.osmUnavailable,
+      );
+      if (_segmentsOnlyModeController.reason ==
+              SegmentsOnlyModeReason.osmUnavailable &&
+          !_segmentsOnlyPageOpen) {
+        _segmentsOnlyModeController.exitMode();
+      }
     } catch (_) {
       if (!mounted) return;
 
       _segmentsOnlyModeController.enterMode(
         SegmentsOnlyModeReason.osmUnavailable,
       );
-      if (_hasNotifiedOsmUnavailable) {
-        return;
-      }
-
-      _hasNotifiedOsmUnavailable = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        unawaited(_openSegmentsOnlyPage(SegmentsOnlyModeReason.osmUnavailable));
-      });
+      _scheduleSegmentsOnlyRedirect(
+        SegmentsOnlyModeReason.osmUnavailable,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- introduce timers that wait 3 seconds before redirecting to Segments Only mode when connectivity or OSM access is lost
- cancel pending redirects when connectivity or OSM services recover to avoid unnecessary navigation

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fc9513cf98832da42f583533f967c5