### PR TITLE
Add resume button for segments-only mode

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -227,6 +227,7 @@ class AppLocalizations {
           "Don't worry, we are still observing for segments and average speed, but as this is a free app, we rely on free map providers, which are currently experiencing a shortage. We are sorry for the inconvenience and we are working on the issue.",
       'segmentsOnlyModeOfflineMessage':
           "You appear to be offline. We'll keep monitoring segments and your average speed, but the map requires an internet connection. Check your connection and come back when you're online again.",
+      'segmentsOnlyModeContinueButton': 'Continue to map',
       'segmentsOnlyModeReminder':
           'Segments and averages continue to update while this view is open.',
       'selectLanguage': 'Select language',
@@ -433,6 +434,7 @@ class AppLocalizations {
 'Не се притеснявайте, все още наблюдаваме сегментите и средната скорост, но тъй като приложението е безплатно, разчитаме на безплатни доставчици на карти, които в момента изпитват затруднения. Извиняваме се за неудобството и работим по отстраняването на проблема.',
 'segmentsOnlyModeOfflineMessage':
 'Изглежда сте офлайн. Продължаваме да следим сегментите и средната ви скорост, но картата изисква интернет връзка. Проверете връзката си и се върнете, когато сте отново онлайн.',
+'segmentsOnlyModeContinueButton': 'Продължи към картата',
 'segmentsOnlyModeReminder':
 'Сегментите и средната скорост продължават да се обновяват, докато този екран е отворен.',
 'selectLanguage': 'Избери език',
@@ -558,6 +560,8 @@ class AppLocalizations {
       _value('segmentsOnlyModeOsmBlockedMessage');
   String get segmentsOnlyModeOfflineMessage =>
       _value('segmentsOnlyModeOfflineMessage');
+  String get segmentsOnlyModeContinueButton =>
+      _value('segmentsOnlyModeContinueButton');
   String get segmentsOnlyModeReminder =>
       _value('segmentsOnlyModeReminder');
   String get language => _value('language');

--- a/lib/features/map/presentation/pages/segments_only_page.dart
+++ b/lib/features/map/presentation/pages/segments_only_page.dart
@@ -18,9 +18,11 @@ class SegmentsOnlyPage extends StatelessWidget {
     final segmentsController = context.watch<SegmentsOnlyModeController>();
     final avgController = context.watch<AverageSpeedController>();
 
-    final reason = segmentsController.reason ?? SegmentsOnlyModeReason.manual;
+    final SegmentsOnlyModeReason reason =
+        segmentsController.reason ?? SegmentsOnlyModeReason.manual;
     final bool isForcedMode = reason == SegmentsOnlyModeReason.offline ||
         reason == SegmentsOnlyModeReason.osmUnavailable;
+    final bool canResumeMap = !isForcedMode;
 
     final String message;
     switch (reason) {
@@ -47,43 +49,57 @@ class SegmentsOnlyPage extends StatelessWidget {
             padding: const EdgeInsets.all(16),
             child: LayoutBuilder(
               builder: (context, constraints) {
-                return SingleChildScrollView(
-                  child: ConstrainedBox(
-                    constraints:
-                        BoxConstraints(minHeight: constraints.maxHeight),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Text(
-                          message,
-                          style: theme.textTheme.bodyLarge,
-                        ),
-                        const SizedBox(height: 24),
-                        MapControlsPanelCard(
-                          colorScheme: theme.colorScheme,
-                          speedKmh: segmentsController.currentSpeedKmh,
-                          avgController: avgController,
-                          hasActiveSegment: segmentsController.hasActiveSegment,
-                          segmentSpeedLimitKph:
-                              segmentsController.segmentSpeedLimitKph,
-                          segmentDebugPath: segmentsController.segmentDebugPath,
-                          distanceToSegmentStartMeters:
-                              segmentsController.distanceToSegmentStartMeters,
-                          maxWidth: constraints.maxWidth,
-                          maxHeight: null,
-                          stackMetricsVertically: constraints.maxWidth < 480,
-                          forceSingleRow: false,
-                          isLandscape:
-                              mediaQuery.orientation == Orientation.landscape,
-                        ),
-                        const SizedBox(height: 24),
-                        Text(
-                          localizations.segmentsOnlyModeReminder,
-                          style: theme.textTheme.bodyMedium,
-                        ),
-                      ],
-                    ),
+                final Widget scrollChild = ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text(
+                        message,
+                        style: theme.textTheme.bodyLarge,
+                      ),
+                      const SizedBox(height: 24),
+                      MapControlsPanelCard(
+                        colorScheme: theme.colorScheme,
+                        speedKmh: segmentsController.currentSpeedKmh,
+                        avgController: avgController,
+                        hasActiveSegment: segmentsController.hasActiveSegment,
+                        segmentSpeedLimitKph:
+                            segmentsController.segmentSpeedLimitKph,
+                        segmentDebugPath: segmentsController.segmentDebugPath,
+                        distanceToSegmentStartMeters:
+                            segmentsController.distanceToSegmentStartMeters,
+                        maxWidth: constraints.maxWidth,
+                        maxHeight: null,
+                        stackMetricsVertically: constraints.maxWidth < 480,
+                        forceSingleRow: false,
+                        isLandscape:
+                            mediaQuery.orientation == Orientation.landscape,
+                      ),
+                      const SizedBox(height: 24),
+                      Text(
+                        localizations.segmentsOnlyModeReminder,
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ],
                   ),
+                );
+
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(
+                      child: SingleChildScrollView(child: scrollChild),
+                    ),
+                    if (canResumeMap) ...[
+                      const SizedBox(height: 24),
+                      FilledButton(
+                        onPressed: () => Navigator.of(context).maybePop(),
+                        child:
+                            Text(localizations.segmentsOnlyModeContinueButton),
+                      ),
+                    ],
+                  ],
                 );
               },
             ),


### PR DESCRIPTION
## Summary
- add a continue button to the segments-only page so users can return to the map when forced mode conditions clear
- localize the continue button label in English and Bulgarian

## Testing
- flutter test *(fails: Flutter is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcb9524ff0832da0718ee65eaca24f