### PR TITLE
Add shared current segment controller for consistent tracking

### DIFF
--- a/lib/features/map/presentation/pages/segments_only_page.dart
+++ b/lib/features/map/presentation/pages/segments_only_page.dart
@@ -4,12 +4,12 @@ import 'package:provider/provider.dart';
 import 'package:toll_cam_finder/app/app_routes.dart';
 import 'package:toll_cam_finder/app/localization/app_localizations.dart';
 import 'package:toll_cam_finder/features/auth/application/auth_controller.dart';
-import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/guidance_audio_controller.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/segments_only_mode_controller.dart';
 import 'package:toll_cam_finder/features/map/presentation/pages/map/widgets/map_controls/map_controls_panel_card.dart';
 import 'package:toll_cam_finder/shared/services/language_controller.dart';
 import 'package:toll_cam_finder/shared/services/theme_controller.dart';
+import 'package:toll_cam_finder/features/segments/domain/controllers/current_segment_controller.dart';
 
 class SegmentsOnlyPage extends StatelessWidget {
   const SegmentsOnlyPage({super.key});
@@ -21,7 +21,8 @@ class SegmentsOnlyPage extends StatelessWidget {
     final mediaQuery = MediaQuery.of(context);
 
     final segmentsController = context.watch<SegmentsOnlyModeController>();
-    final avgController = context.watch<AverageSpeedController>();
+    final currentSegment = context.watch<CurrentSegmentController>();
+    final avgController = currentSegment.averageController;
 
     final SegmentsOnlyModeReason reason =
         segmentsController.reason ?? SegmentsOnlyModeReason.manual;

--- a/lib/features/segments/domain/controllers/current_segment_controller.dart
+++ b/lib/features/segments/domain/controllers/current_segment_controller.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/foundation.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
+import 'package:toll_cam_finder/features/segments/domain/tracking/segment_tracker.dart';
+
+class CurrentSegmentController extends ChangeNotifier {
+  CurrentSegmentController({
+    AverageSpeedController? averageController,
+    Distance? distanceCalculator,
+  })  : _averageController = averageController ?? AverageSpeedController(),
+        _distance = distanceCalculator ?? const Distance();
+
+  final AverageSpeedController _averageController;
+  final Distance _distance;
+
+  SegmentTrackerEvent? _lastEvent;
+  SegmentDebugPath? _activePath;
+  SegmentTrackerDebugData _debugData = const SegmentTrackerDebugData.empty();
+  double? _distanceToSegmentStartMeters;
+  double? _lastSegmentAverageKph;
+  String? _progressLabel;
+  LatLng? _lastAverageSamplePosition;
+  DateTime? _lastAverageSampleAt;
+
+  AverageSpeedController get averageController => _averageController;
+  SegmentTrackerEvent? get lastEvent => _lastEvent;
+  SegmentDebugPath? get activePath => _activePath;
+  SegmentTrackerDebugData get debugData => _debugData;
+  double? get distanceToSegmentStartMeters => _distanceToSegmentStartMeters;
+  double? get activeSegmentSpeedLimitKph => _lastEvent?.activeSegmentSpeedLimitKph;
+  double? get lastSegmentAverageKph => _lastSegmentAverageKph;
+  String? get progressLabel => _progressLabel;
+  double? get distanceToSegmentEndMeters => _activePath?.remainingDistanceMeters;
+  bool get hasActiveSegment => _lastEvent?.activeSegmentId != null;
+  String? get activeSegmentId => _lastEvent?.activeSegmentId;
+
+  void reset() {
+    _lastEvent = null;
+    _activePath = null;
+    _debugData = const SegmentTrackerDebugData.empty();
+    _distanceToSegmentStartMeters = null;
+    _lastSegmentAverageKph = null;
+    _progressLabel = null;
+    _lastAverageSamplePosition = null;
+    _lastAverageSampleAt = null;
+    _averageController.reset();
+    notifyListeners();
+  }
+
+  void recordProgress({
+    required LatLng position,
+    required DateTime timestamp,
+  }) {
+    if (!_averageController.isRunning) {
+      return;
+    }
+
+    final LatLng? previousPosition = _lastAverageSamplePosition;
+    if (previousPosition == null || _lastAverageSampleAt == null) {
+      _lastAverageSamplePosition = position;
+      _lastAverageSampleAt = timestamp;
+      return;
+    }
+
+    final double distanceMeters = _distance.as(
+      LengthUnit.Meter,
+      previousPosition,
+      position,
+    );
+
+    final double sanitizedDistance =
+        (distanceMeters.isFinite && distanceMeters > 0) ? distanceMeters : 0.0;
+
+    _averageController.recordProgress(
+      distanceDeltaMeters: sanitizedDistance,
+      timestamp: timestamp,
+    );
+
+    _lastAverageSamplePosition = position;
+    _lastAverageSampleAt = timestamp;
+  }
+
+  double? updateWithEvent({
+    required SegmentTrackerEvent event,
+    required DateTime timestamp,
+    SegmentDebugPath? activePath,
+    double? distanceToSegmentStartMeters,
+    String? progressLabel,
+    LatLng? userPosition,
+  }) {
+    double? exitAverage;
+
+    if (event.endedSegment || event.completedSegmentLengthMeters != null) {
+      final double? segmentLength = event.completedSegmentLengthMeters;
+      final Duration? elapsed = _averageController.elapsed;
+      final double computedAverage = (segmentLength != null && elapsed != null)
+          ? _averageController.avgSpeedDone(
+              segmentLengthMeters: segmentLength,
+              segmentDuration: elapsed,
+            )
+          : _averageController.average;
+
+      exitAverage = computedAverage;
+      _lastSegmentAverageKph = computedAverage.isFinite ? computedAverage : null;
+      _averageController.reset();
+      _lastAverageSamplePosition = null;
+      _lastAverageSampleAt = null;
+    }
+
+    if (event.startedSegment) {
+      _lastSegmentAverageKph = null;
+      _averageController.start(startedAt: timestamp);
+      _lastAverageSamplePosition = userPosition;
+      _lastAverageSampleAt = timestamp;
+    }
+
+    _lastEvent = event;
+    _activePath = activePath;
+    _debugData = event.debugData;
+    _distanceToSegmentStartMeters = distanceToSegmentStartMeters;
+    _progressLabel = progressLabel;
+
+    notifyListeners();
+
+    return exitAverage;
+  }
+
+  @override
+  void dispose() {
+    _averageController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,9 +5,9 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:toll_cam_finder/app/app.dart';
 import 'package:toll_cam_finder/core/supabase_config.dart';
 import 'package:toll_cam_finder/features/auth/application/auth_controller.dart';
-import 'package:toll_cam_finder/features/map/domain/controllers/average_speed_controller.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/guidance_audio_controller.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/segments_only_mode_controller.dart';
+import 'package:toll_cam_finder/features/segments/domain/controllers/current_segment_controller.dart';
 import 'package:toll_cam_finder/shared/services/language_controller.dart';
 import 'package:toll_cam_finder/shared/services/theme_controller.dart';
 import 'package:toll_cam_finder/shared/audio/navigation_audio_context.dart';
@@ -35,10 +35,10 @@ void main() async {
     MultiProvider(
       providers: [
         ChangeNotifierProvider(
-          create: (_) => AverageSpeedController(),
+          create: (_) => SegmentsOnlyModeController(),
         ),
         ChangeNotifierProvider(
-          create: (_) => SegmentsOnlyModeController(),
+          create: (_) => CurrentSegmentController(),
         ),
         ChangeNotifierProvider(
           create: (_) => AuthController(client: supabaseClient),


### PR DESCRIPTION
## Summary
- add a `CurrentSegmentController` that owns active segment metrics and average speed calculations
- register the controller at the app root and update the segments-only view to read the shared data
- refactor the map page to delegate segment event handling to the controller so tracking state persists when switching modes

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fcc048ce70832d971a65717571d44a