### PR TITLE
Add GeoJSON route capture for new segments

### DIFF
--- a/lib/features/segments/presentation/pages/create_segment_page.dart
+++ b/lib/features/segments/presentation/pages/create_segment_page.dart
@@ -35,6 +35,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
   final LocalSegmentsService _localSegmentsService = LocalSegmentsService();
   bool _persistDraftOnDispose = true;
   bool _isNavigatingToLogin = false;
+  String? _routeGeoJson;
 
   @override
   void initState() {
@@ -165,6 +166,9 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
                               child: SegmentPickerMap(
                                 startController: _startController,
                                 endController: _endController,
+                                onRouteGeoJsonChanged: (value) {
+                                  _routeGeoJson = value;
+                                },
                               ),
                             ),
                           ],
@@ -494,6 +498,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
         startCoordinates: _startController.text,
         endCoordinates: _endController.text,
         isPublic: isPublic,
+        routeGeoJson: _routeGeoJson,
       );
     } on LocalSegmentsServiceException catch (error) {
       _showSnackBar(error.message);
@@ -534,6 +539,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     _cachedEndDisplayName = null;
     _cachedStartCoordinates = null;
     _cachedEndCoordinates = null;
+    _routeGeoJson = null;
   }
 
   void _cacheDraftInputs() {

--- a/lib/features/segments/services/local_segments_service.dart
+++ b/lib/features/segments/services/local_segments_service.dart
@@ -40,6 +40,7 @@ class LocalSegmentsService {
     required String startCoordinates,
     required String endCoordinates,
     double? speedLimitKph,
+    String? routeGeoJson,
   }) async {
     final draft = prepareDraft(
       name: name,
@@ -48,6 +49,7 @@ class LocalSegmentsService {
       startCoordinates: startCoordinates,
       endCoordinates: endCoordinates,
       speedLimitKph: speedLimitKph,
+      routeGeoJson: routeGeoJson,
     );
 
     await saveDraft(draft);
@@ -64,6 +66,7 @@ class LocalSegmentsService {
     required String endCoordinates,
     bool isPublic = false,
     double? speedLimitKph,
+    String? routeGeoJson,
   }) {
     final normalizedName = name.trim().isEmpty
         ? AppMessages.personalSegmentDefaultName
@@ -87,6 +90,7 @@ class LocalSegmentsService {
       endCoordinates: normalizedEnd,
       isPublic: isPublic,
       speedLimitKph: speedLimitKph,
+      routeGeoJson: routeGeoJson,
     );
   }
 
@@ -488,6 +492,7 @@ class SegmentDraft {
     required this.endCoordinates,
     this.isPublic = false,
     this.speedLimitKph,
+    this.routeGeoJson,
   });
 
   final String name;
@@ -498,4 +503,5 @@ class SegmentDraft {
   final String endCoordinates;
   final bool isPublic;
   final double? speedLimitKph;
+  final String? routeGeoJson;
 }

--- a/lib/features/segments/services/remote_segments_service.dart
+++ b/lib/features/segments/services/remote_segments_service.dart
@@ -28,6 +28,7 @@ class RemoteSegmentsService {
   static const String _roadColumn = 'road';
   static const String _startColumn = 'Start';
   static const String _endColumn = 'End';
+  static const String _routeGeoJsonColumn = 'route_geojson';
 
   /// Uploads the supplied [draft] to Supabase, marking it as pending moderation.
   Future<void> submitForModeration(
@@ -52,7 +53,7 @@ class RemoteSegmentsService {
     try {
       while (true) {
         try {
-          await client.from(tableName).insert(<String, dynamic>{
+          final payload = <String, dynamic>{
             'id': pendingId,
             _nameColumn: draft.name,
             _roadColumn: draft.roadName,
@@ -63,7 +64,11 @@ class RemoteSegmentsService {
             'speed_limit_kph': draft.speedLimitKph,
             _moderationStatusColumn: _pendingStatus,
             _addedByUserColumn: addedByUserId,
-          });
+          };
+          if (draft.routeGeoJson != null && draft.routeGeoJson!.isNotEmpty) {
+            payload[_routeGeoJsonColumn] = draft.routeGeoJson;
+          }
+          await client.from(tableName).insert(payload);
           break;
         } on PostgrestException catch (error) {
           if (_isIdConflict(error)) {


### PR DESCRIPTION
## Summary
- allow the segment picker map to surface the routed polyline as GeoJSON
- track the GeoJSON on the create segment form and include it in draft data
- send the GeoJSON to Supabase when submitting a segment for moderation

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fcdd16d274832db8d68fa6de28b829