### PR TITLE
Fix GeoJSON column name for submissions

### DIFF
--- a/lib/features/segments/services/remote_segments_service.dart
+++ b/lib/features/segments/services/remote_segments_service.dart
@@ -28,7 +28,7 @@ class RemoteSegmentsService {
   static const String _roadColumn = 'road';
   static const String _startColumn = 'Start';
   static const String _endColumn = 'End';
-  static const String _routeGeoJsonColumn = 'route_geojson';
+  static const String _geoJsonColumn = 'geojson';
 
   /// Uploads the supplied [draft] to Supabase, marking it as pending moderation.
   Future<void> submitForModeration(
@@ -66,7 +66,7 @@ class RemoteSegmentsService {
             _addedByUserColumn: addedByUserId,
           };
           if (draft.routeGeoJson != null && draft.routeGeoJson!.isNotEmpty) {
-            payload[_routeGeoJsonColumn] = draft.routeGeoJson;
+            payload[_geoJsonColumn] = draft.routeGeoJson;
           }
           await client.from(tableName).insert(payload);
           break;


### PR DESCRIPTION
## Summary
- allow the segment picker map to surface the routed polyline as GeoJSON
- track the GeoJSON on the create segment form and include it in draft data
- send the GeoJSON to Supabase when submitting a segment for moderation
- ensure route GeoJSON is stored in the existing `geojson` column when inserting drafts

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fde2c0df14832d87280d87117a5db5