### PR TITLE
Rename guidance experience to simple mode

### DIFF
--- a/lib/app/app_routes.dart
+++ b/lib/app/app_routes.dart
@@ -3,7 +3,7 @@ import 'package:toll_cam_finder/features/auth/presentation/pages/login_page.dart
 import 'package:toll_cam_finder/features/auth/presentation/pages/profile_page.dart';
 import 'package:toll_cam_finder/features/auth/presentation/pages/sign_up_page.dart';
 import 'package:toll_cam_finder/features/map/presentation/pages/map_page.dart';
-import 'package:toll_cam_finder/features/map/presentation/pages/segments_only_page.dart';
+import 'package:toll_cam_finder/features/map/presentation/pages/simple_mode_page.dart';
 import 'package:toll_cam_finder/features/segments/presentation/pages/create_segment_page.dart';
 import 'package:toll_cam_finder/features/segments/presentation/pages/segments_page.dart';
 
@@ -16,7 +16,7 @@ class AppRoutes {
   static const String segments = '/segments';
   static const String localSegments = '/segments/local';
   static const String createSegment = '/segments/create';
-  static const String segmentsOnly = '/segments-only';
+  static const String simpleMode = '/simple';
 
   static Map<String, WidgetBuilder> get routes => {
     map: (_) => const MapPage(),
@@ -26,6 +26,6 @@ class AppRoutes {
     segments: (_) => const SegmentsPage(),
     localSegments: (_) => const LocalSegmentsPage(),
     createSegment: (_) => const CreateSegmentPage(),
-    segmentsOnly: (_) => const SegmentsOnlyPage(),
+    simpleMode: (_) => const SimpleModePage(),
   };
 }

--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -219,17 +219,17 @@ class AppLocalizations {
       'segmentVisible':
           'Segment {displayId} is visible again. Cameras and warnings restored.',
       'segments': 'Segments',
-      'segmentsOnlyModeTitle': 'Segments-only mode',
-      'segmentsOnlyModeButton': 'Segments-only mode',
+      'segmentsOnlyModeTitle': 'Simple mode',
+      'segmentsOnlyModeButton': 'Simple mode',
       'segmentsOnlyModeManualMessage':
-          'You are viewing segments-only mode. Use this screen to monitor your segment metrics without the map. Tap the back button to return to the map.',
+          "You're in simple mode. Use this screen to track your segment metrics without the map. Tap the back button to return to the map.",
       'segmentsOnlyModeOsmBlockedMessage':
-          "Don't worry, we are still observing for segments and average speed, but as this is a free app, we rely on free map providers, which are currently experiencing a shortage. We are sorry for the inconvenience and we are working on the issue.",
+          "Simple mode is still tracking segments and average speed, but our free map provider is temporarily unavailable. We're sorry for the inconvenience and are working on a fix.",
       'segmentsOnlyModeOfflineMessage':
-          "You appear to be offline. We'll keep monitoring segments and your average speed, but the map requires an internet connection. Check your connection and come back when you're online again.",
+          "You're offline. We'll keep tracking segments and your average speed, but the map needs an internet connection. Check your connection and come back when you're online again.",
       'segmentsOnlyModeContinueButton': 'Continue to map',
       'segmentsOnlyModeReminder':
-          'Segments and averages continue to update while this view is open.',
+          'Segments and averages continue updating while simple mode is open.',
       'selectLanguage': 'Select language',
       'shareSegmentPubliclyAction': 'Share segment publicly',
       'showSegmentOnMapAction': 'Show segment on map',
@@ -426,17 +426,17 @@ class AppLocalizations {
 'segmentProgressStartMeters': '{distance} м до началото на сегмента',
 'segmentProgressStartNearby': 'Началото на сегмента е близо',
 'segments': 'Сегменти',
-'segmentsOnlyModeTitle': 'Режим само сегменти',
-'segmentsOnlyModeButton': 'Режим само сегменти',
+'segmentsOnlyModeTitle': 'Опростен режим',
+'segmentsOnlyModeButton': 'Опростен режим',
 'segmentsOnlyModeManualMessage':
-'В момента използвате режим само сегменти. Използвайте този екран, за да следите показателите без картата. Натиснете бутона назад, за да се върнете към картата.',
+'В момента използваш опростен режим. Използвай този екран, за да следиш показателите за сегментите без картата. Натисни бутона назад, за да се върнеш към картата.',
 'segmentsOnlyModeOsmBlockedMessage':
-'Не се притеснявайте, все още наблюдаваме сегментите и средната скорост, но тъй като приложението е безплатно, разчитаме на безплатни доставчици на карти, които в момента изпитват затруднения. Извиняваме се за неудобството и работим по отстраняването на проблема.',
+'Не се притеснявай, опростен режим продължава да наблюдава сегментите и средната скорост, но тъй като приложението е безплатно, разчитаме на безплатни доставчици на карти, които в момента имат затруднения. Извиняваме се за неудобството и работим по отстраняването му.',
 'segmentsOnlyModeOfflineMessage':
-'Изглежда сте офлайн. Продължаваме да следим сегментите и средната ви скорост, но картата изисква интернет връзка. Проверете връзката си и се върнете, когато сте отново онлайн.',
+'Изглежда си офлайн. Ще продължим да следим сегментите и средната ти скорост, но картата изисква интернет връзка. Провери връзката си и се върни, когато отново имаш достъп.',
 'segmentsOnlyModeContinueButton': 'Продължи към картата',
 'segmentsOnlyModeReminder':
-'Сегментите и средната скорост продължават да се обновяват, докато този екран е отворен.',
+'Сегментите и средната скорост продължават да се обновяват, докато опростен режим е отворен.',
 'selectLanguage': 'Избери език',
 'signInToSharePubliclyBody':
 'Трябва да си влязъл в акаунта си, за да изпратиш публичен сегмент. Искаш ли да влезеш или вместо това да запазиш сегмента локално?',

--- a/lib/features/map/presentation/pages/map/map_options_drawer.dart
+++ b/lib/features/map/presentation/pages/map/map_options_drawer.dart
@@ -44,7 +44,7 @@ extension _MapPageDrawer on _MapPageState {
             ListTile(
               leading: const Icon(Icons.speed_outlined),
               title: Text(localizations.segmentsOnlyModeButton),
-              onTap: _onSegmentsOnlyModeSelected,
+              onTap: _onSimpleModeSelected,
             ),
             ListTile(
               leading: const Icon(Icons.volume_up_outlined),
@@ -231,11 +231,11 @@ extension _MapPageDrawer on _MapPageState {
     });
   }
 
-  void _onSegmentsOnlyModeSelected() {
+  void _onSimpleModeSelected() {
     Navigator.of(context).pop();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      unawaited(_openSegmentsOnlyPage(SegmentsOnlyModeReason.manual));
+      unawaited(_openSimpleModePage(SegmentsOnlyModeReason.manual));
     });
   }
 

--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -120,7 +120,7 @@ class _MapPageState extends State<MapPage>
   LatLng? _lastSpeedLimitQueryLocation;
   DateTime? _lastSpeedLimitQueryAt;
   String? _osmSpeedLimitKph;
-  bool _segmentsOnlyPageOpen = false;
+  bool _simpleModePageOpen = false;
   Timer? _offlineRedirectTimer;
   Timer? _osmUnavailableRedirectTimer;
   bool _hasConnectivity = true;
@@ -270,8 +270,8 @@ class _MapPageState extends State<MapPage>
       if (_segmentsOnlyModeController.reason ==
           SegmentsOnlyModeReason.offline) {
         _segmentsOnlyModeController.exitMode();
-        if (_segmentsOnlyPageOpen) {
-          unawaited(_closeSegmentsOnlyPageIfOpen());
+        if (_simpleModePageOpen) {
+          unawaited(_closeSimpleModePageIfOpen());
         }
       }
     }
@@ -316,7 +316,7 @@ class _MapPageState extends State<MapPage>
       if (_segmentsOnlyModeController.reason != reason) {
         return;
       }
-      unawaited(_openSegmentsOnlyPage(reason));
+      unawaited(_openSimpleModePage(reason));
     });
 
     _setRedirectTimer(reason, timer);
@@ -518,8 +518,8 @@ class _MapPageState extends State<MapPage>
       if (_segmentsOnlyModeController.reason ==
           SegmentsOnlyModeReason.osmUnavailable) {
         _segmentsOnlyModeController.exitMode();
-        if (_segmentsOnlyPageOpen) {
-          unawaited(_closeSegmentsOnlyPageIfOpen());
+        if (_simpleModePageOpen) {
+          unawaited(_closeSimpleModePageIfOpen());
         }
       }
     } catch (_) {
@@ -917,26 +917,26 @@ class _MapPageState extends State<MapPage>
     );
   }
 
-  Future<void> _openSegmentsOnlyPage(
+  Future<void> _openSimpleModePage(
       SegmentsOnlyModeReason reason) async {
     _segmentsOnlyModeController.enterMode(reason);
-    if (_segmentsOnlyPageOpen || !mounted) {
+    if (_simpleModePageOpen || !mounted) {
       return;
     }
 
-    _segmentsOnlyPageOpen = true;
+    _simpleModePageOpen = true;
     try {
-      await Navigator.of(context).pushNamed(AppRoutes.segmentsOnly);
+      await Navigator.of(context).pushNamed(AppRoutes.simpleMode);
     } finally {
-      _segmentsOnlyPageOpen = false;
+      _simpleModePageOpen = false;
       if (_shouldExitSegmentsOnlyModeAfterNav(reason)) {
         _segmentsOnlyModeController.exitMode();
       }
     }
   }
 
-  Future<void> _closeSegmentsOnlyPageIfOpen() async {
-    if (!_segmentsOnlyPageOpen || !mounted) {
+  Future<void> _closeSimpleModePageIfOpen() async {
+    if (!_simpleModePageOpen || !mounted) {
       return;
     }
 

--- a/lib/features/map/presentation/pages/simple_mode_page.dart
+++ b/lib/features/map/presentation/pages/simple_mode_page.dart
@@ -11,8 +11,8 @@ import 'package:toll_cam_finder/shared/services/language_controller.dart';
 import 'package:toll_cam_finder/shared/services/theme_controller.dart';
 import 'package:toll_cam_finder/features/segments/domain/controllers/current_segment_controller.dart';
 
-class SegmentsOnlyPage extends StatelessWidget {
-  const SegmentsOnlyPage({super.key});
+class SimpleModePage extends StatelessWidget {
+  const SimpleModePage({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -60,7 +60,7 @@ class SegmentsOnlyPage extends StatelessWidget {
             ),
           ],
         ),
-        endDrawer: const _SegmentsOnlyOptionsDrawer(),
+        endDrawer: const _SimpleModeOptionsDrawer(),
         body: SafeArea(
           child: Padding(
             padding: const EdgeInsets.all(16),
@@ -127,8 +127,8 @@ class SegmentsOnlyPage extends StatelessWidget {
   }
 }
 
-class _SegmentsOnlyOptionsDrawer extends StatelessWidget {
-  const _SegmentsOnlyOptionsDrawer();
+class _SimpleModeOptionsDrawer extends StatelessWidget {
+  const _SimpleModeOptionsDrawer();
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- rename the map-only experience to "simple mode" and expose it via `/simple`
- retitle the simplified view and navigation drawer entries to match the new simple mode name
- refresh the English and Bulgarian copy for the simplified experience to reflect the new terminology

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fde4475f50832d81ec59c08325bb0a