### PR TITLE
Add first-run onboarding intro for Toll Cam Finder

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
+import 'package:toll_cam_finder/app/loading_page.dart';
+import 'package:toll_cam_finder/features/intro/application/intro_controller.dart';
+import 'package:toll_cam_finder/features/intro/presentation/pages/intro_page.dart';
+import 'package:toll_cam_finder/features/map/presentation/pages/map_page.dart';
 import 'package:toll_cam_finder/shared/services/language_controller.dart';
 import 'package:toll_cam_finder/shared/services/theme_controller.dart';
 import 'app_routes.dart';
@@ -13,13 +17,28 @@ class TollCamApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer2<LanguageController, ThemeController>(
-      builder: (context, languageController, themeController, _) {
+    return Consumer3<LanguageController, ThemeController, IntroController>(
+      builder: (
+        context,
+        languageController,
+        themeController,
+        introController,
+        _,
+      ) {
         final appLocalizations = AppLocalizations(languageController.locale);
+        final Widget home;
+
+        if (introController.isLoading) {
+          home = const LoadingPage();
+        } else if (introController.shouldShowIntro) {
+          home = const IntroPage();
+        } else {
+          home = const MapPage();
+        }
         return MaterialApp(
           title: appLocalizations.appTitle,
           theme: buildAppTheme(isDarkMode: themeController.isDarkMode),
-          initialRoute: AppRoutes.map,
+          home: home,
           routes: AppRoutes.routes,
           debugShowCheckedModeBanner: false,
           locale: languageController.locale,

--- a/lib/app/app_routes.dart
+++ b/lib/app/app_routes.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:toll_cam_finder/features/auth/presentation/pages/login_page.dart';
 import 'package:toll_cam_finder/features/auth/presentation/pages/profile_page.dart';
 import 'package:toll_cam_finder/features/auth/presentation/pages/sign_up_page.dart';
+import 'package:toll_cam_finder/app/loading_page.dart';
+import 'package:toll_cam_finder/features/intro/presentation/pages/intro_page.dart';
 import 'package:toll_cam_finder/features/map/presentation/pages/map_page.dart';
 import 'package:toll_cam_finder/features/map/presentation/pages/segments_only_page.dart';
 import 'package:toll_cam_finder/features/segments/presentation/pages/create_segment_page.dart';
@@ -9,6 +11,8 @@ import 'package:toll_cam_finder/features/segments/presentation/pages/segments_pa
 
 
 class AppRoutes {
+  static const String loading = '/loading';
+  static const String intro = '/intro';
   static const String map = '/';
   static const String login = '/login';
   static const String signUp = '/sign-up';
@@ -19,6 +23,8 @@ class AppRoutes {
   static const String segmentsOnly = '/segments-only';
 
   static Map<String, WidgetBuilder> get routes => {
+    loading: (_) => const LoadingPage(),
+    intro: (_) => const IntroPage(),
     map: (_) => const MapPage(),
     login: (_) => const LoginPage(),
     signUp: (_) => const SignUpPage(),

--- a/lib/app/loading_page.dart
+++ b/lib/app/loading_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class LoadingPage extends StatelessWidget {
+  const LoadingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/lib/features/intro/application/intro_controller.dart
+++ b/lib/features/intro/application/intro_controller.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class IntroController extends ChangeNotifier {
+  static const _hasSeenIntroKey = 'has_seen_intro';
+
+  bool _hasLoaded = false;
+  bool _hasSeenIntro = false;
+
+  IntroController() {
+    _loadPreference();
+  }
+
+  bool get isLoading => !_hasLoaded;
+  bool get shouldShowIntro => _hasLoaded && !_hasSeenIntro;
+
+  Future<void> markIntroSeen() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_hasSeenIntroKey, true);
+    _hasSeenIntro = true;
+    notifyListeners();
+  }
+
+  Future<void> _loadPreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    _hasSeenIntro = prefs.getBool(_hasSeenIntroKey) ?? false;
+    _hasLoaded = true;
+    notifyListeners();
+  }
+}

--- a/lib/features/intro/presentation/pages/intro_page.dart
+++ b/lib/features/intro/presentation/pages/intro_page.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:toll_cam_finder/app/app_routes.dart';
+import 'package:toll_cam_finder/features/intro/application/intro_controller.dart';
+
+class IntroPage extends StatelessWidget {
+  const IntroPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Welcome to Toll Cam Finder',
+                style: textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Here\'s a quick tour to help you feel confident the first time you hit the road with the app.',
+                style: textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 32),
+              Expanded(
+                child: ListView(
+                  children: const [
+                    _IntroHighlight(
+                      title: 'Map tour: orienting controls and telemetry',
+                      description:
+                          'Keep the floating controls in mind—they let you lock the map to your driving direction or instantly snap back to your live position so you can regain context mid-trip.',
+                    ),
+                    _IntroHighlight(
+                      title: 'Glanceable speed insights',
+                      description:
+                          'Use the translucent metrics card to monitor your current speed, rolling average, and safe speed guidance versus the posted limit. It also shows the distance to your active or nearest segment so compliance is always clear.',
+                    ),
+                    _IntroHighlight(
+                      title: 'Adaptive audio cues',
+                      description:
+                          'Audio alerts automatically adapt to whether Toll Cam Finder is in the foreground, keeping guidance relevant without overwhelming you.',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () async {
+                    await context.read<IntroController>().markIntroSeen();
+                    if (context.mounted) {
+                      Navigator.of(context).pushReplacementNamed(AppRoutes.map);
+                    }
+                  },
+                  child: const Text('Let\'s drive'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _IntroHighlight extends StatelessWidget {
+  const _IntroHighlight({
+    required this.title,
+    required this.description,
+  });
+
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 24),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceVariant.withOpacity(0.4),
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                description,
+                style: textTheme.bodyMedium,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:toll_cam_finder/app/app.dart';
 import 'package:toll_cam_finder/core/supabase_config.dart';
+import 'package:toll_cam_finder/features/intro/application/intro_controller.dart';
 import 'package:toll_cam_finder/features/auth/application/auth_controller.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/guidance_audio_controller.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/segments_only_mode_controller.dart';
@@ -39,6 +40,9 @@ void main() async {
         ),
         ChangeNotifierProvider(
           create: (_) => CurrentSegmentController(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => IntroController(),
         ),
         ChangeNotifierProvider(
           create: (_) => AuthController(client: supabaseClient),


### PR DESCRIPTION
## Summary
- add an intro controller that tracks whether the welcome tour has been completed
- present a first-run intro page that highlights key map controls, telemetry, and adaptive audio cues
- wire the app bootstrap to show the intro (with a loading placeholder) before entering the main map experience

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fce119db84832d8ad76851f615f352