### PR TITLE
Add weigh station support across app

### DIFF
--- a/assets/data/weigh_stations.csv
+++ b/assets/data/weigh_stations.csv
@@ -1,0 +1,1 @@
+ID;name;road;coordinates

--- a/lib/app/app_routes.dart
+++ b/lib/app/app_routes.dart
@@ -6,6 +6,8 @@ import 'package:toll_cam_finder/features/map/presentation/pages/map_page.dart';
 import 'package:toll_cam_finder/features/map/presentation/pages/simple_mode_page.dart';
 import 'package:toll_cam_finder/features/segments/presentation/pages/create_segment_page.dart';
 import 'package:toll_cam_finder/features/segments/presentation/pages/segments_page.dart';
+import 'package:toll_cam_finder/features/weigh_stations/presentation/pages/create_weigh_station_page.dart';
+import 'package:toll_cam_finder/features/weigh_stations/presentation/pages/weigh_stations_page.dart';
 
 
 class AppRoutes {
@@ -16,6 +18,8 @@ class AppRoutes {
   static const String segments = '/segments';
   static const String localSegments = '/segments/local';
   static const String createSegment = '/segments/create';
+  static const String weighStations = '/weigh-stations';
+  static const String createWeighStation = '/weigh-stations/create';
   static const String simpleMode = '/simple';
 
   static Map<String, WidgetBuilder> get routes => {
@@ -26,6 +30,8 @@ class AppRoutes {
     segments: (_) => const SegmentsPage(),
     localSegments: (_) => const LocalSegmentsPage(),
     createSegment: (_) => const CreateSegmentPage(),
+    weighStations: (_) => const WeighStationsPage(),
+    createWeighStation: (_) => const CreateWeighStationPage(),
     simpleMode: (_) => const SimpleModePage(),
   };
 }

--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -65,6 +65,33 @@ class AppLocalizations {
       'createSegmentStartCoordinatesLabel': 'Start coordinates',
       'createSegmentStartLabel': 'Start',
       'createSegmentStartNameHint': 'Start name',
+      'weighStations': 'Weigh stations',
+      'createWeighStation': 'Add weigh station',
+      'createWeighStationInstructions':
+          'Tap the map to place the weigh station marker. Long-press and drag to fine-tune the location.',
+      'weighStationNameLabel': 'Station name',
+      'weighStationNameHint': 'Optional name',
+      'weighStationRoadInputLabel': 'Road',
+      'weighStationRoadHint': 'A1, E80…',
+      'weighStationCoordinatesInputLabel': 'Coordinates',
+      'weighStationCoordinatesHint': '41.8626802,26.0873785',
+      'saveWeighStation': 'Save weigh station',
+      'failedToLoadWeighStations': 'Failed to load weigh stations.',
+      'noWeighStationsAvailable': 'No weigh stations available.',
+      'failedToSaveWeighStationLocally':
+          'Failed to save the weigh station locally.',
+      'failedToSubmitWeighStation':
+          'Failed to submit the weigh station for moderation.',
+      'weighStationSubmittedForReview':
+          'Weigh station submitted for review.',
+      'weighStationUnnamed': 'Weigh station {id}',
+      'weighStationRoadLabel': 'Road: {road}',
+      'weighStationCoordinatesLabel': 'Coordinates: {coordinates}',
+      'weighStationLocalBadge': 'Local only',
+      'weighStationMapHintPlace':
+          'Tap anywhere on the map to place the weigh station.',
+      'weighStationMapHintDrag':
+          'Long-press and drag the marker to adjust the weigh station.',
       'csvMissingStartEndColumns': 'CSV must contain "Start" and "End" columns',
       'deleteAction': 'Delete',
       'deleteSegmentAction': 'Delete segment',
@@ -77,6 +104,8 @@ class AppLocalizations {
           'Failed to access the segments metadata file.',
       'failedToAccessTollSegmentsFile':
           'Failed to access the toll segments file: {reason}',
+      'failedToAccessWeighStationsFile':
+          'Failed to access the weigh stations file: {reason}',
       'failedToCancelPublicReview':
           'Failed to cancel the public review for this segment.',
       'failedToCancelSubmissionWithReason':
@@ -90,6 +119,8 @@ class AppLocalizations {
           'Failed to determine the local toll segments storage path.',
       'failedToDownloadTollSegments':
           'Failed to download toll segments: {reason}',
+      'failedToDownloadWeighStations':
+          'Failed to download weigh stations: {reason}',
       'failedToLoadCameras': 'Failed to load cameras: {error}',
       'failedToLoadSegmentPreferences':
           'Failed to load segment preferences: {errorMessage}',
@@ -378,8 +409,39 @@ class AppLocalizations {
 'createSegmentStartCoordinatesHint': '41.8626802,26.0873785',
 'createSegmentStartCoordinatesLabel': 'Начални координати',
 'createSegmentStartLabel': 'Начало',
-'createSegmentStartNameHint': 'Име на началото',
-'emailLabel': 'Имейл адрес',
+      'createSegmentStartNameHint': 'Име на началото',
+      'weighStations': 'Кантари',
+      'createWeighStation': 'Добави кантар',
+      'createWeighStationInstructions':
+          'Докоснете картата, за да поставите маркера за кантара. Задръжте и плъзнете, за да коригирате позицията.',
+      'weighStationNameLabel': 'Име на кантара',
+      'weighStationNameHint': 'Незадължително име',
+      'weighStationRoadInputLabel': 'Път',
+      'weighStationRoadHint': 'A1, E80…',
+      'weighStationCoordinatesInputLabel': 'Координати',
+      'weighStationCoordinatesHint': '41.8626802,26.0873785',
+      'saveWeighStation': 'Запази кантара',
+      'failedToLoadWeighStations': 'Неуспешно зареждане на кантари.',
+      'failedToAccessWeighStationsFile':
+          'Неуспешен достъп до файла с кантарите: {reason}',
+      'failedToDownloadWeighStations':
+          'Неуспешно изтегляне на кантари: {reason}',
+      'noWeighStationsAvailable': 'Няма налични кантари.',
+      'failedToSaveWeighStationLocally':
+          'Неуспешно запазване на кантара локално.',
+      'failedToSubmitWeighStation':
+          'Неуспешно изпращане на кантара за модерация.',
+      'weighStationSubmittedForReview':
+          'Кантарът е изпратен за преглед.',
+      'weighStationUnnamed': 'Кантар {id}',
+      'weighStationRoadLabel': 'Път: {road}',
+      'weighStationCoordinatesLabel': 'Координати: {coordinates}',
+      'weighStationLocalBadge': 'Само локален',
+      'weighStationMapHintPlace':
+          'Докоснете картата, за да поставите кантара.',
+      'weighStationMapHintDrag':
+          'Задръжте и плъзнете маркера, за да коригирате кантара.',
+      'emailLabel': 'Имейл адрес',
 'fullNameLabel': 'Пълно име',
 'joinTollCam': 'Присъедини се към TollCam',
 'language': 'Език',
@@ -580,6 +642,40 @@ class AppLocalizations {
   String get logOut => _value('logOut');
   String get localSegments => _value('localSegments');
   String get createSegment => _value('createSegment');
+  String get weighStations => _value('weighStations');
+  String get createWeighStation => _value('createWeighStation');
+  String get createWeighStationInstructions =>
+      _value('createWeighStationInstructions');
+  String get weighStationNameLabel => _value('weighStationNameLabel');
+  String get weighStationNameHint => _value('weighStationNameHint');
+  String get weighStationRoadInputLabel =>
+      _value('weighStationRoadInputLabel');
+  String get weighStationRoadHint => _value('weighStationRoadHint');
+  String get weighStationCoordinatesInputLabel =>
+      _value('weighStationCoordinatesInputLabel');
+  String get weighStationCoordinatesHint =>
+      _value('weighStationCoordinatesHint');
+  String get saveWeighStation => _value('saveWeighStation');
+  String get failedToLoadWeighStations => _value('failedToLoadWeighStations');
+  String get noWeighStationsAvailable =>
+      _value('noWeighStationsAvailable');
+  String get failedToSaveWeighStationLocally =>
+      _value('failedToSaveWeighStationLocally');
+  String get failedToSubmitWeighStation =>
+      _value('failedToSubmitWeighStation');
+  String get weighStationSubmittedForReview =>
+      _value('weighStationSubmittedForReview');
+  String weighStationUnnamed(String id) =>
+      translate('weighStationUnnamed', {'id': id});
+  String weighStationRoadLabel(String road) =>
+      translate('weighStationRoadLabel', {'road': road});
+  String weighStationCoordinatesLabel(String coordinates) => translate(
+        'weighStationCoordinatesLabel',
+        {'coordinates': coordinates},
+      );
+  String get weighStationLocalBadge => _value('weighStationLocalBadge');
+  String get weighStationMapHintPlace => _value('weighStationMapHintPlace');
+  String get weighStationMapHintDrag => _value('weighStationMapHintDrag');
   String get saveSegment => _value('saveSegment');
   String get noSegmentsAvailable => _value('noSegmentsAvailable');
   String get noLocalSegments => _value('noLocalSegments');

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -186,6 +186,10 @@ class AppMessages {
   static String get mapHintPlacePointB =>
       _l.translate('mapHintPlacePointB');
   static String get mapHintDragPoint => _l.translate('mapHintDragPoint');
+  static String get weighStationMapHintPlace =>
+      _l.translate('weighStationMapHintPlace');
+  static String get weighStationMapHintDrag =>
+      _l.translate('weighStationMapHintDrag');
   static String get createSegmentMapInstructionTitle =>
       _l.translate('createSegmentMapInstructionTitle');
   static String get createSegmentMapInstructionBody =>
@@ -206,6 +210,12 @@ class AppMessages {
       _l.translate('createSegmentStartLabel');
   static String get createSegmentStartNameHint =>
       _l.translate('createSegmentStartNameHint');
+  static String get failedToSaveWeighStationLocally =>
+      _l.translate('failedToSaveWeighStationLocally');
+  static String get failedToSubmitWeighStation =>
+      _l.translate('failedToSubmitWeighStation');
+  static String get weighStationSubmittedForReview =>
+      _l.translate('weighStationSubmittedForReview');
   static String get createSegmentEndLabel =>
       _l.translate('createSegmentEndLabel');
   static String get createSegmentEndNameHint =>
@@ -250,8 +260,12 @@ class AppMessages {
       _l.translate('failedToCancelSubmissionWithReason', {'reason': reason});
   static String failedToDownloadTollSegments(String reason) =>
       _l.translate('failedToDownloadTollSegments', {'reason': reason});
+  static String failedToDownloadWeighStations(String reason) =>
+      _l.translate('failedToDownloadWeighStations', {'reason': reason});
   static String failedToAccessTollSegmentsFile(String reason) =>
       _l.translate('failedToAccessTollSegmentsFile', {'reason': reason});
+  static String failedToAccessWeighStationsFile(String reason) =>
+      _l.translate('failedToAccessWeighStationsFile', {'reason': reason});
   static String get failedToDetermineTollSegmentsPath =>
       _l.translate('failedToDetermineTollSegmentsPath');
   static String get segmentMetadataUpdateUnavailable =>

--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -127,6 +127,9 @@ class AppConstants {
   /// Asset path for the toll-road segments dataset (CSV format).
   static const String pathToTollSegments = 'assets/data/toll_segments.csv';
 
+  /// Asset path for the weigh-station dataset (CSV format).
+  static const String pathToWeighStations = 'assets/data/weigh_stations.csv';
+
   /// Asset path to the toll segments dataset. Camera markers are derived from
   /// the start and end points of each segment in this CSV file.
   static const String camerasAsset = pathToTollSegments;

--- a/lib/features/map/presentation/pages/map/map_options_drawer.dart
+++ b/lib/features/map/presentation/pages/map/map_options_drawer.dart
@@ -42,6 +42,11 @@ extension _MapPageDrawer on _MapPageState {
               onTap: _onSegmentsSelected,
             ),
             ListTile(
+              leading: const Icon(Icons.scale_outlined),
+              title: Text(localizations.weighStations),
+              onTap: _onWeighStationsSelected,
+            ),
+            ListTile(
               leading: const Icon(Icons.speed_outlined),
               title: Text(localizations.segmentsOnlyModeButton),
               onTap: _onSimpleModeSelected,
@@ -231,6 +236,34 @@ extension _MapPageDrawer on _MapPageState {
     });
   }
 
+  void _onWeighStationsSelected() {
+    Navigator.of(context).pop();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_openWeighStationsPage());
+    });
+  }
+
+  Future<void> _openWeighStationsPage() async {
+    final result = await Navigator.of(context).pushNamed(AppRoutes.weighStations);
+    if (!mounted || result != true) {
+      return;
+    }
+
+    LatLngBounds? bounds;
+    if (_mapReady) {
+      try {
+        bounds = _mapController.camera.visibleBounds;
+      } catch (_) {
+        bounds = null;
+      }
+    }
+
+    await _segmentsService.loadWeighStations(bounds: bounds);
+    if (!mounted) return;
+    _updateVisibleWeighStations();
+  }
+
   void _onSimpleModeSelected() {
     Navigator.of(context).pop();
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -275,6 +308,7 @@ extension _MapPageDrawer on _MapPageState {
     _nextCameraCheckAt = null;
     _updateVisibleCameras();
     _updateVisibleSegments();
+    _updateVisibleWeighStations();
     setState(() {});
   }
 
@@ -345,5 +379,6 @@ extension _MapPageDrawer on _MapPageState {
     _nextCameraCheckAt = null;
     _updateVisibleCameras();
     _updateVisibleSegments();
+    _updateVisibleWeighStations();
   }
 }

--- a/lib/features/map/presentation/pages/map/weigh_station_controller.dart
+++ b/lib/features/map/presentation/pages/map/weigh_station_controller.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'package:toll_cam_finder/features/weigh_stations/services/weigh_stations_repository.dart';
+
+class WeighStationMarker {
+  const WeighStationMarker({
+    required this.id,
+    required this.position,
+  });
+
+  final String id;
+  final LatLng position;
+}
+
+class WeighStationsState {
+  const WeighStationsState({
+    required this.error,
+    required this.isLoading,
+    required this.visibleStations,
+  });
+
+  final String? error;
+  final bool isLoading;
+  final List<WeighStationMarker> visibleStations;
+}
+
+class NearestWeighStation {
+  const NearestWeighStation({
+    required this.marker,
+    required this.distanceMeters,
+  });
+
+  final WeighStationMarker marker;
+  final double distanceMeters;
+}
+
+class WeighStationController {
+  WeighStationController({WeighStationsRepository? repository})
+      : _repository = repository ?? WeighStationsRepository();
+
+  final WeighStationsRepository _repository;
+
+  final Distance _distance = const Distance();
+  List<WeighStationMarker> _allStations = const [];
+  List<WeighStationMarker> _visibleStations = const [];
+  String? _error;
+  bool _isLoading = false;
+
+  WeighStationsState get state => WeighStationsState(
+        error: _error,
+        isLoading: _isLoading,
+        visibleStations: _visibleStations,
+      );
+
+  Future<void> loadFromAsset(
+    String assetPath, {
+    LatLngBounds? bounds,
+  }) async {
+    _isLoading = true;
+    _error = null;
+    try {
+      final stations = await _repository.loadStations(assetPath: assetPath);
+      _allStations = stations
+          .map((station) {
+            final position = _parseCoordinates(station.coordinates);
+            if (position == null) {
+              return null;
+            }
+            return WeighStationMarker(id: station.id, position: position);
+          })
+          .whereType<WeighStationMarker>()
+          .toList(growable: false);
+      updateVisible(bounds: bounds);
+    } catch (error, stackTrace) {
+      debugPrint('WeighStationController: failed to load stations: $error\n$stackTrace');
+      _error = error.toString();
+      _allStations = const [];
+      _visibleStations = const [];
+    } finally {
+      _isLoading = false;
+    }
+  }
+
+  void updateVisible({LatLngBounds? bounds}) {
+    if (bounds == null) {
+      _visibleStations = _allStations;
+      return;
+    }
+
+    _visibleStations = _allStations
+        .where((station) => bounds.contains(station.position))
+        .toList(growable: false);
+  }
+
+  NearestWeighStation? nearestStation(LatLng point) {
+    if (_allStations.isEmpty) {
+      return null;
+    }
+    NearestWeighStation? nearest;
+    for (final station in _allStations) {
+      final distanceMeters =
+          _distance.as(LengthUnit.Meter, station.position, point);
+      if (nearest == null || distanceMeters < nearest.distanceMeters) {
+        nearest = NearestWeighStation(
+          marker: station,
+          distanceMeters: distanceMeters,
+        );
+      }
+    }
+    return nearest;
+  }
+
+  LatLng? _parseCoordinates(String raw) {
+    final parts = raw.split(',');
+    if (parts.length != 2) {
+      return null;
+    }
+    final lat = double.tryParse(parts[0].trim());
+    final lng = double.tryParse(parts[1].trim());
+    if (lat == null || lng == null) {
+      return null;
+    }
+    if (!lat.isFinite || !lng.isFinite) {
+      return null;
+    }
+    return LatLng(lat, lng);
+  }
+}

--- a/lib/features/map/presentation/widgets/weigh_stations_overlay.dart
+++ b/lib/features/map/presentation/widgets/weigh_stations_overlay.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+import 'package:toll_cam_finder/features/map/presentation/pages/map/weigh_station_controller.dart';
+
+class WeighStationsOverlay extends StatelessWidget {
+  const WeighStationsOverlay({
+    super.key,
+    required this.visibleStations,
+  });
+
+  final List<WeighStationMarker> visibleStations;
+
+  @override
+  Widget build(BuildContext context) {
+    if (visibleStations.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return MarkerLayer(
+      markers: visibleStations
+          .map(
+            (station) => Marker(
+              point: station.position,
+              width: 36,
+              height: 36,
+              alignment: Alignment.center,
+              child: Container(
+                decoration: const BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: Colors.deepPurple,
+                ),
+                child: const Icon(
+                  Icons.scale,
+                  color: Colors.white,
+                  size: 20,
+                ),
+              ),
+            ),
+          )
+          .toList(growable: false),
+    );
+  }
+}

--- a/lib/features/weigh_stations/domain/weigh_station.dart
+++ b/lib/features/weigh_stations/domain/weigh_station.dart
@@ -1,0 +1,27 @@
+import 'package:toll_cam_finder/features/weigh_stations/services/weigh_stations_csv_constants.dart';
+
+class WeighStationInfo {
+  const WeighStationInfo({
+    required this.id,
+    required this.name,
+    required this.road,
+    required this.coordinates,
+    this.isLocalOnly = false,
+  });
+
+  final String id;
+  final String name;
+  final String road;
+  final String coordinates;
+  final bool isLocalOnly;
+
+  String get displayId {
+    if (!isLocalOnly) {
+      return id;
+    }
+    if (id.startsWith(WeighStationsCsvSchema.localWeighStationIdPrefix)) {
+      return id.substring(WeighStationsCsvSchema.localWeighStationIdPrefix.length);
+    }
+    return id;
+  }
+}

--- a/lib/features/weigh_stations/presentation/pages/create_weigh_station_page.dart
+++ b/lib/features/weigh_stations/presentation/pages/create_weigh_station_page.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+import 'package:toll_cam_finder/core/app_messages.dart';
+import 'package:toll_cam_finder/features/auth/application/auth_controller.dart';
+import 'package:toll_cam_finder/features/weigh_stations/presentation/widgets/weigh_station_picker_map.dart';
+import 'package:toll_cam_finder/features/weigh_stations/services/local_weigh_stations_service.dart';
+import 'package:toll_cam_finder/features/weigh_stations/services/remote_weigh_stations_service.dart';
+
+class CreateWeighStationPage extends StatefulWidget {
+  const CreateWeighStationPage({super.key});
+
+  @override
+  State<CreateWeighStationPage> createState() => _CreateWeighStationPageState();
+}
+
+class _CreateWeighStationPageState extends State<CreateWeighStationPage> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _roadController = TextEditingController();
+  final TextEditingController _coordinatesController = TextEditingController();
+
+  final LocalWeighStationsService _localService = LocalWeighStationsService();
+  bool _isSaving = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _roadController.dispose();
+    _coordinatesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final localizations = AppLocalizations.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(localizations.createWeighStation),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                localizations.createWeighStationInstructions,
+                style: theme.textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 16),
+              WeighStationPickerMap(
+                coordinatesController: _coordinatesController,
+              ),
+              const SizedBox(height: 24),
+              TextField(
+                controller: _nameController,
+                decoration: InputDecoration(
+                  labelText: localizations.weighStationNameLabel,
+                  hintText: localizations.weighStationNameHint,
+                ),
+                textInputAction: TextInputAction.next,
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _roadController,
+                decoration: InputDecoration(
+                  labelText: localizations.weighStationRoadInputLabel,
+                  hintText: localizations.weighStationRoadHint,
+                ),
+                textInputAction: TextInputAction.next,
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _coordinatesController,
+                decoration: InputDecoration(
+                  labelText: localizations.weighStationCoordinatesInputLabel,
+                  hintText: localizations.weighStationCoordinatesHint,
+                ),
+              ),
+              const SizedBox(height: 32),
+              Align(
+                alignment: Alignment.centerRight,
+                child: FilledButton.icon(
+                  onPressed: _isSaving ? null : _onSavePressed,
+                  icon: _isSaving
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.save_outlined),
+                  label: Text(localizations.saveWeighStation),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _onSavePressed() async {
+    if (_isSaving) {
+      return;
+    }
+
+    if (_coordinatesController.text.trim().isEmpty) {
+      _showSnackBar(AppMessages.coordinatesMustBeProvided);
+      return;
+    }
+
+    setState(() {
+      _isSaving = true;
+    });
+
+    final auth = context.read<AuthController>();
+    final userId = auth.currentUserId;
+    if (userId == null || userId.isEmpty) {
+      _showSnackBar(AppMessages.unableToDetermineLoggedInAccountRetry);
+      setState(() {
+        _isSaving = false;
+      });
+      return;
+    }
+
+    WeighStationDraft draft;
+    try {
+      draft = _localService.prepareDraft(
+        name: _nameController.text,
+        road: _roadController.text,
+        coordinates: _coordinatesController.text,
+      );
+    } on LocalWeighStationsServiceException catch (error) {
+      _showSnackBar(error.message);
+      setState(() {
+        _isSaving = false;
+      });
+      return;
+    }
+
+    String? localId;
+    try {
+      localId = await _localService.saveDraft(draft);
+    } catch (error) {
+      _showSnackBar(AppMessages.failedToSaveWeighStationLocally);
+      setState(() {
+        _isSaving = false;
+      });
+      return;
+    }
+
+    final remoteService = RemoteWeighStationsService(client: auth.client);
+    try {
+      await remoteService.submitForModeration(
+        name: draft.name,
+        road: draft.road,
+        coordinates: draft.coordinates,
+        addedByUserId: userId,
+      );
+    } on RemoteWeighStationsServiceException catch (error) {
+      _showSnackBar(error.message);
+      setState(() {
+        _isSaving = false;
+      });
+      return;
+    } catch (_) {
+      _showSnackBar(AppMessages.failedToSubmitWeighStation);
+      setState(() {
+        _isSaving = false;
+      });
+      return;
+    }
+
+    if (!mounted) {
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(AppMessages.weighStationSubmittedForReview),
+      ),
+    );
+
+    Navigator.of(context).pop(true);
+  }
+
+  void _showSnackBar(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+}

--- a/lib/features/weigh_stations/presentation/pages/weigh_stations_page.dart
+++ b/lib/features/weigh_stations/presentation/pages/weigh_stations_page.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:toll_cam_finder/app/app_routes.dart';
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+import 'package:toll_cam_finder/features/auth/application/auth_controller.dart';
+import 'package:toll_cam_finder/features/weigh_stations/domain/weigh_station.dart';
+import 'package:toll_cam_finder/features/weigh_stations/services/weigh_stations_repository.dart';
+
+class WeighStationsPage extends StatefulWidget {
+  const WeighStationsPage({super.key});
+
+  @override
+  State<WeighStationsPage> createState() => _WeighStationsPageState();
+}
+
+class _WeighStationsPageState extends State<WeighStationsPage> {
+  final WeighStationsRepository _repository = WeighStationsRepository();
+  late Future<List<WeighStationInfo>> _stationsFuture;
+  bool _stationsUpdated = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _stationsFuture = _repository.loadStations();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context);
+    return WillPopScope(
+      onWillPop: () async {
+        Navigator.of(context).pop(_stationsUpdated);
+        return false;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(localizations.weighStations),
+        ),
+        body: FutureBuilder<List<WeighStationInfo>>(
+          future: _stationsFuture,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            if (snapshot.hasError) {
+              return Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Text(localizations.failedToLoadWeighStations),
+                ),
+              );
+            }
+
+            final stations = snapshot.data ?? const <WeighStationInfo>[];
+            if (stations.isEmpty) {
+              return Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Text(localizations.noWeighStationsAvailable),
+                ),
+              );
+            }
+
+            return ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: stations.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                final station = stations[index];
+                return Card(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: ListTile(
+                    leading: const Icon(Icons.scale_outlined),
+                    title: Text(
+                      station.name.isNotEmpty
+                          ? station.name
+                          : localizations.weighStationUnnamed(station.displayId),
+                    ),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (station.road.isNotEmpty)
+                          Text(localizations.weighStationRoadLabel(station.road)),
+                        Text(localizations.weighStationCoordinatesLabel(station.coordinates)),
+                        if (station.isLocalOnly)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Text(
+                              localizations.weighStationLocalBadge,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelSmall
+                                  ?.copyWith(color: Theme.of(context).colorScheme.tertiary),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+        ),
+        floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+        floatingActionButton: SafeArea(
+          minimum: const EdgeInsets.all(16),
+          child: FilledButton.icon(
+            onPressed: _onCreateWeighStationPressed,
+            icon: const Icon(Icons.add),
+            label: Text(localizations.createWeighStation),
+            style: FilledButton.styleFrom(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 20,
+                vertical: 12,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _onCreateWeighStationPressed() async {
+    final auth = context.read<AuthController>();
+    if (!auth.isLoggedIn) {
+      final result = await Navigator.of(context).pushNamed(AppRoutes.login);
+      final loggedIn = result is bool ? result : null;
+      if (loggedIn != true) {
+        return;
+      }
+    }
+
+    final result = await Navigator.of(context).pushNamed(AppRoutes.createWeighStation);
+    if (!mounted || result != true) {
+      return;
+    }
+
+    _stationsUpdated = true;
+    setState(() {
+      _stationsFuture = _repository.loadStations();
+    });
+  }
+}

--- a/lib/features/weigh_stations/presentation/widgets/weigh_station_picker_map.dart
+++ b/lib/features/weigh_stations/presentation/widgets/weigh_station_picker_map.dart
@@ -1,0 +1,280 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'package:toll_cam_finder/core/app_messages.dart';
+import 'package:toll_cam_finder/core/constants.dart';
+import 'package:toll_cam_finder/features/map/presentation/widgets/base_tile_layer.dart';
+import 'package:toll_cam_finder/features/segments/presentation/widgets/segment_picker/draggable_map_marker.dart';
+import 'package:toll_cam_finder/features/segments/presentation/widgets/segment_picker/map_action_button.dart';
+
+class WeighStationPickerMap extends StatefulWidget {
+  const WeighStationPickerMap({
+    super.key,
+    required this.coordinatesController,
+  });
+
+  final TextEditingController coordinatesController;
+
+  @override
+  State<WeighStationPickerMap> createState() => _WeighStationPickerMapState();
+}
+
+class _WeighStationPickerMapState extends State<WeighStationPickerMap> {
+  late final MapController _mapController;
+  final GlobalKey _mapKey = GlobalKey();
+  LatLng? _point;
+  bool _mapReady = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _mapController = MapController();
+    _point = _parseLatLng(widget.coordinatesController.text);
+    widget.coordinatesController.addListener(_handleTextChanged);
+  }
+
+  @override
+  void dispose() {
+    widget.coordinatesController.removeListener(_handleTextChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final marker = _buildMarker(theme.colorScheme.primary);
+
+    final map = Stack(
+      children: [
+        FlutterMap(
+          key: _mapKey,
+          mapController: _mapController,
+          options: MapOptions(
+            initialCenter: _point ?? AppConstants.initialCenter,
+            initialZoom: AppConstants.initialZoom,
+            minZoom: AppConstants.segmentPickerMinZoom,
+            maxZoom: AppConstants.segmentPickerMaxZoom,
+            onTap: _handleMapTap,
+            onMapReady: _handleMapReady,
+          ),
+          children: [
+            const BaseTileLayer(),
+            if (marker != null) MarkerLayer(markers: [marker]),
+          ],
+        ),
+        Positioned(
+          left: AppConstants.segmentPickerOverlayInset,
+          right: AppConstants.segmentPickerOverlayInset,
+          top: AppConstants.segmentPickerOverlayInset,
+          child: _WeighStationHint(hasPoint: _point != null),
+        ),
+        Positioned(
+          right: AppConstants.segmentPickerOverlayInset,
+          bottom: AppConstants.segmentPickerOverlayInset,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              MapActionButton(
+                icon: Icons.add,
+                onPressed: () => _zoomBy(AppConstants.segmentPickerZoomStep),
+              ),
+              const SizedBox(height: AppConstants.segmentPickerZoomButtonSpacing),
+              MapActionButton(
+                icon: Icons.remove,
+                onPressed: () => _zoomBy(-AppConstants.segmentPickerZoomStep),
+              ),
+              const SizedBox(height: AppConstants.segmentPickerZoomButtonSpacing),
+              MapActionButton(
+                icon: Icons.clear,
+                onPressed: _clearPoint,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+
+    return AspectRatio(
+      aspectRatio: AppConstants.segmentPickerInlineAspectRatio,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppConstants.segmentPickerClipRadius),
+        child: map,
+      ),
+    );
+  }
+
+  Marker? _buildMarker(Color color) {
+    final point = _point;
+    if (point == null) {
+      return null;
+    }
+
+    return Marker(
+      point: point,
+      width: AppConstants.segmentPickerMarkerOuterDiameter,
+      height: AppConstants.segmentPickerMarkerOuterDiameter,
+      alignment: Alignment.center,
+      child: DraggableMapMarker(
+        mapKey: _mapKey,
+        mapController: _mapController,
+        onDragStart: _setPoint,
+        onDragUpdate: _setPoint,
+        onDragEnd: _setPoint,
+        child: _WeighStationMarker(color: color),
+      ),
+    );
+  }
+
+  void _handleMapTap(TapPosition tapPosition, LatLng latLng) {
+    _setPoint(latLng);
+  }
+
+  void _handleMapReady() {
+    _mapReady = true;
+    if (_point != null) {
+      _mapController.move(_point!, _mapController.camera.zoom);
+    }
+  }
+
+  void _handleTextChanged() {
+    if (!mounted) {
+      return;
+    }
+    if (_suppressTextUpdate) {
+      return;
+    }
+    final parsed = _parseLatLng(widget.coordinatesController.text);
+    if (_pointsEqual(parsed, _point)) {
+      return;
+    }
+    setState(() {
+      _point = parsed;
+    });
+    if (parsed != null && _mapReady) {
+      _mapController.move(parsed, _mapController.camera.zoom);
+    }
+  }
+
+  bool _suppressTextUpdate = false;
+
+  void _setPoint(LatLng? value) {
+    setState(() {
+      _point = value;
+    });
+    _updateController(value);
+  }
+
+  void _updateController(LatLng? value) {
+    final formatted = value == null ? '' : _formatLatLng(value);
+    if (widget.coordinatesController.text == formatted) {
+      return;
+    }
+    _suppressTextUpdate = true;
+    widget.coordinatesController.text = formatted;
+    _suppressTextUpdate = false;
+  }
+
+  void _zoomBy(double delta) {
+    final camera = _mapController.camera;
+    _mapController.move(camera.center, camera.zoom + delta);
+  }
+
+  void _clearPoint() {
+    _setPoint(null);
+  }
+
+  LatLng? _parseLatLng(String raw) {
+    final parts = raw.split(',');
+    if (parts.length != 2) {
+      return null;
+    }
+    final lat = double.tryParse(parts[0].trim());
+    final lng = double.tryParse(parts[1].trim());
+    if (lat == null || lng == null) {
+      return null;
+    }
+    if (!lat.isFinite || !lng.isFinite) {
+      return null;
+    }
+    return LatLng(lat, lng);
+  }
+
+  String _formatLatLng(LatLng value) {
+    return '${value.latitude.toStringAsFixed(6)}, '
+        '${value.longitude.toStringAsFixed(6)}';
+  }
+
+  bool _pointsEqual(LatLng? a, LatLng? b) {
+    if (identical(a, b)) return true;
+    if (a == null || b == null) return a == b;
+    final distance = const Distance().distance(a, b);
+    return distance < AppConstants.segmentPickerEqualityThresholdMeters;
+  }
+}
+
+class _WeighStationMarker extends StatelessWidget {
+  const _WeighStationMarker({required this.color});
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: color,
+        boxShadow: const [
+          BoxShadow(
+            color: Colors.black26,
+            blurRadius: AppConstants.segmentPickerMarkerShadowBlurRadius,
+            offset: Offset(0, AppConstants.segmentPickerMarkerShadowOffsetY),
+          ),
+        ],
+      ),
+      child: const Center(
+        child: Icon(
+          Icons.scale,
+          color: Colors.white,
+        ),
+      ),
+    );
+  }
+}
+
+class _WeighStationHint extends StatelessWidget {
+  const _WeighStationHint({required this.hasPoint});
+
+  final bool hasPoint;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final message = hasPoint
+        ? AppMessages.weighStationMapHintDrag
+        : AppMessages.weighStationMapHintPlace;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface
+            .withOpacity(AppConstants.segmentPickerSurfaceOpacity),
+        borderRadius:
+            BorderRadius.circular(AppConstants.segmentPickerHintCornerRadius),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppConstants.segmentPickerHintHorizontalPadding,
+          vertical: AppConstants.segmentPickerHintVerticalPadding,
+        ),
+        child: Text(
+          message,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurface,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/weigh_stations/services/local_weigh_stations_service.dart
+++ b/lib/features/weigh_stations/services/local_weigh_stations_service.dart
@@ -1,0 +1,175 @@
+import 'package:csv/csv.dart';
+import 'package:flutter/foundation.dart';
+
+import 'package:toll_cam_finder/core/app_messages.dart';
+
+import 'weigh_stations_csv_constants.dart';
+import 'weigh_stations_data_store.dart';
+import 'weigh_stations_file_system.dart';
+import 'weigh_stations_file_system_stub.dart'
+    if (dart.library.io) 'weigh_stations_file_system_io.dart' as fs_impl;
+import 'weigh_stations_paths.dart';
+
+class LocalWeighStationsService {
+  LocalWeighStationsService({
+    WeighStationsFileSystem? fileSystem,
+    WeighStationsPathResolver? pathResolver,
+  })  : _fileSystem = fileSystem ?? fs_impl.createFileSystem(),
+        _pathResolver = pathResolver;
+
+  final WeighStationsFileSystem _fileSystem;
+  final WeighStationsPathResolver? _pathResolver;
+
+  Future<void> saveStation({
+    required String name,
+    required String road,
+    required String coordinates,
+  }) async {
+    final draft = prepareDraft(
+      name: name,
+      road: road,
+      coordinates: coordinates,
+    );
+    await saveDraft(draft);
+  }
+
+  WeighStationDraft prepareDraft({
+    required String name,
+    required String road,
+    required String coordinates,
+  }) {
+    final normalizedName = name.trim();
+    final normalizedRoad = road.trim();
+    final normalizedCoordinates = coordinates.trim();
+
+    if (normalizedCoordinates.isEmpty) {
+      throw LocalWeighStationsServiceException(
+        AppMessages.coordinatesMustBeProvided,
+      );
+    }
+
+    return WeighStationDraft(
+      name: normalizedName,
+      road: normalizedRoad,
+      coordinates: normalizedCoordinates,
+    );
+  }
+
+  Future<String> saveDraft(WeighStationDraft draft) async {
+    if (kIsWeb) {
+      throw LocalWeighStationsServiceException(
+        AppMessages.savingLocalSegmentsNotSupportedOnWeb,
+      );
+    }
+
+    final csvPath = await resolveWeighStationsDataPath(
+      overrideResolver: _pathResolver,
+    );
+    await _fileSystem.ensureParentDirectory(csvPath);
+
+    final rows = await _readExistingRows(csvPath);
+    if (rows.isEmpty) {
+      rows.add(WeighStationsCsvSchema.header);
+    } else if (!_isHeaderRow(rows.first)) {
+      rows.insert(0, WeighStationsCsvSchema.header);
+    }
+
+    final remoteRows = await WeighStationsDataStore.instance.ensureRemoteRows();
+    final remoteIds = remoteRows.map((row) => row.isNotEmpty ? row.first : '');
+    final existingLocalIds = rows
+        .where((row) => row.isNotEmpty)
+        .where((row) => row.first.toLowerCase() != 'id')
+        .map((row) => row.first);
+
+    final localId = _generateLocalId(
+      existingLocalIds: existingLocalIds,
+      remoteIds: remoteIds,
+    );
+
+    rows.add(<String>[
+      localId,
+      draft.name,
+      draft.road,
+      draft.coordinates,
+    ]);
+
+    final csv = const ListToCsvConverter(
+      fieldDelimiter: ';',
+      textDelimiter: '"',
+      textEndDelimiter: '"',
+    ).convert(rows);
+
+    await _fileSystem.writeAsString(csvPath, '$csv\n');
+    return localId;
+  }
+
+  Future<List<List<String>>> _readExistingRows(String path) async {
+    if (!await _fileSystem.exists(path)) {
+      return <List<String>>[];
+    }
+    final raw = await _fileSystem.readAsString(path);
+    if (raw.trim().isEmpty) {
+      return <List<String>>[];
+    }
+    final rows = const CsvToListConverter(
+      fieldDelimiter: ';',
+      shouldParseNumbers: false,
+    ).convert(raw);
+    return rows
+        .map((row) => row.map((value) => '$value').toList())
+        .toList();
+  }
+
+  bool _isHeaderRow(List<dynamic> row) {
+    if (row.length < WeighStationsCsvSchema.header.length) {
+      return false;
+    }
+    for (var i = 0; i < WeighStationsCsvSchema.header.length; i++) {
+      if ('${row[i]}'.trim().toLowerCase() !=
+          WeighStationsCsvSchema.header[i].trim().toLowerCase()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  String _generateLocalId({
+    required Iterable<String> existingLocalIds,
+    required Iterable<String> remoteIds,
+  }) {
+    final used = <int>{};
+    final prefix = WeighStationsCsvSchema.localWeighStationIdPrefix;
+    for (final id in existingLocalIds.followedBy(remoteIds)) {
+      if (id.startsWith(prefix)) {
+        final value = int.tryParse(id.substring(prefix.length));
+        if (value != null) {
+          used.add(value);
+        }
+      }
+    }
+
+    var candidate = 1;
+    while (used.contains(candidate)) {
+      candidate += 1;
+    }
+    return '$prefix$candidate';
+  }
+}
+
+class WeighStationDraft {
+  const WeighStationDraft({
+    required this.name,
+    required this.road,
+    required this.coordinates,
+  });
+
+  final String name;
+  final String road;
+  final String coordinates;
+}
+
+class LocalWeighStationsServiceException implements Exception {
+  const LocalWeighStationsServiceException(this.message);
+
+  final String message;
+}

--- a/lib/features/weigh_stations/services/remote_weigh_stations_service.dart
+++ b/lib/features/weigh_stations/services/remote_weigh_stations_service.dart
@@ -1,0 +1,248 @@
+import 'dart:io';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:toll_cam_finder/core/app_messages.dart';
+
+import 'weigh_stations_csv_constants.dart';
+
+class RemoteWeighStationsService {
+  RemoteWeighStationsService({
+    SupabaseClient? client,
+    this.tableName = 'Weigh_Stations',
+  }) : _client = client;
+
+  final SupabaseClient? _client;
+  final String tableName;
+
+  static const String _moderationStatusColumn = 'moderation_status';
+  static const String _pendingStatus = 'pending';
+  static const String _approvedStatus = 'approved';
+  static const String _addedByUserColumn = 'added_by_user';
+  static const String _coordinatesColumn = 'coordinates';
+  static const String _nameColumn = 'name';
+  static const String _roadColumn = 'road';
+  static const String _idColumn = 'id';
+  static const int _smallIntMax = 32767;
+
+  Future<void> submitForModeration({
+    required String name,
+    required String road,
+    required String coordinates,
+    required String addedByUserId,
+  }) async {
+    final client = _client;
+    if (client == null) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.supabaseNotConfiguredForModeration,
+      );
+    }
+
+    if (addedByUserId.trim().isEmpty) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.userRequiredForPublicModeration,
+      );
+    }
+
+    var pendingId = await _computeNextRemoteId(client);
+
+    try {
+      while (true) {
+        try {
+          await client.from(tableName).insert(<String, dynamic>{
+            'id': pendingId,
+            _nameColumn: name,
+            _roadColumn: road,
+            _coordinatesColumn: coordinates,
+            _moderationStatusColumn: _pendingStatus,
+            _addedByUserColumn: addedByUserId,
+          });
+          break;
+        } on PostgrestException catch (error) {
+          if (_isIdConflict(error)) {
+            pendingId += 1;
+            if (pendingId > _smallIntMax) {
+              throw RemoteWeighStationsServiceException(
+                AppMessages.unableToAssignNewSegmentId,
+                cause: error,
+              );
+            }
+            continue;
+          }
+          rethrow;
+        }
+      }
+    } on SocketException catch (error) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.noConnectionUnableToSubmitForModeration,
+        cause: error,
+      );
+    } on PostgrestException catch (error) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.failedToSubmitSegmentForModerationWithReason(
+          error.message,
+        ),
+        cause: error,
+      );
+    } catch (error, stackTrace) {
+      if (error is RemoteWeighStationsServiceException) {
+        rethrow;
+      }
+      throw RemoteWeighStationsServiceException(
+        AppMessages.unexpectedErrorSubmittingForModeration,
+        cause: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<bool> hasPendingSubmission({
+    required String addedByUserId,
+    required String name,
+    required String coordinates,
+  }) async {
+    final client = _client;
+    if (client == null) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.supabaseNotConfiguredForPublicSubmissions,
+      );
+    }
+
+    try {
+      final List<dynamic> rows = await client
+          .from(tableName)
+          .select('$_idColumn')
+          .match(<String, Object>{
+        _moderationStatusColumn: _pendingStatus,
+        _addedByUserColumn: addedByUserId,
+        _nameColumn: name,
+        _coordinatesColumn: coordinates,
+      }).limit(1);
+
+      return rows.isNotEmpty;
+    } on SocketException catch (error) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.noConnectionUnableToManageSubmissions,
+        cause: error,
+      );
+    } on PostgrestException catch (error) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.failedToCheckSubmissionStatusWithReason(error.message),
+        cause: error,
+      );
+    } catch (error, stackTrace) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.unexpectedErrorCheckingSubmissionStatus,
+        cause: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<bool> deleteSubmission({
+    required String addedByUserId,
+    required String name,
+    required String coordinates,
+  }) async {
+    final client = _client;
+    if (client == null) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.supabaseNotConfiguredForPublicSubmissions,
+      );
+    }
+
+    try {
+      final List<dynamic> deleted = await client
+          .from(tableName)
+          .delete()
+          .match(<String, Object>{
+        _addedByUserColumn: addedByUserId,
+        _nameColumn: name,
+        _coordinatesColumn: coordinates,
+      }).select('$_idColumn');
+
+      return deleted.isNotEmpty;
+    } on SocketException catch (error) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.noConnectionUnableToManageSubmissions,
+        cause: error,
+      );
+    } on PostgrestException catch (error) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.failedToCancelSubmissionWithReason(error.message),
+        cause: error,
+      );
+    } catch (error, stackTrace) {
+      throw RemoteWeighStationsServiceException(
+        AppMessages.unexpectedErrorCancellingSubmission,
+        cause: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<int> _computeNextRemoteId(SupabaseClient client) async {
+    try {
+      final List<dynamic> rows = await client
+          .from(tableName)
+          .select('$_idColumn')
+          .order(_idColumn, ascending: false)
+          .limit(1);
+      if (rows.isEmpty) {
+        return 1;
+      }
+      final dynamic value = rows.first[_idColumn];
+      if (value is int) {
+        return value + 1;
+      }
+      if (value is String) {
+        final parsed = int.tryParse(value);
+        if (parsed != null) {
+          return parsed + 1;
+        }
+      }
+      throw const RemoteWeighStationsServiceException(
+        'Unable to determine next weigh station id.',
+      );
+    } on PostgrestException catch (error) {
+      if (_isMissingColumnError(error, _idColumn)) {
+        throw RemoteWeighStationsServiceException(
+          AppMessages.missingRequiredColumn(_idColumn),
+          cause: error,
+        );
+      }
+      rethrow;
+    }
+  }
+
+  bool _isIdConflict(PostgrestException error) {
+    final code = error.code?.toUpperCase();
+    if (code == '23505') {
+      return true;
+    }
+    final message = error.message.toLowerCase();
+    return message.contains('duplicate key value') ||
+        message.contains('unique constraint');
+  }
+
+  bool _isMissingColumnError(PostgrestException error, String column) {
+    final code = error.code?.toUpperCase();
+    if (code == '42703') {
+      return true;
+    }
+    final normalizedMessage = error.message.toLowerCase();
+    return normalizedMessage.contains('column') &&
+        normalizedMessage.contains(column.toLowerCase());
+  }
+}
+
+class RemoteWeighStationsServiceException implements Exception {
+  const RemoteWeighStationsServiceException(this.message, {this.cause, this.stackTrace});
+
+  final String message;
+  final Object? cause;
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() => 'RemoteWeighStationsServiceException: $message';
+}

--- a/lib/features/weigh_stations/services/weigh_station_alert_service.dart
+++ b/lib/features/weigh_stations/services/weigh_station_alert_service.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:audioplayers/audioplayers.dart';
+
+import 'package:toll_cam_finder/core/constants.dart';
+import 'package:toll_cam_finder/features/map/domain/controllers/guidance_audio_controller.dart';
+import 'package:toll_cam_finder/shared/audio/navigation_audio_context.dart';
+
+class WeighStationAlertService {
+  WeighStationAlertService({AudioPlayer? player})
+      : _player = player ?? AudioPlayer() {
+    unawaited(_configurePlayer());
+  }
+
+  final AudioPlayer _player;
+  String? _currentStationId;
+  bool _hasPlayed = false;
+  GuidanceAudioPolicy _audioPolicy = const GuidanceAudioPolicy(
+    allowSpeech: true,
+    allowAlertTones: true,
+    allowBoundaryTones: true,
+  );
+
+  static const double alertDistanceMeters = 500.0;
+
+  void updateAudioPolicy(GuidanceAudioPolicy policy) {
+    if (_audioPolicy == policy) {
+      return;
+    }
+    final bool hadAlert = _audioPolicy.allowAlertTones;
+    _audioPolicy = policy;
+    if (hadAlert && !policy.allowAlertTones) {
+      unawaited(_player.stop());
+    }
+  }
+
+  void updateDistance({required String? stationId, required double? distanceMeters}) {
+    if (stationId == null || distanceMeters == null) {
+      _resetState();
+      return;
+    }
+
+    if (_currentStationId != stationId) {
+      _currentStationId = stationId;
+      _hasPlayed = false;
+    }
+
+    if (distanceMeters >= alertDistanceMeters) {
+      _hasPlayed = false;
+      return;
+    }
+
+    if (!_hasPlayed && distanceMeters >= 1 && _audioPolicy.allowAlertTones) {
+      _hasPlayed = true;
+      unawaited(
+        _player.play(AssetSource(AppConstants.upcomingSegmentSoundAsset)),
+      );
+    }
+  }
+
+  void reset() {
+    _resetState();
+  }
+
+  Future<void> dispose() => _player.dispose();
+
+  void _resetState() {
+    _currentStationId = null;
+    _hasPlayed = false;
+  }
+
+  Future<void> _configurePlayer() async {
+    try {
+      await _player.setAudioContext(navigationAudioContext);
+    } catch (_) {
+      // best effort
+    }
+  }
+}

--- a/lib/features/weigh_stations/services/weigh_stations_csv_constants.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_csv_constants.dart
@@ -1,0 +1,12 @@
+class WeighStationsCsvSchema {
+  const WeighStationsCsvSchema._();
+
+  static const List<String> header = <String>[
+    'ID',
+    'name',
+    'road',
+    'coordinates',
+  ];
+
+  static const String localWeighStationIdPrefix = 'LOCAL_WS:';
+}

--- a/lib/features/weigh_stations/services/weigh_stations_data_store.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_data_store.dart
@@ -1,0 +1,169 @@
+import 'package:csv/csv.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+import 'weigh_stations_csv_constants.dart';
+import 'weigh_stations_file_system.dart';
+import 'weigh_stations_paths.dart';
+
+class WeighStationsDataStore {
+  WeighStationsDataStore._();
+
+  static final WeighStationsDataStore instance = WeighStationsDataStore._();
+
+  List<List<String>>? _remoteRows;
+
+  List<List<String>>? get remoteRows => _remoteRows;
+
+  void updateRemoteRows(List<List<String>> rows) {
+    _remoteRows = List<List<String>>.from(
+      rows.map((row) => List<String>.from(row)),
+      growable: false,
+    );
+  }
+
+  Future<List<List<String>>> ensureRemoteRows({
+    String assetPath = kWeighStationsAssetPath,
+  }) async {
+    final rows = await _ensureRemoteRows(assetPath: assetPath);
+    return List<List<String>>.from(
+      rows.map((row) => List<String>.from(row)),
+      growable: false,
+    );
+  }
+
+  void clear() {
+    _remoteRows = null;
+  }
+
+  Future<String> loadCombinedCsv({
+    required WeighStationsFileSystem fileSystem,
+    String assetPath = kWeighStationsAssetPath,
+    WeighStationsPathResolver? pathResolver,
+  }) async {
+    final remoteRows = await _ensureRemoteRows(assetPath: assetPath);
+    final localRows = await _maybeLoadLocalRows(
+      fileSystem: fileSystem,
+      pathResolver: pathResolver,
+    );
+
+    final csvRows = <List<String>>[]
+      ..add(WeighStationsCsvSchema.header)
+      ..addAll(remoteRows)
+      ..addAll(localRows);
+
+    final csv = const ListToCsvConverter(
+      fieldDelimiter: ';',
+      textDelimiter: '"',
+      textEndDelimiter: '"',
+    ).convert(csvRows);
+
+    return '$csv\n';
+  }
+
+  Future<List<List<String>>> loadLocalRows({
+    required WeighStationsFileSystem fileSystem,
+    WeighStationsPathResolver? pathResolver,
+  }) async {
+    final csvPath = await resolveWeighStationsDataPath(
+      overrideResolver: pathResolver,
+    );
+
+    if (!await fileSystem.exists(csvPath)) {
+      return const <List<String>>[];
+    }
+
+    final raw = await fileSystem.readAsString(csvPath);
+    final parsed = const CsvToListConverter(
+      fieldDelimiter: ';',
+      shouldParseNumbers: false,
+    ).convert(raw);
+
+    if (parsed.isEmpty) {
+      return const <List<String>>[];
+    }
+
+    final rows = <List<String>>[];
+    for (final row in parsed.skip(1)) {
+      final normalized = row
+          .map((value) => value.toString())
+          .toList(growable: false);
+      if (normalized.isEmpty) {
+        continue;
+      }
+
+      if (!normalized.first
+          .startsWith(WeighStationsCsvSchema.localWeighStationIdPrefix)) {
+        continue;
+      }
+
+      rows.add(normalized);
+    }
+
+    return rows;
+  }
+
+  Future<List<List<String>>> _maybeLoadLocalRows({
+    required WeighStationsFileSystem fileSystem,
+    WeighStationsPathResolver? pathResolver,
+  }) async {
+    if (kIsWeb) {
+      return const <List<String>>[];
+    }
+
+    try {
+      return await loadLocalRows(
+        fileSystem: fileSystem,
+        pathResolver: pathResolver,
+      );
+    } on WeighStationsFileSystemException {
+      return const <List<String>>[];
+    }
+  }
+
+  Future<List<List<String>>> _ensureRemoteRows({
+    required String assetPath,
+  }) async {
+    final cached = _remoteRows;
+    if (cached != null) {
+      return cached;
+    }
+
+    String assetRaw;
+    try {
+      assetRaw = await rootBundle.loadString(assetPath);
+    } on FlutterError catch (error) {
+      debugPrint(
+        'WeighStationsDataStore: no bundled weigh stations found at '
+        '"$assetPath" ($error). Using an empty remote dataset until the '
+        'next sync completes.',
+      );
+      _remoteRows = const <List<String>>[];
+      return _remoteRows!;
+    }
+
+    final parsed = const CsvToListConverter(
+      fieldDelimiter: ';',
+      shouldParseNumbers: false,
+    ).convert(assetRaw);
+
+    if (parsed.length <= 1) {
+      return const <List<String>>[];
+    }
+
+    final rows = <List<String>>[];
+    for (final row in parsed.skip(1)) {
+      final normalized = row
+          .map((value) => value.toString())
+          .toList(growable: false);
+      if (normalized.isEmpty) {
+        continue;
+      }
+
+      rows.add(normalized);
+    }
+
+    _remoteRows = rows;
+    return rows;
+  }
+}

--- a/lib/features/weigh_stations/services/weigh_stations_file_system.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_file_system.dart
@@ -1,0 +1,21 @@
+abstract class WeighStationsFileSystem {
+  const WeighStationsFileSystem();
+
+  Future<bool> exists(String path);
+
+  Future<String> readAsString(String path);
+
+  Future<void> writeAsString(String path, String data);
+
+  Future<void> ensureParentDirectory(String path);
+}
+
+class WeighStationsFileSystemException implements Exception {
+  const WeighStationsFileSystemException(this.message, [this.cause]);
+
+  final String message;
+  final Object? cause;
+
+  @override
+  String toString() => 'WeighStationsFileSystemException: $message';
+}

--- a/lib/features/weigh_stations/services/weigh_stations_file_system_io.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_file_system_io.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'weigh_stations_file_system.dart';
+
+class IoWeighStationsFileSystem extends WeighStationsFileSystem {
+  const IoWeighStationsFileSystem();
+
+  @override
+  Future<void> ensureParentDirectory(String path) async {
+    final directory = Directory(path).parent;
+    if (await directory.exists()) {
+      return;
+    }
+    await directory.create(recursive: true);
+  }
+
+  @override
+  Future<bool> exists(String path) async {
+    return File(path).exists();
+  }
+
+  @override
+  Future<String> readAsString(String path) async {
+    try {
+      return await File(path).readAsString();
+    } on FileSystemException catch (error) {
+      throw WeighStationsFileSystemException(error.message, error);
+    }
+  }
+
+  @override
+  Future<void> writeAsString(String path, String data) async {
+    try {
+      await File(path).writeAsString(data);
+    } on FileSystemException catch (error) {
+      throw WeighStationsFileSystemException(error.message, error);
+    }
+  }
+}
+
+WeighStationsFileSystem createFileSystem() => const IoWeighStationsFileSystem();

--- a/lib/features/weigh_stations/services/weigh_stations_file_system_stub.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_file_system_stub.dart
@@ -1,0 +1,28 @@
+import 'package:toll_cam_finder/core/app_messages.dart';
+
+import 'weigh_stations_file_system.dart';
+
+class UnsupportedWeighStationsFileSystem extends WeighStationsFileSystem {
+  const UnsupportedWeighStationsFileSystem();
+
+  Future<T> _unsupported<T>() {
+    throw WeighStationsFileSystemException(
+      AppMessages.fileSystemOperationsNotSupported,
+    );
+  }
+
+  @override
+  Future<void> ensureParentDirectory(String path) => _unsupported();
+
+  @override
+  Future<bool> exists(String path) => _unsupported();
+
+  @override
+  Future<String> readAsString(String path) => _unsupported();
+
+  @override
+  Future<void> writeAsString(String path, String data) => _unsupported();
+}
+
+WeighStationsFileSystem createFileSystem() =>
+    const UnsupportedWeighStationsFileSystem();

--- a/lib/features/weigh_stations/services/weigh_stations_paths.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_paths.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+const String kWeighStationsAssetPath = 'assets/data/weigh_stations.csv';
+const String kWeighStationsFileName = 'weigh_stations.csv';
+const String kWeighStationsMetadataSuffix = '_metadata.json';
+
+typedef WeighStationsPathResolver = Future<String> Function();
+
+Future<String> resolveWeighStationsDataPath({
+  WeighStationsPathResolver? overrideResolver,
+}) async {
+  if (overrideResolver != null) {
+    return overrideResolver();
+  }
+
+  if (kIsWeb) {
+    return kWeighStationsAssetPath;
+  }
+
+  final directory = await getApplicationSupportDirectory();
+  return p.join(directory.path, kWeighStationsFileName);
+}
+
+Future<String> resolveWeighStationsMetadataPath({
+  WeighStationsPathResolver? overrideResolver,
+}) async {
+  final csvPath = await resolveWeighStationsDataPath(
+    overrideResolver: overrideResolver,
+  );
+  return '$csvPath$kWeighStationsMetadataSuffix';
+}

--- a/lib/features/weigh_stations/services/weigh_stations_repository.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_repository.dart
@@ -1,0 +1,101 @@
+import 'package:csv/csv.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+import 'package:toll_cam_finder/features/weigh_stations/domain/weigh_station.dart';
+
+import 'weigh_stations_csv_constants.dart';
+import 'weigh_stations_data_store.dart';
+import 'weigh_stations_file_system.dart';
+import 'weigh_stations_file_system_stub.dart'
+    if (dart.library.io) 'weigh_stations_file_system_io.dart' as fs_impl;
+import 'weigh_stations_paths.dart';
+
+class WeighStationsRepository {
+  WeighStationsRepository({
+    WeighStationsFileSystem? fileSystem,
+    WeighStationsPathResolver? pathResolver,
+  })  : _fileSystem = fileSystem ?? fs_impl.createFileSystem(),
+        _pathResolver = pathResolver;
+
+  final WeighStationsFileSystem _fileSystem;
+  final WeighStationsPathResolver? _pathResolver;
+
+  Future<List<WeighStationInfo>> loadStations({
+    String assetPath = kWeighStationsAssetPath,
+  }) async {
+    final raw = await _loadStationsData(assetPath);
+    final rows = const CsvToListConverter(fieldDelimiter: ';').convert(raw);
+    if (rows.isEmpty) {
+      return const [];
+    }
+
+    final header = rows.first
+        .map((cell) => '$cell'.trim().toLowerCase())
+        .toList();
+    final idIndex = header.indexOf('id');
+    final nameIndex = header.indexOf('name');
+    final roadIndex = header.indexOf('road');
+    final coordIndex = header.indexOf('coordinates');
+    final stations = <WeighStationInfo>[];
+
+    for (final row in rows.skip(1)) {
+      if (row.length <= idIndex || row.length <= coordIndex) {
+        continue;
+      }
+      final id = _stringAt(row, idIndex);
+      final name = _stringAt(row, nameIndex);
+      final road = _stringAt(row, roadIndex);
+      final coordinates = _stringAt(row, coordIndex);
+      if (id.isEmpty && coordinates.isEmpty) {
+        continue;
+      }
+
+      final isLocalOnly = id.startsWith(
+        WeighStationsCsvSchema.localWeighStationIdPrefix,
+      );
+
+      stations.add(
+        WeighStationInfo(
+          id: id,
+          name: name,
+          road: road,
+          coordinates: coordinates,
+          isLocalOnly: isLocalOnly,
+        ),
+      );
+    }
+
+    stations.sort((a, b) {
+      final idComparison = a.displayId.compareTo(b.displayId);
+      if (idComparison != 0) {
+        return idComparison;
+      }
+      final nameComparison = a.name.compareTo(b.name);
+      if (nameComparison != 0) {
+        return nameComparison;
+      }
+      return a.coordinates.compareTo(b.coordinates);
+    });
+
+    return stations;
+  }
+
+  Future<String> _loadStationsData(String assetPath) async {
+    if (assetPath == kWeighStationsAssetPath) {
+      return WeighStationsDataStore.instance.loadCombinedCsv(
+        fileSystem: _fileSystem,
+        assetPath: assetPath,
+        pathResolver: _pathResolver,
+      );
+    }
+
+    return rootBundle.loadString(assetPath);
+  }
+
+  String _stringAt(List<dynamic> row, int index) {
+    if (index < 0 || index >= row.length) {
+      return '';
+    }
+    return '${row[index]}'.trim();
+  }
+}

--- a/lib/features/weigh_stations/services/weigh_stations_sync_service.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_sync_service.dart
@@ -1,0 +1,393 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' show SocketException;
+
+import 'package:csv/csv.dart';
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:toll_cam_finder/core/app_messages.dart';
+
+import 'weigh_stations_csv_constants.dart';
+import 'weigh_stations_data_store.dart';
+import 'weigh_stations_file_system.dart';
+import 'weigh_stations_file_system_stub.dart'
+    if (dart.library.io) 'weigh_stations_file_system_io.dart' as fs_impl;
+import 'weigh_stations_paths.dart';
+
+class WeighStationsSyncResult {
+  const WeighStationsSyncResult({
+    required this.downloaded,
+    required this.removed,
+    required this.localApproved,
+  });
+
+  final int downloaded;
+  final int removed;
+  final int localApproved;
+}
+
+class WeighStationsSyncException implements Exception {
+  const WeighStationsSyncException(this.message, {this.cause, this.stackTrace});
+
+  final String message;
+  final Object? cause;
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() => 'WeighStationsSyncException: $message';
+}
+
+class WeighStationsSyncService {
+  WeighStationsSyncService({
+    this.tableName = 'Weigh_Stations',
+    WeighStationsFileSystem? fileSystem,
+    WeighStationsPathResolver? localPathResolver,
+  })  : _fileSystem = fileSystem ?? fs_impl.createFileSystem(),
+        _localPathResolver = localPathResolver;
+
+  final String tableName;
+  final WeighStationsFileSystem _fileSystem;
+  final WeighStationsPathResolver? _localPathResolver;
+
+  static const String _moderationStatusColumn = 'moderation_status';
+  static const String _approvedStatus = 'approved';
+  static const String _addedByUserColumn = 'added_by_user';
+
+  Future<WeighStationsSyncResult> sync({
+    required SupabaseClient client,
+  }) async {
+    if (kIsWeb) {
+      throw const WeighStationsSyncException(
+        'Sync is not supported on the web.',
+      );
+    }
+
+    try {
+      final localCsvPath = await _resolveLocalCsvPath();
+      await _fileSystem.ensureParentDirectory(localCsvPath);
+
+      final remoteRows = await _fetchRemoteRows(client);
+      final localRows = await _readLocalRows(localCsvPath);
+      final approvalOutcome = _filterApprovedLocalStations(
+        remoteRows,
+        localRows.localRows,
+      );
+      final diff = _calculateDiff(
+        localRows.remoteRows,
+        remoteRows,
+        approvedLocalStations: approvalOutcome.approvedCount,
+      );
+
+      await _writeLocalRows(localCsvPath, approvalOutcome.remainingLocalRows);
+      WeighStationsDataStore.instance.updateRemoteRows(remoteRows);
+
+      return diff;
+    } on WeighStationsSyncException {
+      rethrow;
+    } on SocketException catch (error) {
+      throw WeighStationsSyncException(
+        AppMessages.syncRequiresInternetConnection,
+        cause: error,
+      );
+    } on PostgrestException catch (error) {
+      throw WeighStationsSyncException(
+        AppMessages.failedToDownloadWeighStations(error.message),
+        cause: error,
+      );
+    } on WeighStationsFileSystemException catch (error) {
+      throw WeighStationsSyncException(
+        AppMessages.failedToAccessWeighStationsFile(error.message),
+        cause: error,
+      );
+    } catch (error, stackTrace) {
+      throw WeighStationsSyncException(
+        AppMessages.unexpectedSyncError,
+        cause: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<List<List<String>>> _fetchRemoteRows(SupabaseClient client) async {
+    final attemptedTables = <String>[];
+    PostgrestException? lastMissingTableException;
+
+    for (final candidate in _candidateTableNames) {
+      try {
+        final response = await _selectApprovedRows(client, candidate);
+
+        if (candidate != tableName) {
+          debugPrint(
+            'WeighStationsSyncService: using "$candidate" as the weigh stations source.',
+          );
+        }
+
+        return response
+            .map((record) => _toCanonicalRow(record))
+            .toList(growable: false);
+      } on WeighStationsSyncException {
+        rethrow;
+      } on PostgrestException catch (error) {
+        if (_isMissingTableError(error)) {
+          attemptedTables.add(candidate);
+          lastMissingTableException = error;
+          continue;
+        }
+        rethrow;
+      }
+    }
+
+    if (attemptedTables.isEmpty) {
+      throw WeighStationsSyncException(
+        AppMessages.tableReturnedNoRows(tableName),
+        cause: lastMissingTableException,
+      );
+    }
+
+    throw WeighStationsSyncException(
+      AppMessages.noTollSegmentRowsFound(attemptedTables.join(', ')),
+      cause: lastMissingTableException,
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> _selectApprovedRows(
+    SupabaseClient client,
+    String table,
+  ) async {
+    try {
+      final List<dynamic> response = await client
+          .from(table)
+          .select('*')
+          .eq(_moderationStatusColumn, _approvedStatus);
+
+      return response
+          .cast<Map<String, dynamic>>()
+          .map(
+            (record) => Map<String, dynamic>.from(record)
+              ..removeWhere(
+                (key, value) =>
+                    _normalize(key) == _normalize(_addedByUserColumn),
+              ),
+          )
+          .toList(growable: false);
+    } on PostgrestException catch (error) {
+      if (_isMissingColumnError(error, _moderationStatusColumn)) {
+        throw WeighStationsSyncException(
+          AppMessages.tableMissingModerationColumn(
+            table,
+            _moderationStatusColumn,
+          ),
+          cause: error,
+        );
+      }
+      rethrow;
+    }
+  }
+
+  Iterable<String> get _candidateTableNames {
+    final normalized = tableName.trim();
+    final lower = normalized.toLowerCase();
+    final snake = _toSnakeCase(normalized);
+    final title = lower.isEmpty
+        ? lower
+        : lower[0].toUpperCase() + lower.substring(1);
+
+    return <String>{normalized, lower, title, snake}
+      ..removeWhere((name) => name.isEmpty);
+  }
+
+  bool _isMissingTableError(PostgrestException error) {
+    final code = error.code?.toUpperCase();
+    if (code == '42P01') {
+      return true;
+    }
+    final message = error.message.toLowerCase();
+    return message.contains('does not exist') ||
+        message.contains('not exist') ||
+        message.contains('unknown table');
+  }
+
+  bool _isMissingColumnError(PostgrestException error, String column) {
+    final code = error.code?.toUpperCase();
+    if (code == '42703') {
+      return true;
+    }
+
+    final normalizedMessage = error.message.toLowerCase();
+    return normalizedMessage.contains('column') &&
+        normalizedMessage.contains(column.toLowerCase());
+  }
+
+  Future<String> _resolveLocalCsvPath() async {
+    return resolveWeighStationsDataPath(
+      overrideResolver: _localPathResolver,
+    );
+  }
+
+  Future<_LocalRows> _readLocalRows(String path) async {
+    if (!await _fileSystem.exists(path)) {
+      return const _LocalRows.empty();
+    }
+
+    final raw = await _fileSystem.readAsString(path);
+    if (raw.trim().isEmpty) {
+      return const _LocalRows.empty();
+    }
+
+    final rows = const CsvToListConverter(
+      fieldDelimiter: ';',
+      shouldParseNumbers: false,
+    ).convert(raw);
+
+    if (rows.isEmpty) {
+      return const _LocalRows.empty();
+    }
+
+    final header = rows.first
+        .map((value) => value.toString())
+        .toList(growable: false);
+    final dataRows = rows
+        .skip(1)
+        .map(
+          (row) => row
+              .map((value) => value.toString())
+              .toList(growable: false),
+        )
+        .toList(growable: false);
+
+    return _LocalRows(header: header, rows: dataRows);
+  }
+
+  Future<void> _writeLocalRows(
+    String path,
+    List<List<String>> rows,
+  ) async {
+    final csvRows = <List<String>>[]
+      ..add(WeighStationsCsvSchema.header)
+      ..addAll(rows);
+
+    final csv = const ListToCsvConverter(
+      fieldDelimiter: ';',
+      textDelimiter: '"',
+      textEndDelimiter: '"',
+    ).convert(csvRows);
+
+    await _fileSystem.writeAsString(path, '$csv\n');
+  }
+
+  _ApprovalOutcome _filterApprovedLocalStations(
+    List<List<String>> remoteRows,
+    List<List<String>> localRows,
+  ) {
+    if (localRows.isEmpty) {
+      return const _ApprovalOutcome(
+        approvedCount: 0,
+        remainingLocalRows: <List<String>>[],
+      );
+    }
+
+    final remoteIds = remoteRows.map((row) => row.first).toSet();
+    final remaining = <List<String>>[];
+    var approved = 0;
+    for (final row in localRows) {
+      if (row.isEmpty) {
+        continue;
+      }
+      final id = row.first;
+      if (!id.startsWith(WeighStationsCsvSchema.localWeighStationIdPrefix)) {
+        continue;
+      }
+      if (remoteIds.contains(id)) {
+        approved += 1;
+        continue;
+      }
+      remaining.add(row);
+    }
+
+    return _ApprovalOutcome(
+      approvedCount: approved,
+      remainingLocalRows: remaining,
+    );
+  }
+
+  WeighStationsSyncResult _calculateDiff(
+    List<List<String>> localRemoteRows,
+    List<List<String>> remoteRows,
+    {required int approvedLocalStations,}
+  ) {
+    final localIds = localRemoteRows.map((row) => row.first).toSet();
+    final remoteIds = remoteRows.map((row) => row.first).toSet();
+
+    final added = remoteIds.difference(localIds).length;
+    final removed = localIds.difference(remoteIds).length;
+
+    return WeighStationsSyncResult(
+      downloaded: added,
+      removed: removed,
+      localApproved: approvedLocalStations,
+    );
+  }
+
+  List<String> _toCanonicalRow(Map<String, dynamic> record) {
+    final normalized = <String, String>{};
+    record.forEach((key, value) {
+      normalized[_normalize(key)] = value?.toString() ?? '';
+    });
+
+    final id = normalized['id'] ?? '';
+    final name = normalized['name'] ?? '';
+    final road = normalized['road'] ?? '';
+    final coordinates = normalized['coordinates'] ?? '';
+
+    return <String>[id, name, road, coordinates];
+  }
+
+  String _normalize(String value) => value.trim().toLowerCase();
+
+  String _toSnakeCase(String value) {
+    final buffer = StringBuffer();
+    for (var i = 0; i < value.length; i++) {
+      final char = value[i];
+      if (_isUppercase(char) && i > 0 && value[i - 1] != '_') {
+        buffer.write('_');
+      }
+      buffer.write(char.toLowerCase());
+    }
+    return buffer.toString();
+  }
+
+  bool _isUppercase(String char) {
+    return char.toUpperCase() == char && char.toLowerCase() != char;
+  }
+}
+
+class _LocalRows {
+  const _LocalRows({required this.header, required this.rows});
+
+  const _LocalRows.empty()
+      : header = const <String>[],
+        rows = const <List<String>>[];
+
+  final List<String> header;
+  final List<List<String>> rows;
+
+  List<List<String>> get localRows => rows;
+
+  List<List<String>> get remoteRows => rows
+      .where(
+        (row) => !row.first
+            .startsWith(WeighStationsCsvSchema.localWeighStationIdPrefix),
+      )
+      .toList(growable: false);
+}
+
+class _ApprovalOutcome {
+  const _ApprovalOutcome({
+    required this.approvedCount,
+    required this.remainingLocalRows,
+  });
+
+  final int approvedCount;
+  final List<List<String>> remainingLocalRows;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/data/toll_segments.csv
+    - assets/data/weigh_stations.csv
     - assets/data/ding_sound.mp3
 
 flutter_launcher_icons:


### PR DESCRIPTION
## Summary
- add weigh station domain, storage, sync, and alert services
- expose weigh station management UI and navigation routes
- render weigh station markers and alerts on the map and ship dataset asset

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fde7d83bbc832da8af00c9237a1a7d