### PR TITLE
Remove unused weigh station fields

### DIFF
--- a/assets/data/weigh_stations.csv
+++ b/assets/data/weigh_stations.csv
@@ -1,1 +1,1 @@
-ID;name;road;coordinates
+ID;coordinates

--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -69,10 +69,6 @@ class AppLocalizations {
       'createWeighStation': 'Add weigh station',
       'createWeighStationInstructions':
           'Tap the map to place the weigh station marker. Long-press and drag to fine-tune the location.',
-      'weighStationNameLabel': 'Station name',
-      'weighStationNameHint': 'Optional name',
-      'weighStationRoadInputLabel': 'Road',
-      'weighStationRoadHint': 'A1, E80…',
       'weighStationCoordinatesInputLabel': 'Coordinates',
       'weighStationCoordinatesHint': '41.8626802,26.0873785',
       'saveWeighStation': 'Save weigh station',
@@ -84,8 +80,7 @@ class AppLocalizations {
           'Failed to submit the weigh station for moderation.',
       'weighStationSubmittedForReview':
           'Weigh station submitted for review.',
-      'weighStationUnnamed': 'Weigh station {id}',
-      'weighStationRoadLabel': 'Road: {road}',
+      'weighStationIdentifier': 'Weigh station {id}',
       'weighStationCoordinatesLabel': 'Coordinates: {coordinates}',
       'weighStationLocalBadge': 'Local only',
       'weighStationMapHintPlace':
@@ -414,10 +409,6 @@ class AppLocalizations {
       'createWeighStation': 'Добави кантар',
       'createWeighStationInstructions':
           'Докоснете картата, за да поставите маркера за кантара. Задръжте и плъзнете, за да коригирате позицията.',
-      'weighStationNameLabel': 'Име на кантара',
-      'weighStationNameHint': 'Незадължително име',
-      'weighStationRoadInputLabel': 'Път',
-      'weighStationRoadHint': 'A1, E80…',
       'weighStationCoordinatesInputLabel': 'Координати',
       'weighStationCoordinatesHint': '41.8626802,26.0873785',
       'saveWeighStation': 'Запази кантара',
@@ -433,8 +424,7 @@ class AppLocalizations {
           'Неуспешно изпращане на кантара за модерация.',
       'weighStationSubmittedForReview':
           'Кантарът е изпратен за преглед.',
-      'weighStationUnnamed': 'Кантар {id}',
-      'weighStationRoadLabel': 'Път: {road}',
+      'weighStationIdentifier': 'Кантар {id}',
       'weighStationCoordinatesLabel': 'Координати: {coordinates}',
       'weighStationLocalBadge': 'Само локален',
       'weighStationMapHintPlace':
@@ -646,11 +636,6 @@ class AppLocalizations {
   String get createWeighStation => _value('createWeighStation');
   String get createWeighStationInstructions =>
       _value('createWeighStationInstructions');
-  String get weighStationNameLabel => _value('weighStationNameLabel');
-  String get weighStationNameHint => _value('weighStationNameHint');
-  String get weighStationRoadInputLabel =>
-      _value('weighStationRoadInputLabel');
-  String get weighStationRoadHint => _value('weighStationRoadHint');
   String get weighStationCoordinatesInputLabel =>
       _value('weighStationCoordinatesInputLabel');
   String get weighStationCoordinatesHint =>
@@ -665,10 +650,8 @@ class AppLocalizations {
       _value('failedToSubmitWeighStation');
   String get weighStationSubmittedForReview =>
       _value('weighStationSubmittedForReview');
-  String weighStationUnnamed(String id) =>
-      translate('weighStationUnnamed', {'id': id});
-  String weighStationRoadLabel(String road) =>
-      translate('weighStationRoadLabel', {'road': road});
+  String weighStationIdentifier(String id) =>
+      translate('weighStationIdentifier', {'id': id});
   String weighStationCoordinatesLabel(String coordinates) => translate(
         'weighStationCoordinatesLabel',
         {'coordinates': coordinates},

--- a/lib/features/weigh_stations/domain/weigh_station.dart
+++ b/lib/features/weigh_stations/domain/weigh_station.dart
@@ -3,15 +3,11 @@ import 'package:toll_cam_finder/features/weigh_stations/services/weigh_stations_
 class WeighStationInfo {
   const WeighStationInfo({
     required this.id,
-    required this.name,
-    required this.road,
     required this.coordinates,
     this.isLocalOnly = false,
   });
 
   final String id;
-  final String name;
-  final String road;
   final String coordinates;
   final bool isLocalOnly;
 

--- a/lib/features/weigh_stations/presentation/pages/create_weigh_station_page.dart
+++ b/lib/features/weigh_stations/presentation/pages/create_weigh_station_page.dart
@@ -16,8 +16,6 @@ class CreateWeighStationPage extends StatefulWidget {
 }
 
 class _CreateWeighStationPageState extends State<CreateWeighStationPage> {
-  final TextEditingController _nameController = TextEditingController();
-  final TextEditingController _roadController = TextEditingController();
   final TextEditingController _coordinatesController = TextEditingController();
 
   final LocalWeighStationsService _localService = LocalWeighStationsService();
@@ -25,8 +23,6 @@ class _CreateWeighStationPageState extends State<CreateWeighStationPage> {
 
   @override
   void dispose() {
-    _nameController.dispose();
-    _roadController.dispose();
     _coordinatesController.dispose();
     super.dispose();
   }
@@ -55,24 +51,6 @@ class _CreateWeighStationPageState extends State<CreateWeighStationPage> {
                 coordinatesController: _coordinatesController,
               ),
               const SizedBox(height: 24),
-              TextField(
-                controller: _nameController,
-                decoration: InputDecoration(
-                  labelText: localizations.weighStationNameLabel,
-                  hintText: localizations.weighStationNameHint,
-                ),
-                textInputAction: TextInputAction.next,
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: _roadController,
-                decoration: InputDecoration(
-                  labelText: localizations.weighStationRoadInputLabel,
-                  hintText: localizations.weighStationRoadHint,
-                ),
-                textInputAction: TextInputAction.next,
-              ),
-              const SizedBox(height: 16),
               TextField(
                 controller: _coordinatesController,
                 decoration: InputDecoration(
@@ -129,8 +107,6 @@ class _CreateWeighStationPageState extends State<CreateWeighStationPage> {
     WeighStationDraft draft;
     try {
       draft = _localService.prepareDraft(
-        name: _nameController.text,
-        road: _roadController.text,
         coordinates: _coordinatesController.text,
       );
     } on LocalWeighStationsServiceException catch (error) {
@@ -155,8 +131,6 @@ class _CreateWeighStationPageState extends State<CreateWeighStationPage> {
     final remoteService = RemoteWeighStationsService(client: auth.client);
     try {
       await remoteService.submitForModeration(
-        name: draft.name,
-        road: draft.road,
         coordinates: draft.coordinates,
         addedByUserId: userId,
       );

--- a/lib/features/weigh_stations/presentation/pages/weigh_stations_page.dart
+++ b/lib/features/weigh_stations/presentation/pages/weigh_stations_page.dart
@@ -76,16 +76,12 @@ class _WeighStationsPageState extends State<WeighStationsPage> {
                   child: ListTile(
                     leading: const Icon(Icons.scale_outlined),
                     title: Text(
-                      station.name.isNotEmpty
-                          ? station.name
-                          : localizations.weighStationUnnamed(station.displayId),
+                      localizations.weighStationIdentifier(station.displayId),
                     ),
                     subtitle: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        if (station.road.isNotEmpty)
-                          Text(localizations.weighStationRoadLabel(station.road)),
                         Text(localizations.weighStationCoordinatesLabel(station.coordinates)),
                         if (station.isLocalOnly)
                           Padding(

--- a/lib/features/weigh_stations/services/local_weigh_stations_service.dart
+++ b/lib/features/weigh_stations/services/local_weigh_stations_service.dart
@@ -21,25 +21,17 @@ class LocalWeighStationsService {
   final WeighStationsPathResolver? _pathResolver;
 
   Future<void> saveStation({
-    required String name,
-    required String road,
     required String coordinates,
   }) async {
     final draft = prepareDraft(
-      name: name,
-      road: road,
       coordinates: coordinates,
     );
     await saveDraft(draft);
   }
 
   WeighStationDraft prepareDraft({
-    required String name,
-    required String road,
     required String coordinates,
   }) {
-    final normalizedName = name.trim();
-    final normalizedRoad = road.trim();
     final normalizedCoordinates = coordinates.trim();
 
     if (normalizedCoordinates.isEmpty) {
@@ -49,8 +41,6 @@ class LocalWeighStationsService {
     }
 
     return WeighStationDraft(
-      name: normalizedName,
-      road: normalizedRoad,
       coordinates: normalizedCoordinates,
     );
   }
@@ -88,8 +78,6 @@ class LocalWeighStationsService {
 
     rows.add(<String>[
       localId,
-      draft.name,
-      draft.road,
       draft.coordinates,
     ]);
 
@@ -158,13 +146,9 @@ class LocalWeighStationsService {
 
 class WeighStationDraft {
   const WeighStationDraft({
-    required this.name,
-    required this.road,
     required this.coordinates,
   });
 
-  final String name;
-  final String road;
   final String coordinates;
 }
 

--- a/lib/features/weigh_stations/services/remote_weigh_stations_service.dart
+++ b/lib/features/weigh_stations/services/remote_weigh_stations_service.dart
@@ -20,14 +20,10 @@ class RemoteWeighStationsService {
   static const String _approvedStatus = 'approved';
   static const String _addedByUserColumn = 'added_by_user';
   static const String _coordinatesColumn = 'coordinates';
-  static const String _nameColumn = 'name';
-  static const String _roadColumn = 'road';
   static const String _idColumn = 'id';
   static const int _smallIntMax = 32767;
 
   Future<void> submitForModeration({
-    required String name,
-    required String road,
     required String coordinates,
     required String addedByUserId,
   }) async {
@@ -51,8 +47,6 @@ class RemoteWeighStationsService {
         try {
           await client.from(tableName).insert(<String, dynamic>{
             'id': pendingId,
-            _nameColumn: name,
-            _roadColumn: road,
             _coordinatesColumn: coordinates,
             _moderationStatusColumn: _pendingStatus,
             _addedByUserColumn: addedByUserId,
@@ -98,7 +92,6 @@ class RemoteWeighStationsService {
 
   Future<bool> hasPendingSubmission({
     required String addedByUserId,
-    required String name,
     required String coordinates,
   }) async {
     final client = _client;
@@ -115,7 +108,6 @@ class RemoteWeighStationsService {
           .match(<String, Object>{
         _moderationStatusColumn: _pendingStatus,
         _addedByUserColumn: addedByUserId,
-        _nameColumn: name,
         _coordinatesColumn: coordinates,
       }).limit(1);
 
@@ -141,7 +133,6 @@ class RemoteWeighStationsService {
 
   Future<bool> deleteSubmission({
     required String addedByUserId,
-    required String name,
     required String coordinates,
   }) async {
     final client = _client;
@@ -157,7 +148,6 @@ class RemoteWeighStationsService {
           .delete()
           .match(<String, Object>{
         _addedByUserColumn: addedByUserId,
-        _nameColumn: name,
         _coordinatesColumn: coordinates,
       }).select('$_idColumn');
 

--- a/lib/features/weigh_stations/services/weigh_stations_csv_constants.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_csv_constants.dart
@@ -3,8 +3,6 @@ class WeighStationsCsvSchema {
 
   static const List<String> header = <String>[
     'ID',
-    'name',
-    'road',
     'coordinates',
   ];
 

--- a/lib/features/weigh_stations/services/weigh_stations_repository.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_repository.dart
@@ -33,8 +33,6 @@ class WeighStationsRepository {
         .map((cell) => '$cell'.trim().toLowerCase())
         .toList();
     final idIndex = header.indexOf('id');
-    final nameIndex = header.indexOf('name');
-    final roadIndex = header.indexOf('road');
     final coordIndex = header.indexOf('coordinates');
     final stations = <WeighStationInfo>[];
 
@@ -43,8 +41,6 @@ class WeighStationsRepository {
         continue;
       }
       final id = _stringAt(row, idIndex);
-      final name = _stringAt(row, nameIndex);
-      final road = _stringAt(row, roadIndex);
       final coordinates = _stringAt(row, coordIndex);
       if (id.isEmpty && coordinates.isEmpty) {
         continue;
@@ -57,8 +53,6 @@ class WeighStationsRepository {
       stations.add(
         WeighStationInfo(
           id: id,
-          name: name,
-          road: road,
           coordinates: coordinates,
           isLocalOnly: isLocalOnly,
         ),
@@ -69,10 +63,6 @@ class WeighStationsRepository {
       final idComparison = a.displayId.compareTo(b.displayId);
       if (idComparison != 0) {
         return idComparison;
-      }
-      final nameComparison = a.name.compareTo(b.name);
-      if (nameComparison != 0) {
-        return nameComparison;
       }
       return a.coordinates.compareTo(b.coordinates);
     });


### PR DESCRIPTION
## Summary
- drop the unused name and road fields from weigh station data models, repositories, and sync services
- simplify the weigh station creation and listing UI to only collect and display coordinates
- update localizations and the bundled CSV header to reflect the leaner schema

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fe2e013c60832da8aff9439ab1b21d