### PR TITLE
feat: allow deleting local weigh stations

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -87,6 +87,16 @@ class AppLocalizations {
           'Tap anywhere on the map to place the weigh station.',
       'weighStationMapHintDrag':
           'Long-press and drag the marker to adjust the weigh station.',
+      'deleteWeighStationAction': 'Delete weigh station',
+      'deleteWeighStationConfirmationTitle': 'Delete weigh station',
+      'confirmDeleteWeighStation':
+          'Are you sure you want to delete weigh station {id}?',
+      'weighStationDeleted': 'Weigh station {id} deleted.',
+      'failedToDeleteWeighStation': 'Failed to delete the weigh station.',
+      'onlyLocalWeighStationsCanBeDeleted':
+          'Only weigh stations saved locally can be deleted.',
+      'deletingLocalWeighStationsNotSupportedOnWeb':
+          'Deleting local weigh stations is not supported on the web.',
       'csvMissingStartEndColumns': 'CSV must contain "Start" and "End" columns',
       'deleteAction': 'Delete',
       'deleteSegmentAction': 'Delete segment',
@@ -431,6 +441,16 @@ class AppLocalizations {
           'Докоснете картата, за да поставите кантара.',
       'weighStationMapHintDrag':
           'Задръжте и плъзнете маркера, за да коригирате кантара.',
+      'deleteWeighStationAction': 'Изтрий кантара',
+      'deleteWeighStationConfirmationTitle': 'Изтриване на кантара',
+      'confirmDeleteWeighStation':
+          'Сигурни ли сте, че искате да изтриете кантар {id}?',
+      'weighStationDeleted': 'Кантар {id} беше изтрит.',
+      'failedToDeleteWeighStation': 'Неуспешно изтриване на кантара.',
+      'onlyLocalWeighStationsCanBeDeleted':
+          'Само локално запазени кантари могат да бъдат изтрити.',
+      'deletingLocalWeighStationsNotSupportedOnWeb':
+          'Изтриването на локални кантари не се поддържа в уеб.',
       'emailLabel': 'Имейл адрес',
 'fullNameLabel': 'Пълно име',
 'joinTollCam': 'Присъедини се към TollCam',

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -135,6 +135,20 @@ class AppMessages {
       _l.translate('deleteSegmentConfirmationTitle');
   static String confirmDeleteSegment(String displayId) =>
       _l.translate('confirmDeleteSegment', {'displayId': displayId});
+  static String get deleteWeighStationAction =>
+      _l.translate('deleteWeighStationAction');
+  static String get deleteWeighStationConfirmationTitle =>
+      _l.translate('deleteWeighStationConfirmationTitle');
+  static String confirmDeleteWeighStation(String displayId) =>
+      _l.translate('confirmDeleteWeighStation', {'id': displayId});
+  static String weighStationDeleted(String displayId) =>
+      _l.translate('weighStationDeleted', {'id': displayId});
+  static String get failedToDeleteWeighStation =>
+      _l.translate('failedToDeleteWeighStation');
+  static String get onlyLocalWeighStationsCanBeDeleted =>
+      _l.translate('onlyLocalWeighStationsCanBeDeleted');
+  static String get deletingLocalWeighStationsNotSupportedOnWeb =>
+      _l.translate('deletingLocalWeighStationsNotSupportedOnWeb');
   static String get unableToDetermineLoggedInAccountRetry =>
       _l.translate('unableToDetermineLoggedInAccountRetry');
   static String get chooseSegmentVisibilityQuestion =>

--- a/lib/features/weigh_stations/presentation/widgets/weigh_station_action_dialogs.dart
+++ b/lib/features/weigh_stations/presentation/widgets/weigh_station_action_dialogs.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import 'package:toll_cam_finder/core/app_messages.dart';
+import 'package:toll_cam_finder/features/weigh_stations/domain/weigh_station.dart';
+
+enum WeighStationAction { delete }
+
+Future<WeighStationAction?> showWeighStationActionsSheet(
+  BuildContext context,
+  WeighStationInfo station,
+) {
+  final canDelete = station.isLocalOnly;
+  return showModalBottomSheet<WeighStationAction>(
+    context: context,
+    builder: (context) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.delete_outline),
+              title: Text(AppMessages.deleteWeighStationAction),
+              subtitle: canDelete
+                  ? null
+                  : Text(AppMessages.onlyLocalWeighStationsCanBeDeleted),
+              enabled: canDelete,
+              onTap: canDelete
+                  ? () => Navigator.of(context).pop(WeighStationAction.delete)
+                  : null,
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+Future<bool> showDeleteWeighStationConfirmationDialog(
+  BuildContext context,
+  WeighStationInfo station,
+) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        title: Text(AppMessages.deleteWeighStationConfirmationTitle),
+        content: Text(
+          AppMessages.confirmDeleteWeighStation(station.displayId),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(AppMessages.cancelAction),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(AppMessages.deleteAction),
+          ),
+        ],
+      );
+    },
+  );
+
+  return result ?? false;
+}


### PR DESCRIPTION
## Summary
- add localized strings and messages for weigh station deletion flows
- allow removing locally stored weigh stations through the repository service
- expose long-press actions on the weigh stations list to confirm and delete local entries

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fe30f8033c832d86b2fde00df61633