### PR TITLE
Reload weigh stations after manual sync

### DIFF
--- a/lib/features/map/services/map_segments_service.dart
+++ b/lib/features/map/services/map_segments_service.dart
@@ -206,16 +206,18 @@ class MapSegmentsService {
       );
     }
 
+    SegmentTrackerEvent? seedEvent;
+    bool reloaded = false;
+
     try {
       final syncResult = await _syncService.sync(client: client);
-      final bool reloaded = await _segmentTracker.reload(
+      reloaded = await _segmentTracker.reload(
         assetPath: AppConstants.pathToTollSegments,
       );
       _segmentTracker.updateIgnoredSegments(ignoredSegmentIds);
       await loadCameras(excludedSegmentIds: ignoredSegmentIds);
       await loadWeighStations();
 
-      SegmentTrackerEvent? seedEvent;
       if (reloaded && userLatLng != null) {
         seedEvent = _segmentTracker.handleLocationUpdate(
           current: userLatLng,
@@ -223,6 +225,7 @@ class MapSegmentsService {
       }
 
       await _weighStationsSyncService.sync(client: client);
+      await loadWeighStations();
 
       final message = _syncMessageService.buildSuccessMessage(syncResult);
       return SegmentsSyncResult(
@@ -237,6 +240,13 @@ class MapSegmentsService {
         message: error.message,
         seedEvent: null,
         reloaded: false,
+      );
+    } on WeighStationsSyncException catch (error) {
+      return SegmentsSyncResult(
+        status: SyncResultStatus.failure,
+        message: error.message,
+        seedEvent: null,
+        reloaded: reloaded,
       );
     } catch (error, stackTrace) {
       debugPrint('MapSegmentsService: unexpected sync error: $error\n$stackTrace');


### PR DESCRIPTION
## Summary
- reload weigh stations after syncing remote data so manual sync updates the map with new stations
- surface weigh station sync failures to the user instead of reporting an unexpected error

## Testing
- flutter test *(fails: Flutter tooling is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe38868f88832d8a956e0cf8384094