### PR TITLE
Restrict weigh station votes to a single user vote

### DIFF
--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -826,6 +826,8 @@ class _MapPageState extends State<MapPage>
     final WeighStationVotes initialVotes =
         _segmentsService.weighStationsState.votes[station.id] ??
             const WeighStationVotes();
+    final bool hasVoted =
+        _segmentsService.weighStationsState.userVotes.containsKey(station.id);
 
     showModalBottomSheet<void>(
       context: context,
@@ -844,6 +846,7 @@ class _MapPageState extends State<MapPage>
             }
             return updated;
           },
+          hasVoted: hasVoted,
         );
       },
     );

--- a/lib/features/map/presentation/widgets/weigh_station_feedback_sheet.dart
+++ b/lib/features/map/presentation/widgets/weigh_station_feedback_sheet.dart
@@ -11,11 +11,13 @@ class WeighStationFeedbackSheet extends StatefulWidget {
     required this.stationId,
     required this.initialVotes,
     required this.onVote,
+    required this.hasVoted,
   });
 
   final String stationId;
   final WeighStationVotes initialVotes;
   final WeighStationVoteHandler onVote;
+  final bool hasVoted;
 
   @override
   State<WeighStationFeedbackSheet> createState() =>
@@ -26,15 +28,17 @@ class _WeighStationFeedbackSheetState
     extends State<WeighStationFeedbackSheet> {
   late WeighStationVotes _votes;
   bool _isProcessing = false;
+  late bool _hasVoted;
 
   @override
   void initState() {
     super.initState();
     _votes = widget.initialVotes;
+    _hasVoted = widget.hasVoted;
   }
 
   void _handleVote(bool isUpvote) {
-    if (_isProcessing) {
+    if (_isProcessing || _hasVoted) {
       return;
     }
 
@@ -51,6 +55,7 @@ class _WeighStationFeedbackSheetState
     setState(() {
       _votes = updated;
       _isProcessing = false;
+      _hasVoted = true;
     });
   }
 
@@ -100,8 +105,9 @@ class _WeighStationFeedbackSheetState
               children: [
                 Expanded(
                   child: ElevatedButton.icon(
-                    onPressed:
-                        _isProcessing ? null : () => _handleVote(true),
+                    onPressed: _isProcessing || _hasVoted
+                        ? null
+                        : () => _handleVote(true),
                     icon: const Icon(Icons.thumb_up),
                     label: Text(localizations.weighStationUpvoteAction),
                   ),
@@ -109,8 +115,9 @@ class _WeighStationFeedbackSheetState
                 const SizedBox(width: 12),
                 Expanded(
                   child: ElevatedButton.icon(
-                    onPressed:
-                        _isProcessing ? null : () => _handleVote(false),
+                    onPressed: _isProcessing || _hasVoted
+                        ? null
+                        : () => _handleVote(false),
                     icon: const Icon(Icons.thumb_down),
                     label: Text(localizations.weighStationDownvoteAction),
                   ),


### PR DESCRIPTION
## Summary
- track whether the current user has already voted on each weigh station
- prevent additional vote registrations and disable the vote buttons after the first vote
- surface user vote state through the controller so the sheet can render correctly

## Testing
- Not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fe3990d42c832da442181d4e5fe1ec