### PR TITLE
Allow toggling weigh station votes

### DIFF
--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -826,8 +826,8 @@ class _MapPageState extends State<MapPage>
     final WeighStationVotes initialVotes =
         _segmentsService.weighStationsState.votes[station.id] ??
             const WeighStationVotes();
-    final bool hasVoted =
-        _segmentsService.weighStationsState.userVotes.containsKey(station.id);
+    final bool? userVote =
+        _segmentsService.weighStationsState.userVotes[station.id];
 
     showModalBottomSheet<void>(
       context: context,
@@ -836,7 +836,7 @@ class _MapPageState extends State<MapPage>
           stationId: station.id,
           initialVotes: initialVotes,
           onVote: (isUpvote) {
-            final WeighStationVotes updated =
+            final WeighStationVoteResult updated =
                 _segmentsService.registerWeighStationVote(
               stationId: station.id,
               isUpvote: isUpvote,
@@ -846,7 +846,7 @@ class _MapPageState extends State<MapPage>
             }
             return updated;
           },
-          hasVoted: hasVoted,
+          initialUserVote: userVote,
         );
       },
     );

--- a/lib/features/map/services/map_segments_service.dart
+++ b/lib/features/map/services/map_segments_service.dart
@@ -127,7 +127,7 @@ class MapSegmentsService {
 
   WeighStationsState get weighStationsState => _weighStationController.state;
 
-  WeighStationVotes registerWeighStationVote({
+  WeighStationVoteResult registerWeighStationVote({
     required String stationId,
     required bool isUpvote,
   }) {


### PR DESCRIPTION
## Summary
- allow users to remove or change their weigh station vote by tracking the updated vote state
- update the feedback sheet UI to reflect the user vote selection and enable toggling
- surface the latest vote status through the segments service for the sheet

## Testing
- Not run (flutter is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68fe3ba8d39c832da2fe34324b5bd236