### PR TITLE
Adjust weigh station feedback button colors

### DIFF
--- a/lib/features/map/presentation/widgets/weigh_station_feedback_sheet.dart
+++ b/lib/features/map/presentation/widgets/weigh_station_feedback_sheet.dart
@@ -66,9 +66,13 @@ class _WeighStationFeedbackSheetState
     final ColorScheme colorScheme = theme.colorScheme;
     final bool isUpvoted = _userVote == true;
     final bool isDownvoted = _userVote == false;
-    final ButtonStyle selectedStyle = ElevatedButton.styleFrom(
-      backgroundColor: colorScheme.secondaryContainer,
-      foregroundColor: colorScheme.onSecondaryContainer,
+    final ButtonStyle upvoteSelectedStyle = ElevatedButton.styleFrom(
+      backgroundColor: colorScheme.secondary,
+      foregroundColor: colorScheme.onSecondary,
+    );
+    final ButtonStyle downvoteSelectedStyle = ElevatedButton.styleFrom(
+      backgroundColor: colorScheme.error,
+      foregroundColor: colorScheme.onError,
     );
 
     return SafeArea(
@@ -116,7 +120,7 @@ class _WeighStationFeedbackSheetState
                         _isProcessing ? null : () => _handleVote(true),
                     icon: const Icon(Icons.thumb_up),
                     label: Text(localizations.weighStationUpvoteAction),
-                    style: isUpvoted ? selectedStyle : null,
+                    style: isUpvoted ? upvoteSelectedStyle : null,
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -126,7 +130,7 @@ class _WeighStationFeedbackSheetState
                         _isProcessing ? null : () => _handleVote(false),
                     icon: const Icon(Icons.thumb_down),
                     label: Text(localizations.weighStationDownvoteAction),
-                    style: isDownvoted ? selectedStyle : null,
+                    style: isDownvoted ? downvoteSelectedStyle : null,
                   ),
                 ),
               ],


### PR DESCRIPTION
## Summary
- highlight selected upvotes with the theme's success color
- highlight selected downvotes with the theme's error color to appear red

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fe3ce15aa0832dbabeb2fd57153bb6