### PR TITLE
Rollback local draft when weigh station publish fails

### DIFF
--- a/lib/features/weigh_stations/presentation/pages/create_weigh_station_page.dart
+++ b/lib/features/weigh_stations/presentation/pages/create_weigh_station_page.dart
@@ -135,12 +135,14 @@ class _CreateWeighStationPageState extends State<CreateWeighStationPage> {
         addedByUserId: userId,
       );
     } on RemoteWeighStationsServiceException catch (error) {
+      await _rollbackLocalSave(localId);
       _showSnackBar(error.message);
       setState(() {
         _isSaving = false;
       });
       return;
     } catch (_) {
+      await _rollbackLocalSave(localId);
       _showSnackBar(AppMessages.failedToSubmitWeighStation);
       setState(() {
         _isSaving = false;
@@ -166,5 +168,17 @@ class _CreateWeighStationPageState extends State<CreateWeighStationPage> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(message)),
     );
+  }
+
+  Future<void> _rollbackLocalSave(String? localId) async {
+    if (localId == null) {
+      return;
+    }
+
+    try {
+      await _localService.deleteLocalStation(localId);
+    } catch (_) {
+      // Best-effort rollback. Ignore failures.
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add best-effort rollback of locally saved weigh station drafts when remote publishing fails
- ensure the user does not retain failed drafts after an error message

## Testing
- flutter test *(fails: command not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe3e78ef6c832d9effef2d5836881e