### PR TITLE
Add Supabase weigh station vote sync

### DIFF
--- a/assets/data/weigh_stations.csv
+++ b/assets/data/weigh_stations.csv
@@ -1,1 +1,1 @@
-ID;coordinates
+ID;name;road;coordinates;upvotes;downvotes

--- a/lib/features/map/presentation/pages/map/map_options_drawer.dart
+++ b/lib/features/map/presentation/pages/map/map_options_drawer.dart
@@ -282,9 +282,12 @@ extension _MapPageDrawer on _MapPageState {
   }
 
   Future<void> _refreshSegmentsData() async {
+    final auth = context.read<AuthController>();
     final result = await _segmentsService.refreshSegmentsData(
       showMetadataErrors: true,
       userLatLng: _userLatLng,
+      client: auth.client,
+      currentUserId: auth.currentUserId,
     );
 
     _segmentsMetadata = result.metadata;
@@ -328,6 +331,7 @@ extension _MapPageDrawer on _MapPageState {
         client: auth.client,
         ignoredSegmentIds: _segmentsMetadata.deactivatedSegmentIds,
         userLatLng: _userLatLng,
+        currentUserId: auth.currentUserId,
       );
     } finally {
       if (mounted) {

--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -37,6 +37,7 @@ import 'package:toll_cam_finder/features/segments/domain/tracking/segment_guidan
 import 'package:toll_cam_finder/features/segments/domain/tracking/segment_tracker.dart';
 import 'package:toll_cam_finder/features/segments/services/segments_metadata_service.dart';
 import 'package:toll_cam_finder/features/segments/services/toll_segments_sync_service.dart';
+import 'package:toll_cam_finder/features/weigh_stations/domain/weigh_station_vote.dart';
 import 'package:toll_cam_finder/shared/services/language_controller.dart';
 import 'package:toll_cam_finder/shared/services/theme_controller.dart';
 import 'package:toll_cam_finder/shared/services/location_service.dart';
@@ -782,7 +783,12 @@ class _MapPageState extends State<MapPage>
         bounds = null;
       }
     }
+    final auth = context.read<AuthController>();
     await _segmentsService.loadWeighStations(bounds: bounds);
+    await _segmentsService.refreshWeighStationVotes(
+      client: auth.client,
+      userId: auth.currentUserId,
+    );
     if (!mounted) return;
     _weighStationAlertService.reset();
     _updateVisibleWeighStations();
@@ -836,10 +842,13 @@ class _MapPageState extends State<MapPage>
           stationId: station.id,
           initialVotes: initialVotes,
           onVote: (isUpvote) {
+            final auth = sheetContext.read<AuthController>();
             final WeighStationVoteResult updated =
                 _segmentsService.registerWeighStationVote(
               stationId: station.id,
               isUpvote: isUpvote,
+              client: auth.client,
+              userId: auth.currentUserId,
             );
             if (mounted) {
               setState(() {});

--- a/lib/features/map/presentation/widgets/weigh_station_feedback_sheet.dart
+++ b/lib/features/map/presentation/widgets/weigh_station_feedback_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:toll_cam_finder/app/localization/app_localizations.dart';
 import 'package:toll_cam_finder/features/map/presentation/pages/map/weigh_station_controller.dart';
+import 'package:toll_cam_finder/features/weigh_stations/domain/weigh_station_vote.dart';
 
 typedef WeighStationVoteHandler = WeighStationVoteResult Function(bool isUpvote);
 

--- a/lib/features/weigh_stations/domain/weigh_station.dart
+++ b/lib/features/weigh_stations/domain/weigh_station.dart
@@ -4,11 +4,19 @@ class WeighStationInfo {
   const WeighStationInfo({
     required this.id,
     required this.coordinates,
+    this.name = '',
+    this.road = '',
+    this.upvotes = 0,
+    this.downvotes = 0,
     this.isLocalOnly = false,
   });
 
   final String id;
   final String coordinates;
+  final String name;
+  final String road;
+  final int upvotes;
+  final int downvotes;
   final bool isLocalOnly;
 
   String get displayId {

--- a/lib/features/weigh_stations/domain/weigh_station_vote.dart
+++ b/lib/features/weigh_stations/domain/weigh_station_vote.dart
@@ -1,0 +1,28 @@
+class WeighStationVotes {
+  const WeighStationVotes({
+    this.upvotes = 0,
+    this.downvotes = 0,
+  });
+
+  final int upvotes;
+  final int downvotes;
+
+  static const empty = WeighStationVotes();
+
+  WeighStationVotes copyWith({int? upvotes, int? downvotes}) {
+    return WeighStationVotes(
+      upvotes: upvotes ?? this.upvotes,
+      downvotes: downvotes ?? this.downvotes,
+    );
+  }
+}
+
+class WeighStationVoteResult {
+  const WeighStationVoteResult({
+    required this.votes,
+    required this.userVote,
+  });
+
+  final WeighStationVotes votes;
+  final bool? userVote;
+}

--- a/lib/features/weigh_stations/services/remote_weigh_station_votes_service.dart
+++ b/lib/features/weigh_stations/services/remote_weigh_station_votes_service.dart
@@ -1,0 +1,165 @@
+import 'dart:io';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:toll_cam_finder/features/weigh_stations/domain/weigh_station_vote.dart';
+
+class WeighStationVotesSnapshot {
+  const WeighStationVotesSnapshot({
+    required this.votes,
+    required this.userVotes,
+  });
+
+  final Map<String, WeighStationVotes> votes;
+  final Map<String, bool> userVotes;
+}
+
+class RemoteWeighStationVotesService {
+  RemoteWeighStationVotesService({
+    this.tableName = 'Weigh_Station_Votes',
+  });
+
+  final String tableName;
+
+  static const String _stationIdColumn = 'station_id';
+  static const String _userIdColumn = 'user_id';
+  static const String _isUpvoteColumn = 'is_upvote';
+
+  Future<WeighStationVotesSnapshot> fetchVotes({
+    required SupabaseClient client,
+    String? currentUserId,
+  }) async {
+    try {
+      final List<dynamic> response = await client
+          .from(tableName)
+          .select('$_stationIdColumn,$_userIdColumn,$_is_upvoteColumn');
+
+      final votes = <String, WeighStationVotes>{};
+      final userVotes = <String, bool>{};
+
+      for (final dynamic entry in response) {
+        if (entry is! Map<String, dynamic>) {
+          continue;
+        }
+        final stationId = '${entry[_stationIdColumn] ?? ''}'.trim();
+        if (stationId.isEmpty) {
+          continue;
+        }
+        final bool? isUpvote = _parseVote(entry[_isUpvoteColumn]);
+        if (isUpvote == null) {
+          continue;
+        }
+
+        final existing = votes[stationId] ?? const WeighStationVotes();
+        votes[stationId] = isUpvote
+            ? existing.copyWith(upvotes: existing.upvotes + 1)
+            : existing.copyWith(downvotes: existing.downvotes + 1);
+
+        final userId = entry[_userIdColumn]?.toString();
+        if (currentUserId != null && currentUserId == userId) {
+          userVotes[stationId] = isUpvote;
+        }
+      }
+
+      return WeighStationVotesSnapshot(votes: votes, userVotes: userVotes);
+    } on SocketException catch (error) {
+      throw RemoteWeighStationVotesException(
+        'Network error while loading weigh station votes.',
+        cause: error,
+      );
+    } on PostgrestException catch (error) {
+      throw RemoteWeighStationVotesException(
+        error.message,
+        cause: error,
+      );
+    } catch (error, stackTrace) {
+      throw RemoteWeighStationVotesException(
+        'Unexpected error while loading weigh station votes.',
+        cause: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> applyVote({
+    required SupabaseClient client,
+    required String stationId,
+    required String userId,
+    required bool? vote,
+  }) async {
+    try {
+      if (vote == null) {
+        await client
+            .from(tableName)
+            .delete()
+            .match(<String, String>{
+          _stationIdColumn: stationId,
+          _userIdColumn: userId,
+        });
+        return;
+      }
+
+      await client.from(tableName).upsert(
+        <String, dynamic>{
+          _stationIdColumn: stationId,
+          _userIdColumn: userId,
+          _isUpvoteColumn: vote,
+        },
+        onConflict: '$_stationIdColumn,$_userIdColumn',
+      );
+    } on SocketException catch (error) {
+      throw RemoteWeighStationVotesException(
+        'Network error while submitting weigh station vote.',
+        cause: error,
+      );
+    } on PostgrestException catch (error) {
+      throw RemoteWeighStationVotesException(
+        error.message,
+        cause: error,
+      );
+    } catch (error, stackTrace) {
+      throw RemoteWeighStationVotesException(
+        'Unexpected error while submitting weigh station vote.',
+        cause: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  bool? _parseVote(dynamic value) {
+    if (value is bool) {
+      return value;
+    }
+    if (value is num) {
+      return value != 0;
+    }
+    if (value is String) {
+      final normalized = value.trim().toLowerCase();
+      if (normalized.isEmpty) {
+        return null;
+      }
+      if (normalized == 'true' || normalized == 't' || normalized == '1') {
+        return true;
+      }
+      if (normalized == 'false' || normalized == 'f' || normalized == '0') {
+        return false;
+      }
+    }
+    return null;
+  }
+}
+
+class RemoteWeighStationVotesException implements Exception {
+  const RemoteWeighStationVotesException(
+    this.message, {
+    this.cause,
+    this.stackTrace,
+  });
+
+  final String message;
+  final Object? cause;
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() => 'RemoteWeighStationVotesException: $message';
+}

--- a/lib/features/weigh_stations/services/weigh_stations_csv_constants.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_csv_constants.dart
@@ -1,9 +1,20 @@
 class WeighStationsCsvSchema {
   const WeighStationsCsvSchema._();
 
+  static const String columnId = 'ID';
+  static const String columnName = 'name';
+  static const String columnRoad = 'road';
+  static const String columnCoordinates = 'coordinates';
+  static const String columnUpvotes = 'upvotes';
+  static const String columnDownvotes = 'downvotes';
+
   static const List<String> header = <String>[
-    'ID',
-    'coordinates',
+    columnId,
+    columnName,
+    columnRoad,
+    columnCoordinates,
+    columnUpvotes,
+    columnDownvotes,
   ];
 
   static const String localWeighStationIdPrefix = 'LOCAL_WS:';

--- a/lib/features/weigh_stations/services/weigh_stations_repository.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_repository.dart
@@ -34,6 +34,10 @@ class WeighStationsRepository {
         .toList();
     final idIndex = header.indexOf('id');
     final coordIndex = header.indexOf('coordinates');
+    final nameIndex = header.indexOf('name');
+    final roadIndex = header.indexOf('road');
+    final upvotesIndex = header.indexOf('upvotes');
+    final downvotesIndex = header.indexOf('downvotes');
     final stations = <WeighStationInfo>[];
 
     for (final row in rows.skip(1)) {
@@ -42,6 +46,10 @@ class WeighStationsRepository {
       }
       final id = _stringAt(row, idIndex);
       final coordinates = _stringAt(row, coordIndex);
+      final name = _stringAt(row, nameIndex);
+      final road = _stringAt(row, roadIndex);
+      final upvotes = _intAt(row, upvotesIndex);
+      final downvotes = _intAt(row, downvotesIndex);
       if (id.isEmpty && coordinates.isEmpty) {
         continue;
       }
@@ -54,6 +62,10 @@ class WeighStationsRepository {
         WeighStationInfo(
           id: id,
           coordinates: coordinates,
+          name: name,
+          road: road,
+          upvotes: upvotes,
+          downvotes: downvotes,
           isLocalOnly: isLocalOnly,
         ),
       );
@@ -87,5 +99,13 @@ class WeighStationsRepository {
       return '';
     }
     return '${row[index]}'.trim();
+  }
+
+  int _intAt(List<dynamic> row, int index) {
+    final raw = _stringAt(row, index);
+    if (raw.isEmpty) {
+      return 0;
+    }
+    return int.tryParse(raw) ?? 0;
   }
 }

--- a/lib/features/weigh_stations/services/weigh_stations_sync_service.dart
+++ b/lib/features/weigh_stations/services/weigh_stations_sync_service.dart
@@ -310,11 +310,28 @@ class WeighStationsSyncService {
     final name = normalized['name'] ?? '';
     final road = normalized['road'] ?? '';
     final coordinates = normalized['coordinates'] ?? '';
+    final upvotes = _normalizeVoteCount(normalized['upvotes']);
+    final downvotes = _normalizeVoteCount(normalized['downvotes']);
 
-    return <String>[id, name, road, coordinates];
+    return <String>[id, name, road, coordinates, upvotes, downvotes];
   }
 
   String _normalize(String value) => value.trim().toLowerCase();
+
+  String _normalizeVoteCount(String? value) {
+    if (value == null) {
+      return '0';
+    }
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return '0';
+    }
+    final parsed = int.tryParse(trimmed);
+    if (parsed == null) {
+      return '0';
+    }
+    return parsed.toString();
+  }
 
   String _toSnakeCase(String value) {
     final buffer = StringBuffer();


### PR DESCRIPTION
## Summary
- integrate Supabase-backed fetching of weigh station vote totals and user selections during loads and syncs
- upload weigh station vote actions to Supabase when users cast or clear votes from the map
- extend local weigh station schema and persistence to store upvote/downvote columns

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fe3fecf0ec832d89a3936ac4464805