### PR TITLE
Update weigh station vote syncing for aggregated Supabase columns

### DIFF
--- a/lib/features/map/services/map_segments_service.dart
+++ b/lib/features/map/services/map_segments_service.dart
@@ -149,8 +149,7 @@ class MapSegmentsService {
       unawaited(_submitWeighStationVote(
         client: client,
         stationId: stationId,
-        userId: userId,
-        userVote: result.userVote,
+        votes: result.votes,
       ));
     }
     return result;
@@ -332,15 +331,13 @@ class MapSegmentsService {
   Future<void> _submitWeighStationVote({
     required SupabaseClient client,
     required String stationId,
-    required String userId,
-    required bool? userVote,
+    required WeighStationVotes votes,
   }) async {
     try {
       await _weighStationVotesService.applyVote(
         client: client,
         stationId: stationId,
-        userId: userId,
-        vote: userVote,
+        votes: votes,
       );
     } on RemoteWeighStationVotesException catch (error) {
       debugPrint(


### PR DESCRIPTION
## Summary
- read weigh station vote counts from the `Weigh_Stations` table and update rows directly using the aggregated columns
- skip remote updates for local-only stations and send the latest totals from the controller when voting

## Testing
- not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fe445279b4832db7ed1a40834bd9aa