### PR TITLE
Add voice alert when approaching weigh stations

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -91,6 +91,7 @@ class AppLocalizations {
       'weighStationDownvoteAction': 'Downvote',
       'weighStationUpvoteCount': 'Upvotes: {count}',
       'weighStationDownvoteCount': 'Downvotes: {count}',
+      'weighStationApproachAlert': 'Approaching weigh station.',
       'deleteWeighStationAction': 'Delete weigh station',
       'deleteWeighStationConfirmationTitle': 'Delete weigh station',
       'confirmDeleteWeighStation':
@@ -465,6 +466,7 @@ class AppLocalizations {
       'weighStationDownvoteAction': 'Отрицателен вот',
       'weighStationUpvoteCount': 'Положителни гласове: {count}',
       'weighStationDownvoteCount': 'Отрицателни гласове: {count}',
+      'weighStationApproachAlert': 'Приближавате кантар.',
       'deleteWeighStationAction': 'Изтрий кантара',
       'deleteWeighStationConfirmationTitle': 'Изтриване на кантара',
       'confirmDeleteWeighStation':
@@ -724,6 +726,8 @@ class AppLocalizations {
         'weighStationDownvoteCount',
         {'count': '$count'},
       );
+  String get weighStationApproachAlert =>
+      _value('weighStationApproachAlert');
   String get saveSegment => _value('saveSegment');
   String get noSegmentsAvailable => _value('noSegmentsAvailable');
   String get noLocalSegments => _value('noLocalSegments');

--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -440,6 +440,7 @@ class _MapPageState extends State<MapPage>
     _weighStationAlertService.updateDistance(
       stationId: nearestWeigh?.marker.id,
       distanceMeters: nearestWeigh?.distanceMeters,
+      approachMessage: AppLocalizations.of(context).weighStationApproachAlert,
     );
     if (_segmentsService.shouldProcessSegmentUpdate(
       now: now,

--- a/lib/features/weigh_stations/services/weigh_station_alert_service.dart
+++ b/lib/features/weigh_stations/services/weigh_station_alert_service.dart
@@ -1,20 +1,26 @@
 import 'dart:async';
 
 import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter_tts/flutter_tts.dart';
 
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/guidance_audio_controller.dart';
 import 'package:toll_cam_finder/shared/audio/navigation_audio_context.dart';
 
 class WeighStationAlertService {
-  WeighStationAlertService({AudioPlayer? player})
-      : _player = player ?? AudioPlayer() {
+  WeighStationAlertService({AudioPlayer? player, FlutterTts? tts})
+      : _player = player ?? AudioPlayer(),
+        _tts = tts ?? FlutterTts() {
     unawaited(_configurePlayer());
+    unawaited(_tts.awaitSpeakCompletion(true));
+    unawaited(_configureTextToSpeech());
   }
 
   final AudioPlayer _player;
+  final FlutterTts _tts;
   String? _currentStationId;
   bool _hasPlayed = false;
+  bool _hasSpoken = false;
   GuidanceAudioPolicy _audioPolicy = const GuidanceAudioPolicy(
     allowSpeech: true,
     allowAlertTones: true,
@@ -28,13 +34,21 @@ class WeighStationAlertService {
       return;
     }
     final bool hadAlert = _audioPolicy.allowAlertTones;
+    final bool hadSpeech = _audioPolicy.allowSpeech;
     _audioPolicy = policy;
     if (hadAlert && !policy.allowAlertTones) {
       unawaited(_player.stop());
     }
+    if (hadSpeech && !policy.allowSpeech) {
+      unawaited(_tts.stop());
+    }
   }
 
-  void updateDistance({required String? stationId, required double? distanceMeters}) {
+  void updateDistance({
+    required String? stationId,
+    required double? distanceMeters,
+    required String approachMessage,
+  }) {
     if (stationId == null || distanceMeters == null) {
       _resetState();
       return;
@@ -43,18 +57,27 @@ class WeighStationAlertService {
     if (_currentStationId != stationId) {
       _currentStationId = stationId;
       _hasPlayed = false;
+      _hasSpoken = false;
     }
 
     if (distanceMeters >= alertDistanceMeters) {
       _hasPlayed = false;
+      _hasSpoken = false;
       return;
     }
 
-    if (!_hasPlayed && distanceMeters >= 1 && _audioPolicy.allowAlertTones) {
+    final bool isCloseEnough = distanceMeters >= 1;
+
+    if (!_hasPlayed && isCloseEnough && _audioPolicy.allowAlertTones) {
       _hasPlayed = true;
       unawaited(
         _player.play(AssetSource(AppConstants.upcomingSegmentSoundAsset)),
       );
+    }
+
+    if (!_hasSpoken && isCloseEnough && _audioPolicy.allowSpeech) {
+      _hasSpoken = true;
+      unawaited(_speak(approachMessage));
     }
   }
 
@@ -62,16 +85,53 @@ class WeighStationAlertService {
     _resetState();
   }
 
-  Future<void> dispose() => _player.dispose();
+  Future<void> dispose() async {
+    await _tts.stop();
+    await _player.dispose();
+  }
 
   void _resetState() {
     _currentStationId = null;
     _hasPlayed = false;
+    _hasSpoken = false;
   }
 
   Future<void> _configurePlayer() async {
     try {
       await _player.setAudioContext(navigationAudioContext);
+    } catch (_) {
+      // best effort
+    }
+  }
+
+  Future<void> _configureTextToSpeech() async {
+    try {
+      await Future<void>.value();
+    } catch (_) {
+      // best effort
+    }
+
+    try {
+      await _tts.setIosAudioCategory(
+        IosTextToSpeechAudioCategory.playback,
+        <IosTextToSpeechAudioCategoryOptions>[
+          IosTextToSpeechAudioCategoryOptions.mixWithOthers,
+          IosTextToSpeechAudioCategoryOptions.duckOthers,
+          IosTextToSpeechAudioCategoryOptions.interruptSpokenAudioAndMixWithOthers,
+        ],
+        IosTextToSpeechAudioMode.voicePrompt,
+      );
+    } catch (_) {
+      // best effort
+    }
+  }
+
+  Future<void> _speak(String message) async {
+    if (message.trim().isEmpty) {
+      return;
+    }
+    try {
+      await _tts.speak(message);
     } catch (_) {
       // best effort
     }


### PR DESCRIPTION
## Summary
- add a text-to-speech announcement to the weigh station alert service while still honoring audio policy limits
- expose a localized "approaching weigh station" message and pass it to the alert service when the driver nears a station

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fe46901e94832da25f96506f19e5b6