### PR TITLE
Remove local-only badge from weigh station list

### DIFF
--- a/lib/features/weigh_stations/presentation/pages/weigh_stations_page.dart
+++ b/lib/features/weigh_stations/presentation/pages/weigh_stations_page.dart
@@ -87,17 +87,6 @@ class _WeighStationsPageState extends State<WeighStationsPage> {
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         Text(localizations.weighStationCoordinatesLabel(station.coordinates)),
-                        if (station.isLocalOnly)
-                          Padding(
-                            padding: const EdgeInsets.only(top: 4),
-                            child: Text(
-                              localizations.weighStationLocalBadge,
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .labelSmall
-                                  ?.copyWith(color: Theme.of(context).colorScheme.tertiary),
-                            ),
-                          ),
                       ],
                     ),
                     onLongPress: () => _onWeighStationLongPress(station),


### PR DESCRIPTION
## Summary
- remove the local-only indicator from the weigh stations list to avoid showing an unreachable state to users

## Testing
- flutter test *(fails: Flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe4c958a28832db1f5a5f761eec0c6