### PR TITLE
Add Bulgarian voice prompts for navigation events

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -139,6 +139,24 @@ class AppConstants {
   /// monitored area.
   static const String upcomingSegmentSoundAsset = 'data/ding_sound.mp3';
 
+  /// Voice prompt that announces an upcoming segment (Bulgarian locale).
+  static const String approachingSegmentVoiceAsset =
+      'data/approaching_segment.mp3';
+
+  /// Voice prompt that confirms a segment entry (Bulgarian locale).
+  static const String segmentEnteredVoiceAsset = 'data/entered_segmen.mp3';
+
+  /// Voice prompt that announces an upcoming segment end (Bulgarian locale).
+  static const String segmentEndingSoonVoiceAsset =
+      'data/segment_ends_in800.mp3';
+
+  /// Voice prompt that confirms a segment exit (Bulgarian locale).
+  static const String segmentEndedVoiceAsset = 'data/segment_ended.mp3';
+
+  /// Voice prompt that announces an upcoming weigh control (Bulgarian locale).
+  static const String approachingWeighControlVoiceAsset =
+      'data/approaching_weigh_control.mp3';
+
   
   /// The animation controller starts with, and falls back to, a 500 ms duration for
   /// each interpolation run. Increasing that duration makes movements appear slower

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,11 @@ flutter:
     - assets/data/toll_segments.csv
     - assets/data/weigh_stations.csv
     - assets/data/ding_sound.mp3
+    - assets/data/approaching_segment.mp3
+    - assets/data/entered_segmen.mp3
+    - assets/data/segment_ends_in800.mp3
+    - assets/data/segment_ended.mp3
+    - assets/data/approaching_weigh_control.mp3
 
 flutter_launcher_icons:
   android: true


### PR DESCRIPTION
## Summary
- add constants and asset registrations for Bulgarian voice prompt assets
- play recorded Bulgarian audio cues for segment approach, entry, exit, and weigh control events
- propagate language changes to audio services so cues switch between text-to-speech and recordings

## Testing
- Not run (Flutter SDK unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68fe62b773a0832d977bb6a5a8da381a