### PR TITLE
Fix TTS language selection for Bulgarian voice prompts

### DIFF
--- a/lib/features/segments/domain/tracking/segment_guidance_controller.dart
+++ b/lib/features/segments/domain/tracking/segment_guidance_controller.dart
@@ -93,11 +93,13 @@ class SegmentGuidanceController {
   }
 
   void updateLanguage(String languageCode) {
-    final bool useBulgarian = languageCode.toLowerCase() == 'bg';
+    final String normalized = languageCode.toLowerCase();
+    final bool useBulgarian = normalized == 'bg' || normalized.startsWith('bg-');
     if (_useBulgarianVoice == useBulgarian) {
       return;
     }
     _useBulgarianVoice = useBulgarian;
+    unawaited(_updateTtsLanguage());
   }
 
   Future<SegmentGuidanceResult?> handleUpdate({
@@ -255,6 +257,8 @@ class SegmentGuidanceController {
     } catch (_) {
       // Ignored: best-effort configuration.
     }
+
+    await _updateTtsLanguage();
   }
 
   Future<void> _handleSegmentEntry({double? limitKph}) async {
@@ -581,5 +585,14 @@ class SegmentGuidanceController {
       return;
     }
     await _tts.speak(message);
+  }
+
+  Future<void> _updateTtsLanguage() async {
+    final String locale = _useBulgarianVoice ? 'bg-BG' : 'en-US';
+    try {
+      await _tts.setLanguage(locale);
+    } catch (_) {
+      // best effort
+    }
   }
 }

--- a/lib/features/weigh_stations/services/weigh_station_alert_service.dart
+++ b/lib/features/weigh_stations/services/weigh_station_alert_service.dart
@@ -49,11 +49,13 @@ class WeighStationAlertService {
   }
 
   void updateLanguage(String languageCode) {
-    final bool useBulgarian = languageCode.toLowerCase() == 'bg';
+    final String normalized = languageCode.toLowerCase();
+    final bool useBulgarian = normalized == 'bg' || normalized.startsWith('bg-');
     if (_useBulgarianVoice == useBulgarian) {
       return;
     }
     _useBulgarianVoice = useBulgarian;
+    unawaited(_updateTtsLanguage());
   }
 
   void updateDistance({
@@ -146,6 +148,8 @@ class WeighStationAlertService {
     } catch (_) {
       // best effort
     }
+
+    await _updateTtsLanguage();
   }
 
   Future<void> _playVoiceAsset(String asset) async {
@@ -163,6 +167,15 @@ class WeighStationAlertService {
     }
     try {
       await _tts.speak(message);
+    } catch (_) {
+      // best effort
+    }
+  }
+
+  Future<void> _updateTtsLanguage() async {
+    final String locale = _useBulgarianVoice ? 'bg-BG' : 'en-US';
+    try {
+      await _tts.setLanguage(locale);
     } catch (_) {
       // best effort
     }


### PR DESCRIPTION
## Summary
- normalize language codes so Bulgarian is detected when region suffixes are present
- update the text-to-speech engine to switch between Bulgarian and English voices based on the selected language

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fe69ed4ad8832d82e5843b8bdff66d