### PR TITLE
Preserve geojson when saving local segments

### DIFF
--- a/lib/features/segments/services/local_segments_service.dart
+++ b/lib/features/segments/services/local_segments_service.dart
@@ -139,7 +139,7 @@ class LocalSegmentsService {
       draft.speedLimitKph != null
           ? draft.speedLimitKph!.toString()
           : '',
-      '',
+      draft.routeGeoJson?.trim() ?? '',
     ];
 
     rows.add(newRow);
@@ -204,6 +204,7 @@ class LocalSegmentsService {
       final speedLimit = row.length > 7 ? row[7].trim() : '';
       final speedLimitKph =
           speedLimit.isEmpty ? null : double.tryParse(speedLimit);
+      final routeGeoJson = row.length > 8 ? row[8].trim() : '';
 
       if (startCoordinates.isEmpty || endCoordinates.isEmpty) {
         throw LocalSegmentsServiceException(
@@ -229,6 +230,7 @@ class LocalSegmentsService {
         endCoordinates: endCoordinates,
         isPublic: true,
         speedLimitKph: speedLimitKph,
+        routeGeoJson: routeGeoJson.isNotEmpty ? routeGeoJson : null,
       );
     }
 


### PR DESCRIPTION
## Summary
- persist the route GeoJSON when saving local-only segment drafts
- restore saved GeoJSON when reading a locally stored segment draft

## Testing
- flutter analyze *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ffa1c67400832d80f6f7cfb8a3926a