### PR TITLE
Add confirmation dialog for absolute audio mute selection

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -166,6 +166,10 @@ class AppLocalizations {
       'audioModeBackgroundMuted':
           'Mute in background (in-app guidance, start/end dings only)',
       'audioModeAbsoluteMute': 'Absolute mute (no sounds)',
+      'audioModeAbsoluteMuteConfirmationTitle':
+          'Mute all voice guidance?',
+      'audioModeAbsoluteMuteConfirmationBody':
+          'If you mute all voice guidance, you will not receive alerts while driving when the app is in the foreground or background. Do you want to continue?',
       'localSegments': 'Local segments',
       'logIn': 'Log in',
       'logOut': 'Log out',
@@ -627,6 +631,10 @@ class AppLocalizations {
       'audioModeBackgroundMuted':
           'Заглушено на заден план (активно в приложението, само сигнал при старт/край)',
       'audioModeAbsoluteMute': 'Пълно заглушаване (без звук)',
+      'audioModeAbsoluteMuteConfirmationTitle':
+          'Изключване на всички гласови предупреждения?',
+      'audioModeAbsoluteMuteConfirmationBody':
+          'Ако изключиш всички гласови предупреждения, няма да получаваш известия нито когато приложението е на преден план, нито във фонов режим. Искаш ли да продължиш?',
 'savingLocalSegmentsNotSupportedOnWeb':
 'Запазването на локални сегменти не се поддържа в уеб версията.',
 'loadingLocalSegmentsNotSupportedOnWeb':
@@ -753,6 +761,10 @@ class AppLocalizations {
   String get audioModeBackgroundMuted =>
       _value('audioModeBackgroundMuted');
   String get audioModeAbsoluteMute => _value('audioModeAbsoluteMute');
+  String get audioModeAbsoluteMuteConfirmationTitle =>
+      _value('audioModeAbsoluteMuteConfirmationTitle');
+  String get audioModeAbsoluteMuteConfirmationBody =>
+      _value('audioModeAbsoluteMuteConfirmationBody');
   String get welcomeTitle => _value('welcomeTitle');
   String get joinTollCam => _value('joinTollCam');
   String get emailLabel => _value('emailLabel');

--- a/lib/features/map/presentation/pages/map/map_options_drawer.dart
+++ b/lib/features/map/presentation/pages/map/map_options_drawer.dart
@@ -120,11 +120,21 @@ extension _MapPageDrawer on _MapPageState {
                         title: Text(_audioModeLabel(mode, localizations)),
                         value: mode,
                         groupValue: controller.mode,
-                        onChanged: (value) {
+                        onChanged: (value) async {
                           if (value == null) {
                             return;
                           }
+                          if (value == GuidanceAudioMode.absoluteMute) {
+                            final confirmed =
+                                await _confirmAbsoluteMute(sheetContext);
+                            if (!confirmed) {
+                              return;
+                            }
+                          }
                           controller.setMode(value);
+                          if (!sheetContext.mounted) {
+                            return;
+                          }
                           Navigator.of(sheetContext).pop();
                         },
                       ),
@@ -136,6 +146,31 @@ extension _MapPageDrawer on _MapPageState {
         },
       );
     });
+  }
+
+  Future<bool> _confirmAbsoluteMute(BuildContext context) async {
+    final localizations = AppLocalizations.of(context);
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(localizations.audioModeAbsoluteMuteConfirmationTitle),
+          content: Text(localizations.audioModeAbsoluteMuteConfirmationBody),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(localizations.noAction),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(localizations.yesAction),
+            ),
+          ],
+        );
+      },
+    );
+
+    return result ?? false;
   }
 
   void _onLanguageSelected() {

--- a/lib/features/map/presentation/pages/simple_mode_page.dart
+++ b/lib/features/map/presentation/pages/simple_mode_page.dart
@@ -231,11 +231,21 @@ class _SimpleModeOptionsDrawer extends StatelessWidget {
                         ),
                         value: mode,
                         groupValue: controller.mode,
-                        onChanged: (value) {
+                        onChanged: (value) async {
                           if (value == null) {
                             return;
                           }
+                          if (value == GuidanceAudioMode.absoluteMute) {
+                            final confirmed =
+                                await _confirmAbsoluteMute(sheetContext);
+                            if (!confirmed) {
+                              return;
+                            }
+                          }
                           controller.setMode(value);
+                          if (!sheetContext.mounted) {
+                            return;
+                          }
                           Navigator.of(sheetContext).pop();
                         },
                       ),
@@ -336,5 +346,30 @@ class _SimpleModeOptionsDrawer extends StatelessWidget {
         },
       );
     });
+  }
+
+  Future<bool> _confirmAbsoluteMute(BuildContext context) async {
+    final localizations = AppLocalizations.of(context);
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(localizations.audioModeAbsoluteMuteConfirmationTitle),
+          content: Text(localizations.audioModeAbsoluteMuteConfirmationBody),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(localizations.noAction),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(localizations.yesAction),
+            ),
+          ],
+        );
+      },
+    );
+
+    return result ?? false;
   }
 }


### PR DESCRIPTION
## Summary
- prompt users with a confirmation dialog before enabling the absolute mute guidance mode from the map and simple mode drawers
- add localized strings for the new confirmation message in English and Bulgarian

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ffbdd19800832db918651cf7edf557