### PR TITLE
Constrain map zoom to Europe bounds

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
 class AppConstants {
@@ -69,6 +70,13 @@ class AppConstants {
   /// Geographic center used before a GPS fix is available; shifting it moves the
   /// initial map focus to another country or region.
   static const LatLng initialCenter = LatLng(42.7339, 25.4858);
+
+  /// Geographic bounds used to constrain the map camera so the user cannot zoom
+  /// out beyond a Europe-sized view.
+  static final LatLngBounds europeBounds = LatLngBounds(
+    LatLng(34.0, -11.0),
+    LatLng(72.0, 45.0),
+  );
 
   /// Map zoom level applied at startup; increasing it starts the user closer to
   /// street level, while decreasing shows a broader overview.

--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -1095,6 +1095,9 @@ class _MapPageState extends State<MapPage>
           options: MapOptions(
             initialCenter: _center,
             initialZoom: _currentZoom,
+            cameraConstraint: CameraConstraint.contain(
+              bounds: AppConstants.europeBounds,
+            ),
             onMapReady: _onMapReady,
           ),
           children: [

--- a/lib/features/segments/presentation/widgets/segment_picker/segment_picker_map.dart
+++ b/lib/features/segments/presentation/widgets/segment_picker/segment_picker_map.dart
@@ -104,6 +104,9 @@ class _SegmentPickerMapState extends State<SegmentPickerMap> {
             initialZoom: AppConstants.initialZoom,
             minZoom: AppConstants.segmentPickerMinZoom,
             maxZoom: AppConstants.segmentPickerMaxZoom,
+            cameraConstraint: CameraConstraint.contain(
+              bounds: AppConstants.europeBounds,
+            ),
             onTap: _handleMapTap,
             onMapReady: _handleMapReady,
           ),

--- a/lib/features/weigh_stations/presentation/widgets/weigh_station_picker_map.dart
+++ b/lib/features/weigh_stations/presentation/widgets/weigh_station_picker_map.dart
@@ -55,6 +55,9 @@ class _WeighStationPickerMapState extends State<WeighStationPickerMap> {
             initialZoom: AppConstants.initialZoom,
             minZoom: AppConstants.segmentPickerMinZoom,
             maxZoom: AppConstants.segmentPickerMaxZoom,
+            cameraConstraint: CameraConstraint.contain(
+              bounds: AppConstants.europeBounds,
+            ),
             onTap: _handleMapTap,
             onMapReady: _handleMapReady,
           ),


### PR DESCRIPTION
## Summary
- add a reusable Europe bounding box constant for map constraints
- apply the camera constraint to the live map and picker maps to prevent zooming out past Europe

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ffbebf6e04832dbc3b8f7b3cbd2df1