### PR TITLE
Add profile deletion flow

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -205,6 +205,10 @@ class AppLocalizations {
       'passwordsDoNotMatch': 'Passwords do not match',
       'profile': 'Profile',
       'profileSubtitle': 'Manage your TollCam account and preferences.',
+      'deleteProfileAction': 'Delete profile',
+      'deleteProfileTitle': 'Delete profile',
+      'deleteProfileConfirmation':
+          'Are you sure you want to delete your profile? This action cannot be undone.',
       'publicSharingUnavailable':
           'Public segment sharing is currently unavailable.',
       'publicSharingUnavailableShort': 'Public sharing is not available.',
@@ -350,6 +354,7 @@ class AppLocalizations {
       'unableToDetermineLoggedInAccountRetry':
           'Unable to determine the logged in account. Please sign in again.',
       'unableToLogOutTryAgain': 'Unable to log out. Please try again.',
+      'unableToDeleteAccount': 'Unable to delete your profile. Please try again.',
       'unableToWithdrawSubmission': 'Unable to withdraw the public submission.',
       'unexpectedErrorCancellingSubmission':
           'Unexpected error while cancelling the public submission.',
@@ -504,6 +509,10 @@ class AppLocalizations {
 'passwordLabel': 'Парола',
 'profile': 'Профил',
 'profileSubtitle': 'Управлявай акаунта и настройките си в TollCam.',
+'deleteProfileAction': 'Изтрий профила',
+'deleteProfileTitle': 'Изтриване на профил',
+'deleteProfileConfirmation':
+'Сигурни ли сте, че искате да изтриете профила си? Това действие не може да бъде отменено.',
 'faceTravelDirection': 'По посока на движение',
 'northUp': 'Север нагоре',
 'recenter': 'Центрирай Екрана',
@@ -635,6 +644,12 @@ class AppLocalizations {
 'Изтриването на локални сегменти не се поддържа в уеб версията.',
 'fileSystemOperationsNotSupported':
 'Операциите с файловата система не се поддържат на тази платформа.',
+'unableToDetermineLoggedInAccount':
+'Неуспешно определяне на влезлия акаунт.',
+'unableToDetermineLoggedInAccountRetry':
+'Неуспешно определяне на влезлия акаунт. Моля, влез отново.',
+'unableToLogOutTryAgain': 'Неуспешен изход. Опитайте отново.',
+'unableToDeleteAccount': 'Профилът не може да бъде изтрит. Опитайте отново.',
 'unitKilometersShort': 'км',
 'unitMetersShort': 'м',
 'unknownUserLabel': 'Непознат потребител',
@@ -760,6 +775,10 @@ class AppLocalizations {
   String get confirmPasswordLabel => _value('confirmPasswordLabel');
   String get fullNameLabel => _value('fullNameLabel');
   String get profileSubtitle => _value('profileSubtitle');
+  String get deleteProfileAction => _value('deleteProfileAction');
+  String get deleteProfileTitle => _value('deleteProfileTitle');
+  String get deleteProfileConfirmation =>
+      _value('deleteProfileConfirmation');
   String get unknownUserLabel => _value('unknownUserLabel');
   String get averageSpeedStartTooltip => _value('averageSpeedStartTooltip');
   String get averageSpeedResetTooltip => _value('averageSpeedResetTooltip');

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -167,6 +167,8 @@ class AppMessages {
       _l.translate('accountCreatedCheckEmail');
   static String get unableToLogOutTryAgain =>
       _l.translate('unableToLogOutTryAgain');
+  static String get unableToDeleteAccount =>
+      _l.translate('unableToDeleteAccount');
   static String get authenticationNotConfigured =>
       _l.translate('authenticationNotConfigured');
   static String get backgroundTrackingNotificationRationale =>

--- a/lib/features/auth/application/auth_controller.dart
+++ b/lib/features/auth/application/auth_controller.dart
@@ -121,6 +121,32 @@ class AuthController extends ChangeNotifier {
     }
   }
 
+  Future<void> deleteAccount() async {
+    final userId = _currentUserId;
+
+    if (userId == null) {
+      throw AuthFailure(AppMessages.unableToDetermineLoggedInAccount);
+    }
+
+    if (_client == null) {
+      _applySession(null);
+      return;
+    }
+
+    try {
+      await _client!.auth.admin.deleteUser(userId);
+      await _client!.auth.signOut();
+      _applySession(null);
+    } on AuthException catch (error) {
+      throw AuthFailure(error.message);
+    } on AuthApiException catch (error) {
+      throw AuthFailure(error.message);
+    } catch (error, stackTrace) {
+      debugPrint('Delete account failed: $error\n$stackTrace');
+      throw AuthFailure(AppMessages.unableToDeleteAccount);
+    }
+  }
+
   void _applySession(Session? session) {
     final user = session?.user;
     _currentEmail = user?.email;

--- a/lib/features/auth/presentation/pages/profile_page.dart
+++ b/lib/features/auth/presentation/pages/profile_page.dart
@@ -44,6 +44,59 @@ class ProfilePage extends StatelessWidget {
                 textAlign: TextAlign.center,
               ),
               const Spacer(),
+              OutlinedButton(
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: Theme.of(context).colorScheme.error,
+                ),
+                onPressed: () async {
+                  final confirmed = await showDialog<bool>(
+                        context: context,
+                        builder: (dialogContext) => AlertDialog(
+                          title: Text(localizations.deleteProfileTitle),
+                          content:
+                              Text(localizations.deleteProfileConfirmation),
+                          actions: [
+                            TextButton(
+                              onPressed: () =>
+                                  Navigator.of(dialogContext).pop(false),
+                              child: Text(localizations.cancelAction),
+                            ),
+                            TextButton(
+                              onPressed: () =>
+                                  Navigator.of(dialogContext).pop(true),
+                              child: Text(localizations.deleteAction),
+                            ),
+                          ],
+                        ),
+                      ) ??
+                      false;
+
+                  if (!confirmed) {
+                    return;
+                  }
+
+                  final messenger = ScaffoldMessenger.of(context);
+                  try {
+                    await context.read<AuthController>().deleteAccount();
+                    Navigator.of(context).popUntil(
+                      ModalRoute.withName(AppRoutes.map),
+                    );
+                  } on AuthFailure catch (error) {
+                    messenger.showSnackBar(
+                      SnackBar(content: Text(error.message)),
+                    );
+                  } catch (error, stackTrace) {
+                    debugPrint('Delete profile error: $error\n$stackTrace');
+                    messenger.showSnackBar(
+                      SnackBar(
+                        content: Text(AppMessages.unableToDeleteAccount),
+                      ),
+                    );
+                  }
+                },
+                child: Text(localizations.deleteProfileAction),
+              ),
+              const SizedBox(height: 12),
               ElevatedButton(
                 onPressed: () async {
                   final messenger = ScaffoldMessenger.of(context);


### PR DESCRIPTION
## Summary
- add a profile deletion button with a confirmation dialog on the profile page
- implement account deletion logic in the auth controller and expand localization strings for both languages

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ffbe69bf4c832d9f8b6218688dc4ec