### PR TITLE
Replace Bulgarian average alerts with recorded prompts

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -170,6 +170,16 @@ class AppConstants {
   static const String segmentEndingWithNextVoiceAsset =
       'data/segment_ends_in800_than_a_another_one.mp3';
 
+  /// Voice prompt played when the monitored average speed rises above the
+  /// allowed limit (Bulgarian locale).
+  static const String averageAboveAllowedVoiceAsset =
+      'data/avg_above_allowed.mp3';
+
+  /// Voice prompt played when the monitored average speed returns within the
+  /// allowed limit (Bulgarian locale).
+  static const String averageBackWithinAllowedVoiceAsset =
+      'data/avg_below_allowed.mp3';
+
 
   /// The animation controller starts with, and falls back to, a 500 ms duration for
   /// each interpolation run. Increasing that duration makes movements appear slower

--- a/lib/features/segments/domain/tracking/segment_guidance_controller.dart
+++ b/lib/features/segments/domain/tracking/segment_guidance_controller.dart
@@ -379,7 +379,13 @@ class SegmentGuidanceController {
           now.difference(_aboveLimitSince!) >= _aboveLimitGrace) {
         _aboveLimitAlerted = true;
         await _playChime(times: 2, spacing: const Duration(milliseconds: 180));
-        await _speak('Average above limit. Reduce speed.');
+        if (_useBulgarianVoice) {
+          await _playVoicePrompt(
+            AppConstants.averageAboveAllowedVoiceAsset,
+          );
+        } else {
+          await _speak('Average above limit. Reduce speed.');
+        }
         return true;
       }
       return false;
@@ -393,7 +399,13 @@ class SegmentGuidanceController {
       _wasOverLimit = false;
       _aboveLimitAlerted = false;
       await _playChime();
-      await _speak('Average back within limit.');
+      if (_useBulgarianVoice) {
+        await _playVoicePrompt(
+          AppConstants.averageBackWithinAllowedVoiceAsset,
+        );
+      } else {
+        await _speak('Average back within limit.');
+      }
       return true;
     }
 


### PR DESCRIPTION
## Summary
- add constants for the Bulgarian average-speed alert voice assets
- play the recorded prompts instead of text-to-speech when average speed rises above or drops below the limit in Bulgarian

## Testing
- not run (flutter is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_6900e8d029e4832db86de2a72e25d17c