### PR TITLE
Play average speed warning when entering above limit

### DIFF
--- a/lib/features/segments/domain/tracking/segment_guidance_controller.dart
+++ b/lib/features/segments/domain/tracking/segment_guidance_controller.dart
@@ -374,13 +374,21 @@ class SegmentGuidanceController {
     final double limit = _currentLimitKph!;
     final double margin = 1.0;
 
+    final bool allowInitialBreachAnnouncement = allowSpeech ||
+        (_suppressGuidanceAudio &&
+            _audioPolicy.allowSpeech &&
+            !_aboveLimitAlerted);
+
     if (averageKph > limit + margin) {
       _wasOverLimit = true;
       _aboveLimitSince ??= now;
       if (!_aboveLimitAlerted &&
-          allowSpeech &&
+          allowInitialBreachAnnouncement &&
           now.difference(_aboveLimitSince!) >= _aboveLimitGrace) {
         _aboveLimitAlerted = true;
+        if (_suppressGuidanceAudio) {
+          _suppressGuidanceAudio = false;
+        }
         await _playChime(times: 2, spacing: const Duration(milliseconds: 180));
         if (_useBulgarianVoice) {
           await _playVoicePrompt(


### PR DESCRIPTION
## Summary
- allow the initial average-speed breach announcement to bypass the guidance audio suppression so the Bulgarian prompt plays when entering a segment above the limit
- clear the suppression flag after announcing the breach to keep subsequent reminders available

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_690115592030832d8be68d1d40c7d877