### PR TITLE
Ensure Bulgarian over-limit prompt plays during suppression

### DIFF
--- a/lib/features/segments/domain/tracking/segment_guidance_controller.dart
+++ b/lib/features/segments/domain/tracking/segment_guidance_controller.dart
@@ -373,12 +373,14 @@ class SegmentGuidanceController {
   }) async {
     final double limit = _currentLimitKph!;
     final double margin = 1.0;
+    final bool canDeliverSpeech =
+        allowSpeech || (_useBulgarianVoice && _audioPolicy.allowSpeech);
 
     if (averageKph > limit + margin) {
       _wasOverLimit = true;
       _aboveLimitSince ??= now;
       if (!_aboveLimitAlerted &&
-          allowSpeech &&
+          canDeliverSpeech &&
           now.difference(_aboveLimitSince!) >= _aboveLimitGrace) {
         _aboveLimitAlerted = true;
         await _playChime(times: 2, spacing: const Duration(milliseconds: 180));
@@ -394,7 +396,7 @@ class SegmentGuidanceController {
       }
 
       if (_aboveLimitAlerted &&
-          allowSpeech &&
+          canDeliverSpeech &&
           (_lastAboveLimitReminderAt == null ||
               now.difference(_lastAboveLimitReminderAt!) >=
                   _aboveLimitReminderInterval)) {
@@ -413,7 +415,7 @@ class SegmentGuidanceController {
 
     _aboveLimitSince = null;
     if (_wasOverLimit && averageKph <= limit) {
-      if (!allowSpeech) {
+      if (!canDeliverSpeech) {
         return false;
       }
       _wasOverLimit = false;


### PR DESCRIPTION
## Summary
- allow the Bulgarian over-limit prompt to play even when guidance speech is temporarily suppressed so drivers hear the warning when entering a segment too fast

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690118027e50832da85d6a4973bf78f8