### PR TITLE
Fix location permission request order

### DIFF
--- a/lib/shared/services/permission_service.dart
+++ b/lib/shared/services/permission_service.dart
@@ -2,7 +2,6 @@ import 'package:geolocator/geolocator.dart';
 
 class PermissionService {
   Future<bool> ensureLocationPermission() async {
-    if (!await Geolocator.isLocationServiceEnabled()) return false;
     var perm = await Geolocator.checkPermission();
     if (perm == LocationPermission.denied) {
       perm = await Geolocator.requestPermission();
@@ -10,9 +9,18 @@ class PermissionService {
     if (perm == LocationPermission.deniedForever) {
       return false;
     }
-    if (perm == LocationPermission.whileInUse) {
+    if (perm == LocationPermission.unableToDetermine) {
       perm = await Geolocator.requestPermission();
     }
+    if (perm == LocationPermission.whileInUse) {
+      final upgradedPermission = await Geolocator.requestPermission();
+      if (upgradedPermission != LocationPermission.denied &&
+          upgradedPermission != LocationPermission.deniedForever) {
+        perm = upgradedPermission;
+      }
+    }
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) return false;
     return perm == LocationPermission.always ||
         perm == LocationPermission.whileInUse;
   }


### PR DESCRIPTION
## Summary
- request runtime location permission before checking the location service state so the dialog appears in release builds
- retry requesting permission when the OS initially grants only while-in-use access to allow background access when possible
- keep reporting failure when the location service itself is disabled

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690300a22c2c832da76a2f4242336cd1