### PR TITLE
Cap displayed safe speed value

### DIFF
--- a/lib/features/segments/domain/tracking/segment_guidance_controller.dart
+++ b/lib/features/segments/domain/tracking/segment_guidance_controller.dart
@@ -590,9 +590,21 @@ class SegmentGuidanceController {
       averageStartedAt: averageStartedAt,
     );
 
-    final String? line3 = safeSpeed != null
-        ? 'Est. safe speed now: ${safeSpeed.toStringAsFixed(0)} (computed to finish ≤ limit)'
-        : null;
+    final String? line3;
+    if (safeSpeed != null) {
+      final String safeSpeedText;
+      if (!safeSpeed.isFinite) {
+        safeSpeedText = '--';
+      } else if (safeSpeed > 300) {
+        safeSpeedText = '>300';
+      } else {
+        safeSpeedText = safeSpeed.toStringAsFixed(0);
+      }
+      line3 =
+          'Est. safe speed now: $safeSpeedText (computed to finish ≤ limit)';
+    } else {
+      line3 = null;
+    }
 
     return SegmentGuidanceUiModel(line1: line1, line2: line2, line3: line3);
   }


### PR DESCRIPTION
## Summary
- cap the estimated safe speed display so values above 300 show as >300
- fall back to a placeholder when the estimated speed is not finite

## Testing
- Not run (flutter command not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_6903acbe6c94832d9faf24665dee4fb2