### PR TITLE
Cap map safe speed display

### DIFF
--- a/lib/features/map/presentation/pages/map/widgets/map_controls/segment_metrics_card.dart
+++ b/lib/features/map/presentation/pages/map/widgets/map_controls/segment_metrics_card.dart
@@ -72,7 +72,12 @@ class SegmentMetricsCard extends StatelessWidget {
             : const _MetricValue(value: _MetricValue.missingValue, unit: null);
         final _MetricValue limitSpeed = _formatSpeed(speedLimitKph, speedUnit);
         final _MetricValue safeSpeedFormatted = safeSpeed != null
-            ? _formatSpeed(safeSpeed, speedUnit)
+            ? _formatSpeed(
+                safeSpeed,
+                speedUnit,
+                maxDisplay: 300,
+                showGreaterThanOnCap: true,
+              )
             : const _MetricValue(value: _MetricValue.missingValue, unit: null);
 
         final bool showSafeSpeed =
@@ -603,11 +608,22 @@ double? _estimateSafeSpeed({
   return math.max(0, required);
 }
 
-_MetricValue _formatSpeed(double? speedKph, String unit) {
+_MetricValue _formatSpeed(
+  double? speedKph,
+  String unit, {
+  double? maxDisplay,
+  bool showGreaterThanOnCap = false,
+}) {
   if (speedKph == null || !speedKph.isFinite) {
     return const _MetricValue(value: _MetricValue.missingValue, unit: null);
   }
   final double clamped = speedKph.clamp(0, double.infinity).toDouble();
+  if (maxDisplay != null && clamped > maxDisplay) {
+    final String cappedValue = showGreaterThanOnCap
+        ? '>${maxDisplay.toStringAsFixed(0)}'
+        : maxDisplay.toStringAsFixed(0);
+    return _MetricValue(value: cappedValue, unit: unit);
+  }
   final bool useDecimals = clamped < 10;
   final String formatted = clamped.toStringAsFixed(useDecimals ? 1 : 0);
   return _MetricValue(value: formatted, unit: unit);

--- a/lib/features/segments/domain/tracking/segment_guidance_controller.dart
+++ b/lib/features/segments/domain/tracking/segment_guidance_controller.dart
@@ -590,9 +590,21 @@ class SegmentGuidanceController {
       averageStartedAt: averageStartedAt,
     );
 
-    final String? line3 = safeSpeed != null
-        ? 'Est. safe speed now: ${safeSpeed.toStringAsFixed(0)} (computed to finish ≤ limit)'
-        : null;
+    final String? line3;
+    if (safeSpeed != null) {
+      final String safeSpeedText;
+      if (!safeSpeed.isFinite) {
+        safeSpeedText = '--';
+      } else if (safeSpeed > 300) {
+        safeSpeedText = '>300';
+      } else {
+        safeSpeedText = safeSpeed.toStringAsFixed(0);
+      }
+      line3 =
+          'Est. safe speed now: $safeSpeedText (computed to finish ≤ limit)';
+    } else {
+      line3 = null;
+    }
 
     return SegmentGuidanceUiModel(line1: line1, line2: line2, line3: line3);
   }


### PR DESCRIPTION
## Summary
- cap the map controls safe speed display so values above 300 render as >300
- reuse the existing speed formatting helper with an optional display ceiling to support the capped output

## Testing
- Not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6903acbe6c94832d9faf24665dee4fb2