### PR TITLE
Add introductory overlay explaining dashboard metrics and menu

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -304,6 +304,43 @@ class AppLocalizations {
       'segmentMetricsDistanceToStart': 'To segment start',
       'segmentMetricsDistanceToEnd': 'To segment end',
       'segmentMetricsSafeSpeed': 'Safe to finish',
+      'introTitle': 'Welcome to TollCam',
+      'introSubtitle':
+          'Here\'s how to read the dashboard and what you can do from the menu.',
+      'introMetricsTitle': 'Dashboard metrics',
+      'introMetricCurrentSpeedTitle': 'Current speed',
+      'introMetricCurrentSpeedBody':
+          'Your live GPS speed so you always know how fast you\'re moving.',
+      'introMetricAverageSpeedTitle': 'Segment average',
+      'introMetricAverageSpeedBody':
+          'The running average for the active toll segment since guidance started.',
+      'introMetricLimitTitle': 'Speed limit / safe speed',
+      'introMetricLimitBody':
+          'Shows the posted limit or the safe speed to finish within the limit when averaging.',
+      'introMetricDistanceTitle': 'Distance',
+      'introMetricDistanceBody':
+          'Distance to the start or end of the selected segment, depending on where you are.',
+      'introSidebarTitle': 'What you can do from the menu',
+      'introSidebarSyncTitle': 'Sync',
+      'introSidebarSyncBody':
+          'Download the latest public segments and weigh stations so you stay up to date offline.',
+      'introSidebarSegmentsTitle': 'Segments',
+      'introSidebarSegmentsBody':
+          'Add new segments. You can keep personal ones without signing in, but you must log in to publish them publicly.',
+      'introSidebarWeighStationsTitle': 'Weigh stations',
+      'introSidebarWeighStationsBody':
+          'Review nearby weigh stations or add your own. Signing in is required to publish them for everyone.',
+      'introSidebarAudioTitle': 'Voice guidance',
+      'introSidebarAudioBody':
+          'Choose which voice alerts you hear and when they play during navigation.',
+      'introSidebarLanguageTitle': 'Language',
+      'introSidebarLanguageBody':
+          'Switch the entire app between supported languages instantly.',
+      'introSidebarProfileTitle': 'Profile & login',
+      'introSidebarProfileBody':
+          'Sign in or create an account. It\'s required to publish segments or weigh stations for the community.',
+      'introDismiss': 'Start exploring',
+      'introMenuLabel': 'Show introduction',
       'segmentMetricsStatusTracking': 'Tracking segment',
       'segmentHandoverTitle': 'New zone started',
       'segmentHandoverPreviousAverage': 'Prev avg {value} {unit}',
@@ -594,6 +631,43 @@ class AppLocalizations {
 'segmentMetricsDistanceToStart': 'До началото',
 'segmentMetricsDistanceToEnd': 'До края',
 'segmentMetricsSafeSpeed': 'Безопасна скорост',
+'introTitle': 'Добре дошли в TollCam',
+'introSubtitle':
+'Научете как да разчитате таблото и какво можете да правите от менюто.',
+'introMetricsTitle': 'Показатели на таблото',
+'introMetricCurrentSpeedTitle': 'Текуща скорост',
+'introMetricCurrentSpeedBody':
+'Показва моментната ви GPS скорост, за да знаете с каква скорост се движите.',
+'introMetricAverageSpeedTitle': 'Средна скорост в сегмента',
+'introMetricAverageSpeedBody':
+'Средната скорост за активния тол сегмент от началото на измерването.',
+'introMetricLimitTitle': 'Ограничение / безопасна скорост',
+'introMetricLimitBody':
+'Показва ограничението в сегмента или необходимата безопасна скорост, за да го завършите в рамките на лимита.',
+'introMetricDistanceTitle': 'Разстояние',
+'introMetricDistanceBody':
+'Разстоянието до началото или края на избрания сегмент според текущата ви позиция.',
+'introSidebarTitle': 'Какво можете да правите от менюто',
+'introSidebarSyncTitle': 'Синхронизирай',
+'introSidebarSyncBody':
+'Изтеглете най-новите публични сегменти и кантари, за да сте актуални офлайн.',
+'introSidebarSegmentsTitle': 'Сегменти',
+'introSidebarSegmentsBody':
+'Добавяйте нови сегменти. Можете да пазите лични без вход, но за публично споделяне е необходим акаунт.',
+'introSidebarWeighStationsTitle': 'Кантари',
+'introSidebarWeighStationsBody':
+'Разглеждайте близките кантари или добавяйте свои. За публикуване е нужен вход.',
+'introSidebarAudioTitle': 'Гласови съобщения',
+'introSidebarAudioBody':
+'Изберете кои гласови известия да чувате и кога да се възпроизвеждат.',
+'introSidebarLanguageTitle': 'Език',
+'introSidebarLanguageBody':
+'Сменете езика на приложението по всяко време.',
+'introSidebarProfileTitle': 'Профил и вход',
+'introSidebarProfileBody':
+'Влезте или създайте акаунт. Необходимо е за публикуване на сегменти и кантари.',
+'introDismiss': 'Започни',
+'introMenuLabel': 'Въведение',
 'segmentMetricsStatusTracking': 'Следене на сегмента',
 'segmentHandoverTitle': 'Нова зона',
 'segmentHandoverPreviousAverage': 'Предишна средна {value} {unit}',
@@ -797,6 +871,46 @@ class AppLocalizations {
       _value('segmentHandoverNoNextSegment');
   String get segmentHandoverUnknownValue => _value('segmentHandoverUnknownValue');
   String get speedDialNoActiveSegment => _value('speedDialNoActiveSegment');
+  String get introTitle => _value('introTitle');
+  String get introSubtitle => _value('introSubtitle');
+  String get introMetricsTitle => _value('introMetricsTitle');
+  String get introMetricCurrentSpeedTitle =>
+      _value('introMetricCurrentSpeedTitle');
+  String get introMetricCurrentSpeedBody =>
+      _value('introMetricCurrentSpeedBody');
+  String get introMetricAverageSpeedTitle =>
+      _value('introMetricAverageSpeedTitle');
+  String get introMetricAverageSpeedBody =>
+      _value('introMetricAverageSpeedBody');
+  String get introMetricLimitTitle => _value('introMetricLimitTitle');
+  String get introMetricLimitBody => _value('introMetricLimitBody');
+  String get introMetricDistanceTitle =>
+      _value('introMetricDistanceTitle');
+  String get introMetricDistanceBody =>
+      _value('introMetricDistanceBody');
+  String get introSidebarTitle => _value('introSidebarTitle');
+  String get introSidebarSyncTitle => _value('introSidebarSyncTitle');
+  String get introSidebarSyncBody => _value('introSidebarSyncBody');
+  String get introSidebarSegmentsTitle =>
+      _value('introSidebarSegmentsTitle');
+  String get introSidebarSegmentsBody =>
+      _value('introSidebarSegmentsBody');
+  String get introSidebarWeighStationsTitle =>
+      _value('introSidebarWeighStationsTitle');
+  String get introSidebarWeighStationsBody =>
+      _value('introSidebarWeighStationsBody');
+  String get introSidebarAudioTitle => _value('introSidebarAudioTitle');
+  String get introSidebarAudioBody => _value('introSidebarAudioBody');
+  String get introSidebarLanguageTitle =>
+      _value('introSidebarLanguageTitle');
+  String get introSidebarLanguageBody =>
+      _value('introSidebarLanguageBody');
+  String get introSidebarProfileTitle =>
+      _value('introSidebarProfileTitle');
+  String get introSidebarProfileBody =>
+      _value('introSidebarProfileBody');
+  String get introDismiss => _value('introDismiss');
+  String get introMenuLabel => _value('introMenuLabel');
 }
 
 class AppLocalizationsDelegate

--- a/lib/features/map/presentation/pages/map/map_options_drawer.dart
+++ b/lib/features/map/presentation/pages/map/map_options_drawer.dart
@@ -24,6 +24,17 @@ extension _MapPageDrawer on _MapPageState {
               onTap: themeController.toggle,
             ),
             ListTile(
+              leading: const Icon(Icons.info_outline),
+              title: Text(localizations.introMenuLabel),
+              onTap: () {
+                Navigator.of(context).pop();
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (!mounted) return;
+                  _revealIntro();
+                });
+              },
+            ),
+            ListTile(
               leading: const Icon(Icons.sync),
               title: Text(localizations.sync),
               enabled: !_isSyncing,

--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -154,6 +154,7 @@ class _MapPageState extends State<MapPage>
   bool _useForegroundLocationService = false;
   bool _didRequestNotificationPermission = false;
   String? _lastNotificationStatus;
+  bool _showIntro = false;
 
   AverageSpeedController get _avgCtrl =>
       _currentSegmentController.averageController;
@@ -201,6 +202,15 @@ class _MapPageState extends State<MapPage>
     unawaited(_initLocation());
     unawaited(_initSegmentsIndex());
     _updateAudioPolicy();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _showIntro = true;
+      });
+    });
   }
 
   @override
@@ -1105,6 +1115,24 @@ class _MapPageState extends State<MapPage>
     }
   }
 
+  void _revealIntro() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _showIntro = true;
+    });
+  }
+
+  void _dismissIntro() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _showIntro = false;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final currentSegment = context.watch<CurrentSegmentController>();
@@ -1278,11 +1306,386 @@ class _MapPageState extends State<MapPage>
       else
         Positioned(left: 0, right: 0, bottom: 0, child: controlsPanel),
       mapFab,
+      _buildIntroOverlay(context),
     ];
 
     return Scaffold(
       endDrawer: _buildOptionsDrawer(),
       body: Stack(fit: StackFit.expand, children: stackChildren),
+    );
+  }
+
+  Widget _buildIntroOverlay(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final localizations = AppLocalizations.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+
+    final metrics = <_IntroMetricData>[
+      _IntroMetricData(
+        icon: Icons.speed,
+        title: localizations.introMetricCurrentSpeedTitle,
+        description: localizations.introMetricCurrentSpeedBody,
+      ),
+      _IntroMetricData(
+        icon: Icons.timeline,
+        title: localizations.introMetricAverageSpeedTitle,
+        description: localizations.introMetricAverageSpeedBody,
+      ),
+      _IntroMetricData(
+        icon: Icons.shield_outlined,
+        title: localizations.introMetricLimitTitle,
+        description: localizations.introMetricLimitBody,
+      ),
+      _IntroMetricData(
+        icon: Icons.straighten,
+        title: localizations.introMetricDistanceTitle,
+        description: localizations.introMetricDistanceBody,
+      ),
+    ];
+
+    final actions = <_IntroActionData>[
+      _IntroActionData(
+        icon: Icons.sync,
+        title: localizations.introSidebarSyncTitle,
+        description: localizations.introSidebarSyncBody,
+      ),
+      _IntroActionData(
+        icon: Icons.segment,
+        title: localizations.introSidebarSegmentsTitle,
+        description: localizations.introSidebarSegmentsBody,
+      ),
+      _IntroActionData(
+        icon: Icons.scale_outlined,
+        title: localizations.introSidebarWeighStationsTitle,
+        description: localizations.introSidebarWeighStationsBody,
+      ),
+      _IntroActionData(
+        icon: Icons.volume_up_outlined,
+        title: localizations.introSidebarAudioTitle,
+        description: localizations.introSidebarAudioBody,
+      ),
+      _IntroActionData(
+        icon: Icons.language,
+        title: localizations.introSidebarLanguageTitle,
+        description: localizations.introSidebarLanguageBody,
+      ),
+      _IntroActionData(
+        icon: Icons.person_outline,
+        title: localizations.introSidebarProfileTitle,
+        description: localizations.introSidebarProfileBody,
+      ),
+    ];
+
+    return IgnorePointer(
+      ignoring: !_showIntro,
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeInOut,
+        opacity: _showIntro ? 1 : 0,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: _dismissIntro,
+                child: Container(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        palette.primary.withOpacity(isDark ? 0.72 : 0.55),
+                        palette.surface.withOpacity(isDark ? 0.9 : 0.85),
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Positioned.fill(
+              child: SafeArea(
+                child: Center(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(24),
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 720),
+                      child: _IntroContentCard(
+                        title: localizations.introTitle,
+                        subtitle: localizations.introSubtitle,
+                        metricsTitle: localizations.introMetricsTitle,
+                        actionsTitle: localizations.introSidebarTitle,
+                        metrics: metrics,
+                        actions: actions,
+                        dismissLabel: localizations.introDismiss,
+                        onDismiss: _dismissIntro,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IntroMetricData {
+  const _IntroMetricData({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+}
+
+class _IntroActionData {
+  const _IntroActionData({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+}
+
+class _IntroContentCard extends StatelessWidget {
+  const _IntroContentCard({
+    required this.title,
+    required this.subtitle,
+    required this.metricsTitle,
+    required this.actionsTitle,
+    required this.metrics,
+    required this.actions,
+    required this.dismissLabel,
+    required this.onDismiss,
+  });
+
+  final String title;
+  final String subtitle;
+  final String metricsTitle;
+  final String actionsTitle;
+  final List<_IntroMetricData> metrics;
+  final List<_IntroActionData> actions;
+  final String dismissLabel;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+    final Color cardColor =
+        theme.colorScheme.surface.withOpacity(isDark ? 0.96 : 0.94);
+    final Color borderColor =
+        palette.divider.withOpacity(isDark ? 0.7 : 0.45);
+    final TextStyle? titleStyle =
+        theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700);
+    final TextStyle? subtitleStyle = theme.textTheme.bodyLarge
+        ?.copyWith(color: palette.secondaryText, height: 1.4);
+    final TextStyle? sectionStyle =
+        theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: cardColor,
+        borderRadius: BorderRadius.circular(32),
+        border: Border.all(color: borderColor, width: 1),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(isDark ? 0.5 : 0.18),
+            blurRadius: 42,
+            offset: const Offset(0, 24),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(32, 28, 32, 32),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(title, style: titleStyle),
+                      const SizedBox(height: 12),
+                      Text(subtitle, style: subtitleStyle),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 12),
+                IconButton(
+                  onPressed: onDismiss,
+                  tooltip: MaterialLocalizations.of(context).closeButtonLabel,
+                  icon: const Icon(Icons.close),
+                ),
+              ],
+            ),
+            const SizedBox(height: 28),
+            Text(metricsTitle, style: sectionStyle),
+            const SizedBox(height: 16),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final double width = constraints.maxWidth;
+                final bool twoColumns = width >= 600;
+                final double cardWidth = twoColumns
+                    ? (width - 16) / 2
+                    : width;
+                return Wrap(
+                  spacing: 16,
+                  runSpacing: 16,
+                  children: metrics
+                      .map(
+                        (metric) => SizedBox(
+                          width: cardWidth,
+                          child: _IntroMetricCard(data: metric),
+                        ),
+                      )
+                      .toList(),
+                );
+              },
+            ),
+            const SizedBox(height: 32),
+            Text(actionsTitle, style: sectionStyle),
+            const SizedBox(height: 16),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (int i = 0; i < actions.length; i++) ...[
+                  _IntroActionTile(data: actions[i]),
+                  if (i < actions.length - 1) const SizedBox(height: 12),
+                ],
+              ],
+            ),
+            const SizedBox(height: 24),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton(
+                onPressed: onDismiss,
+                child: Text(dismissLabel),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IntroMetricCard extends StatelessWidget {
+  const _IntroMetricCard({required this.data});
+
+  final _IntroMetricData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        color: palette.surface.withOpacity(isDark ? 0.75 : 0.9),
+        border:
+            Border.all(color: palette.divider.withOpacity(isDark ? 0.8 : 0.45)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                color: palette.primary.withOpacity(isDark ? 0.2 : 0.12),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              padding: const EdgeInsets.all(12),
+              child: Icon(data.icon, color: palette.primary, size: 28),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              data.title,
+              style:
+                  theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              data.description,
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: palette.secondaryText, height: 1.4),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IntroActionTile extends StatelessWidget {
+  const _IntroActionTile({required this.data});
+
+  final _IntroActionData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        color: palette.surface.withOpacity(isDark ? 0.7 : 0.92),
+        border:
+            Border.all(color: palette.divider.withOpacity(isDark ? 0.85 : 0.5)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                color: palette.primary.withOpacity(isDark ? 0.22 : 0.14),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              padding: const EdgeInsets.all(10),
+              child: Icon(data.icon, color: palette.primary, size: 24),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    data.title,
+                    style: theme.textTheme.titleSmall
+                        ?.copyWith(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    data.description,
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(color: palette.secondaryText, height: 1.4),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add a full-screen introduction overlay on the map page that explains each dashboard metric and sidebar capability
- provide an entry in the options drawer so users can reopen the introduction on demand
- localize the new onboarding copy in both English and Bulgarian

## Testing
- not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_6906367ed62c832d8339d9bdcf741e06