### PR TITLE
Log wakelock activity while app is foregrounded

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 import 'package:toll_cam_finder/shared/services/language_controller.dart';
 import 'package:toll_cam_finder/shared/services/theme_controller.dart';
@@ -8,8 +11,78 @@ import 'app_routes.dart';
 import 'app_theme.dart';
 import 'localization/app_localizations.dart';
 
-class TollCamApp extends StatelessWidget {
+class TollCamApp extends StatefulWidget {
   const TollCamApp({super.key});
+
+  @override
+  State<TollCamApp> createState() => _TollCamAppState();
+}
+
+class _TollCamAppState extends State<TollCamApp> with WidgetsBindingObserver {
+  bool _wakelockActive = false;
+  Timer? _wakelockLogTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    unawaited(_updateWakelock(WidgetsBinding.instance.lifecycleState));
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _stopWakelockLogging();
+    unawaited(WakelockPlus.disable());
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    unawaited(_updateWakelock(state));
+  }
+
+  Future<void> _updateWakelock(AppLifecycleState? state) async {
+    final shouldEnable = state == null || state == AppLifecycleState.resumed;
+
+    if (shouldEnable) {
+      await _enableWakelock();
+    } else {
+      await _disableWakelock();
+    }
+  }
+
+  Future<void> _enableWakelock() async {
+    if (_wakelockActive) {
+      return;
+    }
+
+    await WakelockPlus.enable();
+    _wakelockActive = true;
+    _startWakelockLogging();
+  }
+
+  Future<void> _disableWakelock() async {
+    if (!_wakelockActive) {
+      return;
+    }
+
+    await WakelockPlus.disable();
+    _wakelockActive = false;
+    _stopWakelockLogging();
+  }
+
+  void _startWakelockLogging() {
+    _wakelockLogTimer?.cancel();
+    _wakelockLogTimer =
+        Timer.periodic(const Duration(seconds: 5), (_) => debugPrint('WAKELOCK'));
+  }
+
+  void _stopWakelockLogging() {
+    _wakelockLogTimer?.cancel();
+    _wakelockLogTimer = null;
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1162,6 +1162,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.3"
+  wakelock_plus:
+    dependency: "direct main"
+    description:
+      name: wakelock_plus
+      sha256: "9296d40c9adbedaba95d1e704f4e0b434be446e2792948d0e4aa977048104228"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  wakelock_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: wakelock_plus_platform_interface
+      sha256: "036deb14cd62f558ca3b73006d52ce049fabcdcb2eddfe0bf0fe4e8a943b5cf2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   uuid: ^4.4.0
   audioplayers: ^6.5.1
   flutter_tts: ^3.8.5
+  wakelock_plus: ^1.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- guard wakelock enable/disable calls with tracked state to prevent redundant operations
- start and stop periodic "WAKELOCK" logging whenever the wakelock becomes active or inactive

## Testing
- Not run (Flutter tooling unavailable in container)
- `dart format lib/app/app.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6906385ade94832db02138ce4378f71f