### PR TITLE
Add welcome flow and weigh station preference handling

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -339,6 +339,16 @@ class AppLocalizations {
       'introSidebarProfileTitle': 'Profile & login',
       'introSidebarProfileBody':
           'Sign in or create an account. It\'s required to publish segments or weigh stations for the community.',
+      'mapWelcomeTitle': 'Welcome to TollCam',
+      'mapWelcomeDescription':
+          'Let\'s get you set up. Choose your preferred language to personalize the experience.',
+      'mapWelcomeLanguagePrompt': 'Choose your language',
+      'mapWeighStationsPromptTitle': 'See weigh stations on the map?',
+      'mapWeighStationsPromptDescription':
+          'We can show nearby weigh stations while you drive. You can change this anytime from the Weigh stations page.',
+      'mapWeighStationsPromptEnableButton': 'Show weigh stations',
+      'mapWeighStationsPromptSkipButton': 'Not now',
+      'mapWeighStationsEnableButton': 'Enable weigh stations on map',
       'introDismiss': 'Start exploring',
       'introMenuLabel': 'Show introduction',
       'segmentMetricsStatusTracking': 'Tracking segment',
@@ -666,6 +676,16 @@ class AppLocalizations {
 'introSidebarProfileTitle': 'Профил и вход',
 'introSidebarProfileBody':
 'Влезте или създайте акаунт. Необходимо е за публикуване на сегменти и кантари.',
+'mapWelcomeTitle': 'Добре дошли в TollCam',
+'mapWelcomeDescription':
+'Нека ви настроим. Изберете предпочитания от вас език за приложението.',
+'mapWelcomeLanguagePrompt': 'Изберете вашия език',
+'mapWeighStationsPromptTitle': 'Да показваме ли кантари на картата?',
+'mapWeighStationsPromptDescription':
+'Можем да показваме близките кантари по време на пътуване. Можете да промените избора си по всяко време от страницата „Кантари“.',
+'mapWeighStationsPromptEnableButton': 'Показвай кантари',
+'mapWeighStationsPromptSkipButton': 'Не сега',
+'mapWeighStationsEnableButton': 'Активирай кантари на картата',
 'introDismiss': 'Започни',
 'introMenuLabel': 'Въведение',
 'segmentMetricsStatusTracking': 'Следене на сегмента',
@@ -909,6 +929,20 @@ class AppLocalizations {
       _value('introSidebarProfileTitle');
   String get introSidebarProfileBody =>
       _value('introSidebarProfileBody');
+  String get mapWelcomeTitle => _value('mapWelcomeTitle');
+  String get mapWelcomeDescription => _value('mapWelcomeDescription');
+  String get mapWelcomeLanguagePrompt =>
+      _value('mapWelcomeLanguagePrompt');
+  String get mapWeighStationsPromptTitle =>
+      _value('mapWeighStationsPromptTitle');
+  String get mapWeighStationsPromptDescription =>
+      _value('mapWeighStationsPromptDescription');
+  String get mapWeighStationsPromptEnableButton =>
+      _value('mapWeighStationsPromptEnableButton');
+  String get mapWeighStationsPromptSkipButton =>
+      _value('mapWeighStationsPromptSkipButton');
+  String get mapWeighStationsEnableButton =>
+      _value('mapWeighStationsEnableButton');
   String get introDismiss => _value('introDismiss');
   String get introMenuLabel => _value('introMenuLabel');
 }

--- a/lib/features/map/presentation/pages/map/widgets/map_intro_overlay.dart
+++ b/lib/features/map/presentation/pages/map/widgets/map_intro_overlay.dart
@@ -1,0 +1,390 @@
+import 'package:flutter/material.dart';
+
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+import 'package:toll_cam_finder/core/app_colors.dart';
+
+class MapIntroOverlay extends StatelessWidget {
+  const MapIntroOverlay({
+    super.key,
+    required this.visible,
+    required this.onDismiss,
+  });
+
+  final bool visible;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final localizations = AppLocalizations.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+
+    final metrics = <_IntroMetricData>[
+      _IntroMetricData(
+        icon: Icons.speed,
+        title: localizations.introMetricCurrentSpeedTitle,
+        description: localizations.introMetricCurrentSpeedBody,
+      ),
+      _IntroMetricData(
+        icon: Icons.timeline,
+        title: localizations.introMetricAverageSpeedTitle,
+        description: localizations.introMetricAverageSpeedBody,
+      ),
+      _IntroMetricData(
+        icon: Icons.shield_outlined,
+        title: localizations.introMetricLimitTitle,
+        description: localizations.introMetricLimitBody,
+      ),
+      _IntroMetricData(
+        icon: Icons.straighten,
+        title: localizations.introMetricDistanceTitle,
+        description: localizations.introMetricDistanceBody,
+      ),
+    ];
+
+    final actions = <_IntroActionData>[
+      _IntroActionData(
+        icon: Icons.sync,
+        title: localizations.introSidebarSyncTitle,
+        description: localizations.introSidebarSyncBody,
+      ),
+      _IntroActionData(
+        icon: Icons.segment,
+        title: localizations.introSidebarSegmentsTitle,
+        description: localizations.introSidebarSegmentsBody,
+      ),
+      _IntroActionData(
+        icon: Icons.scale_outlined,
+        title: localizations.introSidebarWeighStationsTitle,
+        description: localizations.introSidebarWeighStationsBody,
+      ),
+      _IntroActionData(
+        icon: Icons.volume_up_outlined,
+        title: localizations.introSidebarAudioTitle,
+        description: localizations.introSidebarAudioBody,
+      ),
+      _IntroActionData(
+        icon: Icons.language,
+        title: localizations.introSidebarLanguageTitle,
+        description: localizations.introSidebarLanguageBody,
+      ),
+      _IntroActionData(
+        icon: Icons.person_outline,
+        title: localizations.introSidebarProfileTitle,
+        description: localizations.introSidebarProfileBody,
+      ),
+    ];
+
+    return IgnorePointer(
+      ignoring: !visible,
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeInOut,
+        opacity: visible ? 1 : 0,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: onDismiss,
+                child: Container(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        palette.primary.withOpacity(isDark ? 0.72 : 0.55),
+                        palette.surface.withOpacity(isDark ? 0.9 : 0.85),
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Positioned.fill(
+              child: SafeArea(
+                child: Center(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(24),
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 720),
+                      child: _IntroContentCard(
+                        title: localizations.introTitle,
+                        subtitle: localizations.introSubtitle,
+                        metricsTitle: localizations.introMetricsTitle,
+                        actionsTitle: localizations.introSidebarTitle,
+                        metrics: metrics,
+                        actions: actions,
+                        dismissLabel: localizations.introDismiss,
+                        onDismiss: onDismiss,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IntroMetricData {
+  const _IntroMetricData({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+}
+
+class _IntroActionData {
+  const _IntroActionData({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+}
+
+class _IntroContentCard extends StatelessWidget {
+  const _IntroContentCard({
+    required this.title,
+    required this.subtitle,
+    required this.metricsTitle,
+    required this.actionsTitle,
+    required this.metrics,
+    required this.actions,
+    required this.dismissLabel,
+    required this.onDismiss,
+  });
+
+  final String title;
+  final String subtitle;
+  final String metricsTitle;
+  final String actionsTitle;
+  final List<_IntroMetricData> metrics;
+  final List<_IntroActionData> actions;
+  final String dismissLabel;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+    final Color cardColor =
+        theme.colorScheme.surface.withOpacity(isDark ? 0.96 : 0.94);
+    final Color borderColor =
+        palette.divider.withOpacity(isDark ? 0.7 : 0.45);
+    final TextStyle? titleStyle =
+        theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700);
+    final TextStyle? subtitleStyle = theme.textTheme.bodyLarge
+        ?.copyWith(color: palette.secondaryText, height: 1.4);
+    final TextStyle? sectionStyle =
+        theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: cardColor,
+        borderRadius: BorderRadius.circular(32),
+        border: Border.all(color: borderColor, width: 1),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(isDark ? 0.5 : 0.18),
+            blurRadius: 42,
+            offset: const Offset(0, 24),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(32, 28, 32, 32),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(title, style: titleStyle),
+                      const SizedBox(height: 12),
+                      Text(subtitle, style: subtitleStyle),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 12),
+                IconButton(
+                  onPressed: onDismiss,
+                  tooltip: MaterialLocalizations.of(context).closeButtonLabel,
+                  icon: const Icon(Icons.close),
+                ),
+              ],
+            ),
+            const SizedBox(height: 28),
+            Text(metricsTitle, style: sectionStyle),
+            const SizedBox(height: 16),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final double width = constraints.maxWidth;
+                final bool twoColumns = width >= 600;
+                final double cardWidth = twoColumns
+                    ? (width - 16) / 2
+                    : width;
+                return Wrap(
+                  spacing: 16,
+                  runSpacing: 16,
+                  children: metrics
+                      .map(
+                        (metric) => SizedBox(
+                          width: cardWidth,
+                          child: _IntroMetricCard(data: metric),
+                        ),
+                      )
+                      .toList(),
+                );
+              },
+            ),
+            const SizedBox(height: 32),
+            Text(actionsTitle, style: sectionStyle),
+            const SizedBox(height: 16),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (int i = 0; i < actions.length; i++) ...[
+                  _IntroActionTile(data: actions[i]),
+                  if (i < actions.length - 1) const SizedBox(height: 12),
+                ],
+              ],
+            ),
+            const SizedBox(height: 24),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton(
+                onPressed: onDismiss,
+                child: Text(dismissLabel),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IntroMetricCard extends StatelessWidget {
+  const _IntroMetricCard({required this.data});
+
+  final _IntroMetricData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        color: palette.surface.withOpacity(isDark ? 0.75 : 0.9),
+        border:
+            Border.all(color: palette.divider.withOpacity(isDark ? 0.8 : 0.45)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                color: palette.primary.withOpacity(isDark ? 0.2 : 0.12),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              padding: const EdgeInsets.all(12),
+              child: Icon(data.icon, color: palette.primary, size: 28),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              data.title,
+              style:
+                  theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              data.description,
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: palette.secondaryText, height: 1.4),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IntroActionTile extends StatelessWidget {
+  const _IntroActionTile({required this.data});
+
+  final _IntroActionData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        color: palette.surface.withOpacity(isDark ? 0.7 : 0.92),
+        border:
+            Border.all(color: palette.divider.withOpacity(isDark ? 0.85 : 0.5)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                color: palette.primary.withOpacity(isDark ? 0.22 : 0.14),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              padding: const EdgeInsets.all(10),
+              child: Icon(data.icon, color: palette.primary, size: 24),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    data.title,
+                    style: theme.textTheme.titleSmall
+                        ?.copyWith(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    data.description,
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(color: palette.secondaryText, height: 1.4),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/map/presentation/pages/map/widgets/map_welcome_overlays.dart
+++ b/lib/features/map/presentation/pages/map/widgets/map_welcome_overlays.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+import 'package:toll_cam_finder/core/app_colors.dart';
+import 'package:toll_cam_finder/shared/services/language_controller.dart';
+
+class MapWelcomeOverlay extends StatelessWidget {
+  const MapWelcomeOverlay({
+    super.key,
+    required this.visible,
+    required this.languageOptions,
+    required this.selectedLanguageCode,
+    required this.onLanguageSelected,
+    required this.onContinue,
+  });
+
+  final bool visible;
+  final List<LanguageOption> languageOptions;
+  final String selectedLanguageCode;
+  final ValueChanged<String> onLanguageSelected;
+  final VoidCallback onContinue;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final localizations = AppLocalizations.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+
+    final List<LanguageOption> availableOptions = languageOptions
+        .where((option) => option.available)
+        .toList(growable: false);
+
+    return IgnorePointer(
+      ignoring: !visible,
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeInOut,
+        opacity: visible ? 1 : 0,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      palette.primary.withOpacity(isDark ? 0.7 : 0.55),
+                      palette.surface.withOpacity(isDark ? 0.92 : 0.88),
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                ),
+              ),
+            ),
+            Positioned.fill(
+              child: SafeArea(
+                child: Center(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(24),
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 520),
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.surface
+                              .withOpacity(isDark ? 0.96 : 0.94),
+                          borderRadius: BorderRadius.circular(28),
+                          border: Border.all(
+                            color: palette.divider
+                                .withOpacity(isDark ? 0.7 : 0.5),
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color:
+                                  Colors.black.withOpacity(isDark ? 0.45 : 0.18),
+                              blurRadius: 38,
+                              offset: const Offset(0, 24),
+                            ),
+                          ],
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.all(28),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                localizations.mapWelcomeTitle,
+                                style: theme.textTheme.headlineSmall
+                                    ?.copyWith(fontWeight: FontWeight.w700),
+                              ),
+                              const SizedBox(height: 12),
+                              Text(
+                                localizations.mapWelcomeDescription,
+                                style: theme.textTheme.bodyLarge?.copyWith(
+                                  color: palette.secondaryText,
+                                  height: 1.4,
+                                ),
+                              ),
+                              const SizedBox(height: 24),
+                              Text(
+                                localizations.mapWelcomeLanguagePrompt,
+                                style: theme.textTheme.titleMedium
+                                    ?.copyWith(fontWeight: FontWeight.w600),
+                              ),
+                              const SizedBox(height: 12),
+                              ...availableOptions.map(
+                                (option) => RadioListTile<String>(
+                                  value: option.languageCode,
+                                  groupValue: selectedLanguageCode,
+                                  onChanged: (code) {
+                                    if (code != null) {
+                                      onLanguageSelected(code);
+                                    }
+                                  },
+                                  title: Text(option.label),
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(16),
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(height: 24),
+                              Align(
+                                alignment: Alignment.centerRight,
+                                child: FilledButton(
+                                  onPressed: onContinue,
+                                  child: Text(localizations.continueLabel),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class MapWeighStationPreferenceOverlay extends StatelessWidget {
+  const MapWeighStationPreferenceOverlay({
+    super.key,
+    required this.visible,
+    required this.onEnable,
+    required this.onSkip,
+  });
+
+  final bool visible;
+  final VoidCallback onEnable;
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final localizations = AppLocalizations.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+
+    return IgnorePointer(
+      ignoring: !visible,
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeInOut,
+        opacity: visible ? 1 : 0,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: Container(
+                color: palette.surface.withOpacity(isDark ? 0.85 : 0.82),
+              ),
+            ),
+            Positioned.fill(
+              child: SafeArea(
+                child: Center(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(24),
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 480),
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.surface
+                              .withOpacity(isDark ? 0.97 : 0.95),
+                          borderRadius: BorderRadius.circular(28),
+                          border: Border.all(
+                            color: palette.divider
+                                .withOpacity(isDark ? 0.75 : 0.5),
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color:
+                                  Colors.black.withOpacity(isDark ? 0.5 : 0.2),
+                              blurRadius: 34,
+                              offset: const Offset(0, 20),
+                            ),
+                          ],
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.all(28),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                localizations.mapWeighStationsPromptTitle,
+                                style: theme.textTheme.headlineSmall
+                                    ?.copyWith(fontWeight: FontWeight.w700),
+                              ),
+                              const SizedBox(height: 12),
+                              Text(
+                                localizations.mapWeighStationsPromptDescription,
+                                style: theme.textTheme.bodyLarge?.copyWith(
+                                  color: palette.secondaryText,
+                                  height: 1.4,
+                                ),
+                              ),
+                              const SizedBox(height: 28),
+                              Row(
+                                mainAxisAlignment: MainAxisAlignment.end,
+                                children: [
+                                  TextButton(
+                                    onPressed: onSkip,
+                                    child: Text(
+                                      localizations
+                                          .mapWeighStationsPromptSkipButton,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  FilledButton(
+                                    onPressed: onEnable,
+                                    child: Text(
+                                      localizations
+                                          .mapWeighStationsPromptEnableButton,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/weigh_stations/presentation/pages/weigh_stations_page.dart
+++ b/lib/features/weigh_stations/presentation/pages/weigh_stations_page.dart
@@ -9,6 +9,7 @@ import 'package:toll_cam_finder/features/weigh_stations/domain/weigh_station.dar
 import 'package:toll_cam_finder/features/weigh_stations/presentation/widgets/weigh_station_action_dialogs.dart';
 import 'package:toll_cam_finder/features/weigh_stations/services/local_weigh_stations_service.dart';
 import 'package:toll_cam_finder/features/weigh_stations/services/weigh_stations_repository.dart';
+import 'package:toll_cam_finder/shared/services/weigh_station_preferences_controller.dart';
 
 class WeighStationsPage extends StatefulWidget {
   const WeighStationsPage({super.key});
@@ -109,6 +110,24 @@ class _WeighStationsPageState extends State<WeighStationsPage> {
                 vertical: 12,
               ),
             ),
+          ),
+        ),
+        bottomNavigationBar: SafeArea(
+          minimum: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          child: Consumer<WeighStationPreferencesController>(
+            builder: (context, preferences, _) {
+              final bool hasPreference = preferences.hasPreference;
+              final bool showWeighStations =
+                  preferences.shouldShowWeighStations;
+              if (!hasPreference || showWeighStations) {
+                return const SizedBox.shrink();
+              }
+              return FilledButton.icon(
+                onPressed: () => preferences.setShowWeighStations(true),
+                icon: const Icon(Icons.visibility_outlined),
+                label: Text(localizations.mapWeighStationsEnableButton),
+              );
+            },
           ),
         ),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:toll_cam_finder/features/map/domain/controllers/segments_only_mo
 import 'package:toll_cam_finder/features/segments/domain/controllers/current_segment_controller.dart';
 import 'package:toll_cam_finder/shared/services/language_controller.dart';
 import 'package:toll_cam_finder/shared/services/theme_controller.dart';
+import 'package:toll_cam_finder/shared/services/weigh_station_preferences_controller.dart';
 import 'package:toll_cam_finder/shared/audio/navigation_audio_context.dart';
 
 void main() async {
@@ -51,6 +52,9 @@ void main() async {
         ),
         ChangeNotifierProvider(
           create: (_) => ThemeController(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => WeighStationPreferencesController(),
         ),
       ],
       child: const TollCamApp(),

--- a/lib/shared/services/weigh_station_preferences_controller.dart
+++ b/lib/shared/services/weigh_station_preferences_controller.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class WeighStationPreferencesController extends ChangeNotifier {
+  WeighStationPreferencesController() {
+    unawaited(_loadPreference());
+  }
+
+  static const String _preferenceKey = 'show_weigh_stations_on_map';
+
+  bool? _showWeighStations;
+  bool _isLoaded = false;
+
+  bool get isLoaded => _isLoaded;
+
+  bool get hasPreference => _showWeighStations != null;
+
+  bool get shouldShowWeighStations => _showWeighStations ?? true;
+
+  bool? get showWeighStationsPreference => _showWeighStations;
+
+  Future<void> setShowWeighStations(bool value) async {
+    _showWeighStations = value;
+    _isLoaded = true;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_preferenceKey, value);
+  }
+
+  Future<void> clearPreference() async {
+    _showWeighStations = null;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_preferenceKey);
+  }
+
+  Future<void> _loadPreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.containsKey(_preferenceKey)) {
+      _showWeighStations = prefs.getBool(_preferenceKey);
+    }
+    _isLoaded = true;
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## Summary
- add a welcome overlay to guide users through language selection and weigh-station opt-in before showing the existing intro
- extract the intro overlay into its own widget and centralize weigh-station preference management via a shared controller
- surface an opt-in action on the Weigh stations page and localize all new copy

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69063d002ae0832db7838d26f7b32c41