### PR TITLE
Add optional speed limit field when creating a segment

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -53,6 +53,8 @@ class AppLocalizations {
       'createSegmentMissingFieldEndCoordinates': 'end coordinates',
       'createSegmentMissingFieldsDelimiter': ', ',
       'createSegmentMissingFieldsConjunction': 'and',
+      'createSegmentInvalidSpeedLimit':
+          'Please enter a valid speed limit using numbers only.',
       'createSegmentMapInstructionBody':
           'Drop or drag markers to adjust the start and end points. Coordinates are filled automatically as you move them.',
       'createSegmentMapInstructionTitle':
@@ -61,6 +63,8 @@ class AppLocalizations {
       'createSegmentNameLabel': 'Segment name',
       'createSegmentRoadNameHint': 'Road name',
       'createSegmentRoadNameLabel': 'Road name',
+      'createSegmentSpeedLimitHint': 'e.g. 90',
+      'createSegmentSpeedLimitLabel': 'Speed limit (km/h)',
       'createSegmentStartCoordinatesHint': '41.8626802,26.0873785',
       'createSegmentStartCoordinatesLabel': 'Start coordinates',
       'createSegmentStartLabel': 'Start',
@@ -470,6 +474,8 @@ class AppLocalizations {
       'createSegmentMissingFieldEndCoordinates': 'крайни координати',
       'createSegmentMissingFieldsDelimiter': ', ',
       'createSegmentMissingFieldsConjunction': 'и',
+      'createSegmentInvalidSpeedLimit':
+          'Моля, въведи валидно ограничение на скоростта, използвайки само числа.',
       'cancelAction': 'Отказ',
       'okAction': 'Добре',
       'deleteAction': 'Изтрий',
@@ -483,6 +489,8 @@ class AppLocalizations {
 'createSegmentNameLabel': 'Име на сегмента',
 'createSegmentRoadNameHint': 'Име на пътя',
 'createSegmentRoadNameLabel': 'Име на пътя',
+'createSegmentSpeedLimitHint': 'напр. 90',
+'createSegmentSpeedLimitLabel': 'Ограничение на скоростта (км/ч)',
 'createSegmentStartCoordinatesHint': '41.8626802,26.0873785',
 'createSegmentStartCoordinatesLabel': 'Начални координати',
 'createSegmentStartLabel': 'Начало',

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -220,6 +220,10 @@ class AppMessages {
       _l.translate('createSegmentRoadNameLabel');
   static String get createSegmentRoadNameHint =>
       _l.translate('createSegmentRoadNameHint');
+  static String get createSegmentSpeedLimitLabel =>
+      _l.translate('createSegmentSpeedLimitLabel');
+  static String get createSegmentSpeedLimitHint =>
+      _l.translate('createSegmentSpeedLimitHint');
   static String get createSegmentStartLabel =>
       _l.translate('createSegmentStartLabel');
   static String get createSegmentStartNameHint =>
@@ -254,6 +258,8 @@ class AppMessages {
       _l.translate('createSegmentMissingFieldsDelimiter');
   static String get createSegmentMissingFieldsConjunction =>
       _l.translate('createSegmentMissingFieldsConjunction');
+  static String get createSegmentInvalidSpeedLimit =>
+      _l.translate('createSegmentInvalidSpeedLimit');
   static String failedToLoadCameras(String error) =>
       _l.translate('failedToLoadCameras', {'error': error});
   static String get failedToAccessSegmentsMetadataFile =>

--- a/lib/features/segments/presentation/pages/create_segment_page.dart
+++ b/lib/features/segments/presentation/pages/create_segment_page.dart
@@ -24,6 +24,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
   static String? _cachedEndDisplayName;
   static String? _cachedStartCoordinates;
   static String? _cachedEndCoordinates;
+  static String? _cachedSpeedLimit;
 
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _roadNameController = TextEditingController();
@@ -31,6 +32,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
   final TextEditingController _endNameController = TextEditingController();
   final TextEditingController _startController = TextEditingController();
   final TextEditingController _endController = TextEditingController();
+  final TextEditingController _speedLimitController = TextEditingController();
   final FocusNode _nameFocusNode = FocusNode();
   final LocalSegmentsService _localSegmentsService = LocalSegmentsService();
   bool _persistDraftOnDispose = true;
@@ -58,6 +60,9 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     if (_cachedEndCoordinates != null) {
       _endController.text = _cachedEndCoordinates!;
     }
+    if (_cachedSpeedLimit != null) {
+      _speedLimitController.text = _cachedSpeedLimit!;
+    }
   }
 
   @override
@@ -69,6 +74,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
       _cachedEndDisplayName = _endNameController.text;
       _cachedStartCoordinates = _startController.text;
       _cachedEndCoordinates = _endController.text;
+      _cachedSpeedLimit = _speedLimitController.text;
     } else {
       _cachedName = null;
       _cachedRoadName = null;
@@ -76,6 +82,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
       _cachedEndDisplayName = null;
       _cachedStartCoordinates = null;
       _cachedEndCoordinates = null;
+      _cachedSpeedLimit = null;
     }
     _nameController.dispose();
     _roadNameController.dispose();
@@ -83,6 +90,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     _endNameController.dispose();
     _startController.dispose();
     _endController.dispose();
+    _speedLimitController.dispose();
     _nameFocusNode.dispose();
     super.dispose();
   }
@@ -205,6 +213,16 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
                                   label: AppMessages.createSegmentRoadNameLabel,
                                   hintText:
                                       AppMessages.createSegmentRoadNameHint,
+                                ),
+                              ),
+                              const SizedBox(height: 16),
+                              SegmentLabeledTextField(
+                                controller: _speedLimitController,
+                                label: AppMessages.createSegmentSpeedLimitLabel,
+                                hintText: AppMessages.createSegmentSpeedLimitHint,
+                                keyboardType:
+                                    const TextInputType.numberWithOptions(
+                                  decimal: true,
                                 ),
                               ),
                             ],
@@ -490,6 +508,22 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     }
 
     try {
+      final speedLimitText = _speedLimitController.text.trim();
+      double? speedLimitKph;
+      if (speedLimitText.isNotEmpty) {
+        final normalizedSpeedLimit =
+            speedLimitText.replaceAll(',', '.').replaceAll(' ', '');
+        final parsedSpeedLimit =
+            double.tryParse(normalizedSpeedLimit);
+        if (parsedSpeedLimit == null ||
+            !parsedSpeedLimit.isFinite ||
+            parsedSpeedLimit <= 0) {
+          _showSnackBar(AppMessages.createSegmentInvalidSpeedLimit);
+          return null;
+        }
+        speedLimitKph = parsedSpeedLimit;
+      }
+
       return _localSegmentsService.prepareDraft(
         name: _nameController.text,
         roadName: _roadNameController.text,
@@ -498,6 +532,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
         startCoordinates: _startController.text,
         endCoordinates: _endController.text,
         isPublic: isPublic,
+        speedLimitKph: speedLimitKph,
         routeGeoJson: _routeGeoJson,
       );
     } on LocalSegmentsServiceException catch (error) {
@@ -539,6 +574,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     _cachedEndDisplayName = null;
     _cachedStartCoordinates = null;
     _cachedEndCoordinates = null;
+    _cachedSpeedLimit = null;
     _routeGeoJson = null;
   }
 
@@ -549,6 +585,7 @@ class _CreateSegmentPageState extends State<CreateSegmentPage> {
     _cachedEndDisplayName = _endNameController.text;
     _cachedStartCoordinates = _startController.text;
     _cachedEndCoordinates = _endController.text;
+    _cachedSpeedLimit = _speedLimitController.text;
   }
 }
 

--- a/lib/features/segments/presentation/widgets/segment_labeled_text_field.dart
+++ b/lib/features/segments/presentation/widgets/segment_labeled_text_field.dart
@@ -9,12 +9,14 @@ class SegmentLabeledTextField extends StatelessWidget {
     required this.label,
     this.hintText,
     this.focusNode,
+    this.keyboardType,
   });
 
   final TextEditingController controller;
   final String label;
   final String? hintText;
   final FocusNode? focusNode;
+  final TextInputType? keyboardType;
 
   @visibleForTesting
   static final RegExp allowedCharactersPattern = RegExp(
@@ -27,6 +29,7 @@ class SegmentLabeledTextField extends StatelessWidget {
     return TextField(
       controller: controller,
       focusNode: focusNode,
+      keyboardType: keyboardType,
       inputFormatters: [
         FilteringTextInputFormatter.allow(allowedCharactersPattern),
       ],


### PR DESCRIPTION
## Summary
- add an optional speed limit input to the create segment form and cache its draft value
- validate and forward the speed limit when building segment drafts for local saves or public submissions
- extend English and Bulgarian localizations and messages for the new input and validation feedback

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690643c289d4832d89f2a57a05880096