### PR TITLE
Persist intro overlay dismissal and remove close button

### DIFF
--- a/lib/features/map/presentation/pages/map/widgets/map_intro_overlay.dart
+++ b/lib/features/map/presentation/pages/map/widgets/map_intro_overlay.dart
@@ -223,12 +223,6 @@ class _IntroContentCard extends StatelessWidget {
                     ],
                   ),
                 ),
-                const SizedBox(width: 12),
-                IconButton(
-                  onPressed: onDismiss,
-                  tooltip: MaterialLocalizations.of(context).closeButtonLabel,
-                  icon: const Icon(Icons.close),
-                ),
               ],
             ),
             const SizedBox(height: 28),


### PR DESCRIPTION
## Summary
- remove the close button from the introduction overlay header so the user dismisses it via the primary action
- persist the introduction overlay completion flag so the flow only appears automatically the first time after setup while keeping the manual trigger available

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690647786f98832d92b2c20660c10b2a