### PR TITLE
Add delete account flow to profile page

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -213,6 +213,19 @@ class AppLocalizations {
       'passwordsDoNotMatch': 'Passwords do not match',
       'profile': 'Profile',
       'profileSubtitle': 'Manage your TollCam account and preferences.',
+      'profileDangerZoneTitle': 'Danger zone',
+      'profileDeleteAccountDescription':
+          'Delete your account and all associated data.',
+      'profileDeleteAccountAction': 'Delete account',
+      'profileDeleteAccountConfirmTitle': 'Delete account?',
+      'profileDeleteAccountConfirmBody':
+          'Type DELETE to confirm. This action cannot be undone.',
+      'profileDeleteAccountConfirmLabel': 'Type DELETE to confirm',
+      'profileDeleteAccountConfirmHelper':
+          'This will permanently remove your account.',
+      'profileDeleteAccountMismatch':
+          'Please type DELETE in all caps to continue.',
+      'profileDeleteAccountSuccess': 'Your account was deleted.',
       'publicSharingUnavailable':
           'Public segment sharing is currently unavailable.',
       'publicSharingUnavailableShort': 'Public sharing is not available.',
@@ -406,6 +419,8 @@ class AppLocalizations {
       'unableToDetermineLoggedInAccountRetry':
           'Unable to determine the logged in account. Please sign in again.',
       'unableToLogOutTryAgain': 'Unable to log out. Please try again.',
+      'unableToDeleteAccountTryAgain':
+          'Unable to delete your account. Please try again.',
       'unableToWithdrawSubmission': 'Unable to withdraw the public submission.',
       'unexpectedErrorCancellingSubmission':
           'Unexpected error while cancelling the public submission.',
@@ -564,6 +579,20 @@ class AppLocalizations {
 'passwordLabel': 'Парола',
 'profile': 'Профил',
 'profileSubtitle': 'Управлявай акаунта и настройките си в TollCam.',
+'profileDangerZoneTitle': 'Опасна зона',
+'profileDeleteAccountDescription':
+'Изтрий акаунта си и всички свързани данни.',
+'profileDeleteAccountAction': 'Изтрий акаунта',
+'profileDeleteAccountConfirmTitle': 'Да изтрия ли акаунта?',
+'profileDeleteAccountConfirmBody':
+'Напиши DELETE, за да потвърдиш. Това действие е необратимо.',
+'profileDeleteAccountConfirmLabel': 'Въведи DELETE за потвърждение',
+'profileDeleteAccountConfirmHelper':
+'След изтриване няма връщане.',
+'profileDeleteAccountMismatch': 'Моля, напиши DELETE с главни букви.',
+'profileDeleteAccountSuccess': 'Акаунтът ти беше изтрит.',
+'unableToDeleteAccountTryAgain':
+'Неуспешно изтриване на акаунта. Опитай отново.',
 'faceTravelDirection': 'По посока на движение',
 'northUp': 'Север нагоре',
 'recenter': 'Центрирай Екрана',
@@ -876,6 +905,23 @@ class AppLocalizations {
   String get confirmPasswordLabel => _value('confirmPasswordLabel');
   String get fullNameLabel => _value('fullNameLabel');
   String get profileSubtitle => _value('profileSubtitle');
+  String get profileDangerZoneTitle => _value('profileDangerZoneTitle');
+  String get profileDeleteAccountDescription =>
+      _value('profileDeleteAccountDescription');
+  String get profileDeleteAccountAction =>
+      _value('profileDeleteAccountAction');
+  String get profileDeleteAccountConfirmTitle =>
+      _value('profileDeleteAccountConfirmTitle');
+  String get profileDeleteAccountConfirmBody =>
+      _value('profileDeleteAccountConfirmBody');
+  String get profileDeleteAccountConfirmLabel =>
+      _value('profileDeleteAccountConfirmLabel');
+  String get profileDeleteAccountConfirmHelper =>
+      _value('profileDeleteAccountConfirmHelper');
+  String get profileDeleteAccountMismatch =>
+      _value('profileDeleteAccountMismatch');
+  String get profileDeleteAccountSuccess =>
+      _value('profileDeleteAccountSuccess');
   String get unknownUserLabel => _value('unknownUserLabel');
   String get averageSpeedStartTooltip => _value('averageSpeedStartTooltip');
   String get averageSpeedResetTooltip => _value('averageSpeedResetTooltip');

--- a/lib/core/app_messages.dart
+++ b/lib/core/app_messages.dart
@@ -167,6 +167,8 @@ class AppMessages {
       _l.translate('accountCreatedCheckEmail');
   static String get unableToLogOutTryAgain =>
       _l.translate('unableToLogOutTryAgain');
+  static String get unableToDeleteAccountTryAgain =>
+      _l.translate('unableToDeleteAccountTryAgain');
   static String get authenticationNotConfigured =>
       _l.translate('authenticationNotConfigured');
   static String get backgroundTrackingNotificationRationale =>

--- a/lib/features/auth/presentation/pages/profile_page.dart
+++ b/lib/features/auth/presentation/pages/profile_page.dart
@@ -44,6 +44,11 @@ class ProfilePage extends StatelessWidget {
                 textAlign: TextAlign.center,
               ),
               const Spacer(),
+              _DangerZoneSection(
+                onDeleteAccount: () =>
+                    _handleDeleteAccountPressed(context, localizations),
+              ),
+              const SizedBox(height: 24),
               ElevatedButton(
                 onPressed: () async {
                   final messenger = ScaffoldMessenger.of(context);
@@ -70,6 +75,165 @@ class ProfilePage extends StatelessWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  Future<void> _handleDeleteAccountPressed(
+    BuildContext context,
+    AppLocalizations localizations,
+  ) async {
+    final confirmed = await _showDeleteAccountDialog(context, localizations);
+    if (confirmed != true) {
+      return;
+    }
+
+    final navigator = Navigator.of(context);
+    final rootNavigator = Navigator.of(context, rootNavigator: true);
+    final messenger = ScaffoldMessenger.of(context);
+    var loadingClosed = false;
+    void closeLoadingDialog() {
+      if (!loadingClosed) {
+        rootNavigator.pop();
+        loadingClosed = true;
+      }
+    }
+
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => const Center(child: CircularProgressIndicator()),
+    );
+
+    try {
+      await context.read<AuthController>().deleteAccount();
+      closeLoadingDialog();
+      messenger.showSnackBar(
+        SnackBar(content: Text(localizations.profileDeleteAccountSuccess)),
+      );
+      navigator.popUntil(ModalRoute.withName(AppRoutes.map));
+    } on AuthFailure catch (error) {
+      closeLoadingDialog();
+      messenger.showSnackBar(SnackBar(content: Text(error.message)));
+    } catch (error, stackTrace) {
+      closeLoadingDialog();
+      debugPrint('Delete account error: $error\n$stackTrace');
+      messenger.showSnackBar(
+        SnackBar(content: Text(AppMessages.unableToDeleteAccountTryAgain)),
+      );
+    }
+  }
+
+  Future<bool?> _showDeleteAccountDialog(
+    BuildContext context,
+    AppLocalizations localizations,
+  ) async {
+    final controller = TextEditingController();
+    String? errorText;
+    try {
+      return showDialog<bool>(
+        context: context,
+        builder: (dialogContext) {
+          return StatefulBuilder(
+            builder: (context, setState) {
+              return AlertDialog(
+                title: Text(localizations.profileDeleteAccountConfirmTitle),
+                content: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(localizations.profileDeleteAccountConfirmBody),
+                    const SizedBox(height: 16),
+                    TextField(
+                      controller: controller,
+                      autofocus: true,
+                      decoration: InputDecoration(
+                        labelText:
+                            localizations.profileDeleteAccountConfirmLabel,
+                        helperText:
+                            localizations.profileDeleteAccountConfirmHelper,
+                        errorText: errorText,
+                      ),
+                    ),
+                  ],
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(false),
+                    child: Text(localizations.cancelAction),
+                  ),
+                  FilledButton(
+                    style: FilledButton.styleFrom(
+                      backgroundColor:
+                          Theme.of(context).colorScheme.error,
+                      foregroundColor:
+                          Theme.of(context).colorScheme.onError,
+                    ),
+                    onPressed: () {
+                      final input = controller.text.trim();
+                      if (input.toUpperCase() == 'DELETE') {
+                        Navigator.of(context).pop(true);
+                      } else {
+                        setState(() {
+                          errorText =
+                              localizations.profileDeleteAccountMismatch;
+                        });
+                      }
+                    },
+                    child: Text(localizations.deleteAction),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+      );
+    } finally {
+      controller.dispose();
+    }
+  }
+}
+
+class _DangerZoneSection extends StatelessWidget {
+  const _DangerZoneSection({required this.onDeleteAccount});
+
+  final VoidCallback onDeleteAccount;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final localizations = AppLocalizations.of(context);
+    final colorScheme = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.error.withOpacity(0.4)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            localizations.profileDangerZoneTitle,
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: colorScheme.error,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            localizations.profileDeleteAccountDescription,
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.error,
+              foregroundColor: colorScheme.onError,
+            ),
+            onPressed: onDeleteAccount,
+            child: Text(localizations.profileDeleteAccountAction),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add localized strings and messages for account deletion workflow
- extend AuthController with a Supabase deleteAccount helper
- update the profile page with a danger zone delete button, confirmation dialog, and progress feedback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69071b5d0808832d9c0c850887262913