### PR TITLE
Fix delete account confirmation dialog state handling

### DIFF
--- a/lib/features/auth/presentation/pages/profile_page.dart
+++ b/lib/features/auth/presentation/pages/profile_page.dart
@@ -128,72 +128,70 @@ class ProfilePage extends StatelessWidget {
     BuildContext context,
     AppLocalizations localizations,
   ) async {
-    final controller = TextEditingController();
+    String input = '';
     String? errorText;
-    try {
-      final result = await showDialog<bool>(
-        context: context,
-        builder: (dialogContext) {
-          return StatefulBuilder(
-            builder: (context, setState) {
-              return AlertDialog(
-                title: Text(localizations.profileDeleteAccountConfirmTitle),
-                content: SingleChildScrollView(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(localizations.profileDeleteAccountConfirmBody),
-                      const SizedBox(height: 16),
-                      TextField(
-                        controller: controller,
-                        autofocus: true,
-                        decoration: InputDecoration(
-                          labelText:
-                              localizations.profileDeleteAccountConfirmLabel,
-                          helperText:
-                              localizations.profileDeleteAccountConfirmHelper,
-                          errorText: errorText,
-                        ),
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return AlertDialog(
+              title: Text(localizations.profileDeleteAccountConfirmTitle),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(localizations.profileDeleteAccountConfirmBody),
+                    const SizedBox(height: 16),
+                    TextField(
+                      autofocus: true,
+                      onChanged: (value) => setState(() {
+                        input = value;
+                        errorText = null;
+                      }),
+                      decoration: InputDecoration(
+                        labelText:
+                            localizations.profileDeleteAccountConfirmLabel,
+                        helperText:
+                            localizations.profileDeleteAccountConfirmHelper,
+                        errorText: errorText,
                       ),
-                    ],
-                  ),
-                ),
-                actions: [
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(false),
-                    child: Text(localizations.cancelAction),
-                  ),
-                  FilledButton(
-                    style: FilledButton.styleFrom(
-                      backgroundColor:
-                          Theme.of(context).colorScheme.error,
-                      foregroundColor:
-                          Theme.of(context).colorScheme.onError,
                     ),
-                    onPressed: () {
-                      final input = controller.text.trim();
-                      if (input.toUpperCase() == 'DELETE') {
-                        Navigator.of(context).pop(true);
-                      } else {
-                        setState(() {
-                          errorText =
-                              localizations.profileDeleteAccountMismatch;
-                        });
-                      }
-                    },
-                    child: Text(localizations.deleteAction),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: Text(localizations.cancelAction),
+                ),
+                FilledButton(
+                  style: FilledButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.error,
+                    foregroundColor: Theme.of(context).colorScheme.onError,
                   ),
-                ],
-              );
-            },
-          );
-        },
-      );
-      return result;
-    } finally {
-      controller.dispose();
-    }
+                  onPressed: () {
+                    if (input.trim().toUpperCase() == 'DELETE') {
+                      Navigator.of(context).pop(true);
+                    } else {
+                      setState(() {
+                        errorText =
+                            localizations.profileDeleteAccountMismatch;
+                      });
+                    }
+                  },
+                  child: Text(localizations.deleteAction),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    return result;
   }
 }
 


### PR DESCRIPTION
## Summary
- update the delete account confirmation dialog to rely on local state instead of a disposed TextEditingController
- clear the validation error when the user edits the confirmation text to improve UX

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69075c6e182c832d90db983beb09b95d