### PR TITLE
Keep heading compass FAB visible while following heading

### DIFF
--- a/lib/features/map/presentation/pages/map/widgets/map_fab_column.dart
+++ b/lib/features/map/presentation/pages/map/widgets/map_fab_column.dart
@@ -7,14 +7,12 @@ class MapFabColumn extends StatelessWidget {
   const MapFabColumn({
     super.key,
     required this.followUser,
-    required this.followHeading,
     required this.onToggleHeading,
     required this.onResetView,
     this.headingDegrees,
   });
 
   final bool followUser;
-  final bool followHeading;
   final VoidCallback onToggleHeading;
   final VoidCallback onResetView;
   final double? headingDegrees;
@@ -23,24 +21,26 @@ class MapFabColumn extends StatelessWidget {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context);
     final palette = AppColors.of(context);
+    final bool showRecenterButton = !followUser;
+
     final children = <Widget>[
-      if (!followHeading)
-        _MapMiniFab(
-          heroTag: 'heading_btn',
-          tooltip: localizations.faceTravelDirection,
-          onPressed: onToggleHeading,
-          child: _CompassNeedle(
-            headingDegrees: headingDegrees,
-          ),
+      _MapMiniFab(
+        heroTag: 'heading_btn',
+        tooltip: localizations.faceTravelDirection,
+        onPressed: onToggleHeading,
+        child: _CompassNeedle(
+          headingDegrees: headingDegrees,
         ),
-      if (!followHeading && !followUser) const SizedBox(height: 12),
-      if (!followUser)
+      ),
+      if (showRecenterButton) ...[
+        const SizedBox(height: 12),
         _MapMiniFab(
           heroTag: 'recenter_btn',
           tooltip: localizations.recenter,
           onPressed: onResetView,
           child: Icon(Icons.my_location_outlined, color: palette.onSurface),
         ),
+      ],
     ];
 
     return Column(

--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -1434,7 +1434,6 @@ class _MapPageState extends State<MapPage>
           ),
           child: MapFabColumn(
             followUser: _followUser,
-            followHeading: _followHeading,
             headingDegrees: _userHeading,
             onToggleHeading: _toggleFollowHeading,
             onResetView: _onResetView,


### PR DESCRIPTION
## Summary
- keep the heading compass floating action button visible even while following the user's heading
- reuse the heading control to reset the map orientation back to north on subsequent taps

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6907667a3574832d936748d1f4b75a83