### PR TITLE
Keep map welcome overlay text in English

### DIFF
--- a/lib/features/map/presentation/pages/map/widgets/map_welcome_overlays.dart
+++ b/lib/features/map/presentation/pages/map/widgets/map_welcome_overlays.dart
@@ -25,6 +25,10 @@ class MapWelcomeOverlay extends StatelessWidget {
     final theme = Theme.of(context);
     final palette = AppColors.of(context);
     final localizations = AppLocalizations.of(context);
+    final englishLocalizations =
+        localizations.locale.languageCode == 'en'
+            ? localizations
+            : AppLocalizations(const Locale('en'));
     final bool isDark = theme.brightness == Brightness.dark;
 
     final List<LanguageOption> availableOptions = languageOptions
@@ -85,13 +89,13 @@ class MapWelcomeOverlay extends StatelessWidget {
                             mainAxisSize: MainAxisSize.min,
                             children: [
                               Text(
-                                localizations.mapWelcomeTitle,
+                                englishLocalizations.mapWelcomeTitle,
                                 style: theme.textTheme.headlineSmall
                                     ?.copyWith(fontWeight: FontWeight.w700),
                               ),
                               const SizedBox(height: 24),
                               Text(
-                                localizations.mapWelcomeLanguagePrompt,
+                                englishLocalizations.mapWelcomeLanguagePrompt,
                                 style: theme.textTheme.titleMedium
                                     ?.copyWith(fontWeight: FontWeight.w600),
                               ),
@@ -116,7 +120,7 @@ class MapWelcomeOverlay extends StatelessWidget {
                                 alignment: Alignment.centerRight,
                                 child: FilledButton(
                                   onPressed: onContinue,
-                                  child: Text(localizations.continueLabel),
+                                  child: Text(englishLocalizations.continueLabel),
                                 ),
                               ),
                             ],


### PR DESCRIPTION
## Summary
- ensure the map welcome overlay always displays English text even after selecting another language

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69076b61fab8832d97f291058b3fbcf3