### PR TITLE
Filter upcoming segments by heading

### DIFF
--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -652,12 +652,16 @@ class _MapPageState extends State<MapPage>
         ? 0
         : _segmentUiService.nearestUpcomingSegmentDistance(
             segEvent.debugData.candidatePaths,
+            headingDegrees: _userHeading,
+            speedKph: _speedKmh,
           );
     final String? progressLabel = _segmentUiService.buildSegmentProgressLabel(
       event: segEvent,
       activePath: activePath,
       localizations: AppLocalizations.of(context),
       cueService: _upcomingSegmentCueService,
+      headingDegrees: _userHeading,
+      speedKph: _speedKmh,
     );
 
     final double? exitAverage = _currentSegmentController.updateWithEvent(
@@ -701,6 +705,8 @@ class _MapPageState extends State<MapPage>
     final String status = _foregroundNotificationService.buildStatus(
       event: event,
       avgController: _avgCtrl,
+      headingDegrees: _userHeading,
+      speedKph: _speedKmh,
     );
     if (status == _lastNotificationStatus) {
       return;

--- a/lib/features/map/services/foreground_notification_service.dart
+++ b/lib/features/map/services/foreground_notification_service.dart
@@ -12,6 +12,8 @@ class ForegroundNotificationService {
   String buildStatus({
     required SegmentTrackerEvent event,
     required AverageSpeedController avgController,
+    double? headingDegrees,
+    double? speedKph,
   }) {
     final String? activeId = event.activeSegmentId;
     if (activeId != null) {
@@ -24,7 +26,11 @@ class ForegroundNotificationService {
     }
 
     final double? distance = _segmentUiService
-        .nearestUpcomingSegmentDistance(event.debugData.candidatePaths);
+        .nearestUpcomingSegmentDistance(
+      event.debugData.candidatePaths,
+      headingDegrees: headingDegrees,
+      speedKph: speedKph,
+    );
     if (distance != null && distance <= 1500) {
       final int meters = distance.round();
       return '$meters m to segment start';

--- a/lib/features/map/services/segment_ui_service.dart
+++ b/lib/features/map/services/segment_ui_service.dart
@@ -1,3 +1,6 @@
+import 'dart:math' as math;
+
+import 'package:latlong2/latlong.dart';
 import 'package:toll_cam_finder/app/localization/app_localizations.dart';
 import 'package:toll_cam_finder/features/segments/domain/tracking/segment_tracker.dart';
 
@@ -21,20 +24,26 @@ class SegmentUiService {
         _firstPathMatching(paths, (p) => p.isActive);
   }
 
+  static const double _forwardHeadingToleranceDegrees = 70.0;
+  static const double _headingFlipThresholdDegrees = 135.0;
+  static const double _slowSpeedThresholdKph = 10.0;
+
   String? buildSegmentProgressLabel({
     required SegmentTrackerEvent event,
     required SegmentDebugPath? activePath,
     required AppLocalizations localizations,
-    required UpcomingSegmentCueService cueService,
+    UpcomingSegmentCueService? cueService,
+    double? headingDegrees,
+    double? speedKph,
   }) {
     final Iterable<SegmentDebugPath> paths = event.debugData.candidatePaths;
     if (paths.isEmpty) {
-      cueService.reset();
+      cueService?.reset();
       return null;
     }
 
     if (event.activeSegmentId != null) {
-      cueService.reset();
+      cueService?.reset();
       final SegmentDebugPath? path =
           activePath ?? resolveActiveSegmentPath(paths, event);
 
@@ -59,8 +68,14 @@ class SegmentUiService {
       return null;
     }
 
+    final List<SegmentDebugPath> filteredPaths = _filterCandidatesByHeading(
+      paths,
+      headingDegrees: headingDegrees,
+      speedKph: speedKph,
+    );
+
     SegmentDebugPath? upcoming;
-    for (final path in paths) {
+    for (final path in filteredPaths) {
       final double startDist = path.startDistanceMeters;
       if (!startDist.isFinite) continue;
       if (startDist <= 500) {
@@ -71,12 +86,12 @@ class SegmentUiService {
     }
 
     if (upcoming == null) {
-      cueService.reset();
+      cueService?.reset();
       return null;
     }
 
     final double distance = upcoming.startDistanceMeters;
-    cueService.updateCue(upcoming);
+    cueService?.updateCue(upcoming);
     if (distance >= 1000) {
       return localizations.translate(
         'segmentProgressStartKilometers',
@@ -92,9 +107,18 @@ class SegmentUiService {
     return localizations.translate('segmentProgressStartNearby');
   }
 
-  double? nearestUpcomingSegmentDistance(Iterable<SegmentDebugPath> paths) {
+  double? nearestUpcomingSegmentDistance(
+    Iterable<SegmentDebugPath> paths, {
+    double? headingDegrees,
+    double? speedKph,
+  }) {
+    final List<SegmentDebugPath> filteredPaths = _filterCandidatesByHeading(
+      paths,
+      headingDegrees: headingDegrees,
+      speedKph: speedKph,
+    );
     double? closest;
-    for (final SegmentDebugPath path in paths) {
+    for (final SegmentDebugPath path in filteredPaths) {
       final double distance = path.startDistanceMeters;
       if (!distance.isFinite || distance < 0) continue;
       if (closest == null || distance < closest) {
@@ -102,6 +126,99 @@ class SegmentUiService {
       }
     }
     return closest;
+  }
+
+  List<SegmentDebugPath> _filterCandidatesByHeading(
+    Iterable<SegmentDebugPath> paths, {
+    double? headingDegrees,
+    double? speedKph,
+  }) {
+    final List<SegmentDebugPath> candidates =
+        List<SegmentDebugPath>.from(paths, growable: false);
+    if (candidates.isEmpty) {
+      return const <SegmentDebugPath>[];
+    }
+
+    if (headingDegrees == null) {
+      return candidates;
+    }
+
+    if (speedKph != null && speedKph < _slowSpeedThresholdKph) {
+      return candidates;
+    }
+
+    bool shouldFallback = false;
+    final List<SegmentDebugPath> filtered = <SegmentDebugPath>[];
+    for (final SegmentDebugPath path in candidates) {
+      final double? bearing = _forwardBearing(path.polyline);
+      if (bearing == null) {
+        filtered.add(path);
+        continue;
+      }
+
+      final double delta =
+          _minimalHeadingDeltaDegrees(headingDegrees, bearing);
+      if (delta >= _headingFlipThresholdDegrees) {
+        shouldFallback = true;
+        break;
+      }
+
+      if (delta <= _forwardHeadingToleranceDegrees) {
+        filtered.add(path);
+      }
+    }
+
+    if (shouldFallback || filtered.isEmpty) {
+      return candidates;
+    }
+
+    return filtered;
+  }
+
+  double? _forwardBearing(List<LatLng> polyline) {
+    if (polyline.length < 2) {
+      return null;
+    }
+
+    for (int i = 0; i < polyline.length - 1; i++) {
+      final LatLng current = polyline[i];
+      final LatLng next = polyline[i + 1];
+      final double? bearing = _bearingBetween(current, next);
+      if (bearing != null) {
+        return bearing;
+      }
+    }
+    return null;
+  }
+
+  double? _bearingBetween(LatLng from, LatLng to) {
+    final double lat1 = from.latitude * math.pi / 180.0;
+    final double lat2 = to.latitude * math.pi / 180.0;
+    final double dLon = (to.longitude - from.longitude) * math.pi / 180.0;
+
+    if (dLon.abs() <= 1e-9 && (lat2 - lat1).abs() <= 1e-9) {
+      return null;
+    }
+
+    final double y = math.sin(dLon) * math.cos(lat2);
+    final double x = math.cos(lat1) * math.sin(lat2) -
+        math.sin(lat1) * math.cos(lat2) * math.cos(dLon);
+
+    final double bearingRad = math.atan2(y, x);
+    final double bearingDeg = bearingRad * 180.0 / math.pi;
+    final double normalized = (bearingDeg + 360.0) % 360.0;
+    return normalized.isFinite ? normalized : null;
+  }
+
+  double _minimalHeadingDeltaDegrees(double a, double b) {
+    double diff = (a - b).abs();
+    while (diff > 360) {
+      diff -= 360;
+    }
+    if (diff > 180) {
+      diff = 360 - diff;
+    }
+    return diff.abs();
   }
 
   SegmentDebugPath? _firstPathMatching(

--- a/test/features/map/services/segment_ui_service_test.dart
+++ b/test/features/map/services/segment_ui_service_test.dart
@@ -1,0 +1,164 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:toll_cam_finder/app/localization/app_localizations.dart';
+import 'package:toll_cam_finder/core/spatial/segment_geometry.dart';
+import 'package:toll_cam_finder/features/map/services/segment_ui_service.dart';
+import 'package:toll_cam_finder/features/segments/domain/tracking/segment_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const double forwardStartDistance = 120;
+  const double reverseStartDistance = 30;
+
+  SegmentTrackerEvent _eventWithCandidates(List<SegmentDebugPath> candidates) {
+    return SegmentTrackerEvent(
+      startedSegment: false,
+      endedSegment: true,
+      activeSegmentId: null,
+      activeSegmentSpeedLimitKph: null,
+      activeSegmentLengthMeters: null,
+      completedSegmentLengthMeters: null,
+      debugData: SegmentTrackerDebugData(
+        isReady: true,
+        querySquare: const [],
+        boundingCandidates: const <SegmentGeometry>[],
+        candidatePaths: candidates,
+        startGeofenceRadius: 0,
+        endGeofenceRadius: 0,
+      ),
+    );
+  }
+
+  SegmentDebugPath _forwardCandidate() {
+    return const SegmentDebugPath(
+      id: 'forward',
+      polyline: <LatLng>[
+        LatLng(0, 0),
+        LatLng(0.001, 0),
+      ],
+      distanceMeters: 15,
+      startDistanceMeters: forwardStartDistance,
+      remainingDistanceMeters: 800,
+      isWithinTolerance: true,
+      startHit: false,
+      endHit: false,
+      isActive: false,
+      isDetailed: true,
+    );
+  }
+
+  SegmentDebugPath _reverseCandidate() {
+    return const SegmentDebugPath(
+      id: 'reverse',
+      polyline: <LatLng>[
+        LatLng(0, 0),
+        LatLng(-0.001, 0),
+      ],
+      distanceMeters: 12,
+      startDistanceMeters: reverseStartDistance,
+      remainingDistanceMeters: 600,
+      isWithinTolerance: true,
+      startHit: false,
+      endHit: false,
+      isActive: false,
+      isDetailed: true,
+    );
+  }
+
+  group('SegmentUiService heading filtering', () {
+    late SegmentUiService service;
+    late AppLocalizations localizations;
+
+    setUp(() {
+      service = SegmentUiService();
+      localizations = AppLocalizations(const Locale('en'));
+    });
+
+    test('prefers forward candidate while heading maintained', () {
+      final SegmentTrackerEvent event =
+          _eventWithCandidates(<SegmentDebugPath>[
+        _forwardCandidate(),
+        _reverseCandidate(),
+      ]);
+
+      final String? label = service.buildSegmentProgressLabel(
+        event: event,
+        activePath: null,
+        localizations: localizations,
+        cueService: null,
+        headingDegrees: 0,
+        speedKph: 60,
+      );
+
+      expect(label, isNotNull);
+      expect(label!, contains(forwardStartDistance.toStringAsFixed(0)));
+
+      final double? distance = service.nearestUpcomingSegmentDistance(
+        event.debugData.candidatePaths,
+        headingDegrees: 0,
+        speedKph: 60,
+      );
+
+      expect(distance, forwardStartDistance);
+    });
+
+    test('falls back when heading reverses', () {
+      final SegmentTrackerEvent event =
+          _eventWithCandidates(<SegmentDebugPath>[
+        _forwardCandidate(),
+        _reverseCandidate(),
+      ]);
+
+      final String? label = service.buildSegmentProgressLabel(
+        event: event,
+        activePath: null,
+        localizations: localizations,
+        cueService: null,
+        headingDegrees: 180,
+        speedKph: 55,
+      );
+
+      expect(label, isNotNull);
+      expect(label!, contains(reverseStartDistance.toStringAsFixed(0)));
+
+      final double? distance = service.nearestUpcomingSegmentDistance(
+        event.debugData.candidatePaths,
+        headingDegrees: 180,
+        speedKph: 55,
+      );
+
+      expect(distance, reverseStartDistance);
+    });
+
+    test('falls back when travelling slowly', () {
+      final SegmentTrackerEvent event =
+          _eventWithCandidates(<SegmentDebugPath>[
+        _forwardCandidate(),
+        _reverseCandidate(),
+      ]);
+
+      final String? label = service.buildSegmentProgressLabel(
+        event: event,
+        activePath: null,
+        localizations: localizations,
+        cueService: null,
+        headingDegrees: 0,
+        speedKph: 5,
+      );
+
+      expect(label, isNotNull);
+      expect(label!, contains(reverseStartDistance.toStringAsFixed(0)));
+
+      final double? distance = service.nearestUpcomingSegmentDistance(
+        event.debugData.candidatePaths,
+        headingDegrees: 0,
+        speedKph: 5,
+      );
+
+      expect(distance, reverseStartDistance);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- thread the current heading and speed into the segment UI helpers used by the map page and foreground notification
- filter candidate segments by their forward bearing while the driver maintains heading, falling back when reversing or slowing
- add unit tests that cover leaving a segment, the U-turn fallback, and slow-speed behaviour

## Testing
- flutter test test/features/map/services/segment_ui_service_test.dart *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69076d5a8638832d94fa0c2c2fc5cb84