### PR TITLE
Add intro instructions for speed colors and voice guidance

### DIFF
--- a/lib/app/localization/app_localizations.dart
+++ b/lib/app/localization/app_localizations.dart
@@ -325,6 +325,31 @@ class AppLocalizations {
       'introTitle': 'Welcome to TollCam',
       'introSubtitle':
           'Here\'s how to read the dashboard and what you can do from the menu.',
+      'introInstructionsTitle': 'How guidance keeps you informed',
+      'introInstructionsAverageTitle': 'Average speed indicator',
+      'introInstructionsAverageBody':
+          'We compare your running average with the allowed average. The number updates color instantly so you know when you\'re safe or need to adjust:',
+      'introInstructionsAverageStateGood':
+          'Green when you\'re safely under the limit.',
+      'introInstructionsAverageStateWarning':
+          'Amber when you are close to the limit—ease off to stay compliant.',
+      'introInstructionsAverageStateOver':
+          'Red when you exceed the allowed average. Slow down until it returns to amber or green.',
+      'introInstructionsVoiceTitle': 'Voice alerts along the segment',
+      'introInstructionsVoiceBody':
+          'Audio prompts guide you without taking your eyes off the road:',
+      'introInstructionsVoiceEnterTitle': 'Segment entry',
+      'introInstructionsVoiceEnterBody':
+          'We greet you and confirm the average speed monitoring has started.',
+      'introInstructionsVoiceSpeedTitle': 'Average speed changes',
+      'introInstructionsVoiceSpeedBody':
+          'Optional reminders play whenever the indicator changes color so you can react immediately.',
+      'introInstructionsVoiceApproachTitle': 'Approaching the finish',
+      'introInstructionsVoiceApproachBody':
+          'A heads-up plays in the final stretch so you can hold a safe pace.',
+      'introInstructionsVoiceExitTitle': 'Segment complete',
+      'introInstructionsVoiceExitBody':
+          'We close the loop with your final average and whether you stayed within the limit.',
       'introMetricsTitle': 'Dashboard metrics',
       'introMetricCurrentSpeedTitle': 'Current speed',
       'introMetricCurrentSpeedBody':
@@ -679,9 +704,34 @@ class AppLocalizations {
 'segmentMetricsDistanceToEnd': 'До края',
 'segmentMetricsSafeSpeed': 'Скорост без фиш',
 'introTitle': 'Добре дошли в TollCam',
-'introSubtitle':
-'Научете как да разчитате таблото и какво можете да правите от менюто.',
-'introMetricsTitle': 'Показатели на таблото',
+      'introSubtitle':
+          'Научете как да разчитате таблото и какво можете да правите от менюто.',
+      'introInstructionsTitle': 'Как ви информираме по време на път',
+      'introInstructionsAverageTitle': 'Показател за средна скорост',
+      'introInstructionsAverageBody':
+          'Сравняваме текущата ви средна скорост с допустимата. Числото сменя цвета си мигновено, за да знаете кога сте в безопасност и кога да намалите:',
+      'introInstructionsAverageStateGood':
+          'Зелено – когато сте под лимита и имате запас.',
+      'introInstructionsAverageStateWarning':
+          'Кехлибарено – когато сте близо до границата. Отпуснете педала, за да останете в норма.',
+      'introInstructionsAverageStateOver':
+          'Червено – когато надвишавате допустимата средна скорост. Намалете, докато се върне в жълто или зелено.',
+      'introInstructionsVoiceTitle': 'Гласови съобщения в сегмента',
+      'introInstructionsVoiceBody':
+          'Гласовите подсказки ви насочват, без да сваляте очи от пътя:',
+      'introInstructionsVoiceEnterTitle': 'При влизане в сегмента',
+      'introInstructionsVoiceEnterBody':
+          'Поздравяваме ви и потвърждаваме, че следим средната скорост.',
+      'introInstructionsVoiceSpeedTitle': 'Промяна на средната скорост',
+      'introInstructionsVoiceSpeedBody':
+          'По избор получавате напомняния всеки път, когато показателят смени цвят, за да реагирате навреме.',
+      'introInstructionsVoiceApproachTitle': 'При наближаване на края',
+      'introInstructionsVoiceApproachBody':
+          'Напомняне в последните метри, за да задържите безопасно темпо.',
+      'introInstructionsVoiceExitTitle': 'Край на сегмента',
+      'introInstructionsVoiceExitBody':
+          'Финално съобщение със средната ви скорост и дали сте останали в допустимото.',
+      'introMetricsTitle': 'Показатели на таблото',
 'introMetricCurrentSpeedTitle': 'Текуща скорост',
 'introMetricCurrentSpeedBody':
 'Показва моментната ви GPS скорост, за да знаете с каква скорост се движите.',
@@ -945,6 +995,37 @@ class AppLocalizations {
   String get speedDialNoActiveSegment => _value('speedDialNoActiveSegment');
   String get introTitle => _value('introTitle');
   String get introSubtitle => _value('introSubtitle');
+  String get introInstructionsTitle => _value('introInstructionsTitle');
+  String get introInstructionsAverageTitle =>
+      _value('introInstructionsAverageTitle');
+  String get introInstructionsAverageBody =>
+      _value('introInstructionsAverageBody');
+  String get introInstructionsAverageStateGood =>
+      _value('introInstructionsAverageStateGood');
+  String get introInstructionsAverageStateWarning =>
+      _value('introInstructionsAverageStateWarning');
+  String get introInstructionsAverageStateOver =>
+      _value('introInstructionsAverageStateOver');
+  String get introInstructionsVoiceTitle =>
+      _value('introInstructionsVoiceTitle');
+  String get introInstructionsVoiceBody =>
+      _value('introInstructionsVoiceBody');
+  String get introInstructionsVoiceEnterTitle =>
+      _value('introInstructionsVoiceEnterTitle');
+  String get introInstructionsVoiceEnterBody =>
+      _value('introInstructionsVoiceEnterBody');
+  String get introInstructionsVoiceSpeedTitle =>
+      _value('introInstructionsVoiceSpeedTitle');
+  String get introInstructionsVoiceSpeedBody =>
+      _value('introInstructionsVoiceSpeedBody');
+  String get introInstructionsVoiceApproachTitle =>
+      _value('introInstructionsVoiceApproachTitle');
+  String get introInstructionsVoiceApproachBody =>
+      _value('introInstructionsVoiceApproachBody');
+  String get introInstructionsVoiceExitTitle =>
+      _value('introInstructionsVoiceExitTitle');
+  String get introInstructionsVoiceExitBody =>
+      _value('introInstructionsVoiceExitBody');
   String get introMetricsTitle => _value('introMetricsTitle');
   String get introMetricCurrentSpeedTitle =>
       _value('introMetricCurrentSpeedTitle');

--- a/lib/features/map/presentation/pages/map/widgets/map_intro_overlay.dart
+++ b/lib/features/map/presentation/pages/map/widgets/map_intro_overlay.dart
@@ -20,6 +20,52 @@ class MapIntroOverlay extends StatelessWidget {
     final localizations = AppLocalizations.of(context);
     final bool isDark = theme.brightness == Brightness.dark;
 
+    final instructions = <_IntroInstructionData>[
+      _IntroInstructionData(
+        icon: Icons.insights_outlined,
+        title: localizations.introInstructionsAverageTitle,
+        body: localizations.introInstructionsAverageBody,
+        children: [
+          _AverageSpeedVisual(
+            goodLabel: localizations.introInstructionsAverageStateGood,
+            warningLabel: localizations.introInstructionsAverageStateWarning,
+            overLabel: localizations.introInstructionsAverageStateOver,
+          ),
+        ],
+      ),
+      _IntroInstructionData(
+        icon: Icons.record_voice_over_outlined,
+        title: localizations.introInstructionsVoiceTitle,
+        body: localizations.introInstructionsVoiceBody,
+        children: [
+          _VoiceTimelineVisual(
+            steps: [
+              _VoiceTimelineStepData(
+                icon: Icons.flag_circle_outlined,
+                title: localizations.introInstructionsVoiceEnterTitle,
+                description: localizations.introInstructionsVoiceEnterBody,
+              ),
+              _VoiceTimelineStepData(
+                icon: Icons.speed_outlined,
+                title: localizations.introInstructionsVoiceSpeedTitle,
+                description: localizations.introInstructionsVoiceSpeedBody,
+              ),
+              _VoiceTimelineStepData(
+                icon: Icons.route_outlined,
+                title: localizations.introInstructionsVoiceApproachTitle,
+                description: localizations.introInstructionsVoiceApproachBody,
+              ),
+              _VoiceTimelineStepData(
+                icon: Icons.check_circle_outline,
+                title: localizations.introInstructionsVoiceExitTitle,
+                description: localizations.introInstructionsVoiceExitBody,
+              ),
+            ],
+          ),
+        ],
+      ),
+    ];
+
     final metrics = <_IntroMetricData>[
       _IntroMetricData(
         icon: Icons.speed,
@@ -112,6 +158,8 @@ class MapIntroOverlay extends StatelessWidget {
                       child: _IntroContentCard(
                         title: localizations.introTitle,
                         subtitle: localizations.introSubtitle,
+                        instructionsTitle: localizations.introInstructionsTitle,
+                        instructions: instructions,
                         metricsTitle: localizations.introMetricsTitle,
                         actionsTitle: localizations.introSidebarTitle,
                         metrics: metrics,
@@ -155,10 +203,26 @@ class _IntroActionData {
   final String description;
 }
 
+class _IntroInstructionData {
+  const _IntroInstructionData({
+    required this.icon,
+    required this.title,
+    required this.body,
+    this.children = const <Widget>[],
+  });
+
+  final IconData icon;
+  final String title;
+  final String body;
+  final List<Widget> children;
+}
+
 class _IntroContentCard extends StatelessWidget {
   const _IntroContentCard({
     required this.title,
     required this.subtitle,
+    required this.instructionsTitle,
+    required this.instructions,
     required this.metricsTitle,
     required this.actionsTitle,
     required this.metrics,
@@ -169,6 +233,8 @@ class _IntroContentCard extends StatelessWidget {
 
   final String title;
   final String subtitle;
+  final String instructionsTitle;
+  final List<_IntroInstructionData> instructions;
   final String metricsTitle;
   final String actionsTitle;
   final List<_IntroMetricData> metrics;
@@ -223,6 +289,18 @@ class _IntroContentCard extends StatelessWidget {
                     ],
                   ),
                 ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            Text(instructionsTitle, style: sectionStyle),
+            const SizedBox(height: 16),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (int i = 0; i < instructions.length; i++) ...[
+                  _IntroInstructionCard(data: instructions[i]),
+                  if (i < instructions.length - 1) const SizedBox(height: 16),
+                ],
               ],
             ),
             const SizedBox(height: 28),
@@ -329,6 +407,291 @@ class _IntroMetricCard extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _IntroInstructionCard extends StatelessWidget {
+  const _IntroInstructionCard({required this.data});
+
+  final _IntroInstructionData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+
+    final Color borderColor =
+        palette.divider.withOpacity(isDark ? 0.8 : 0.45);
+    final Color backgroundColor =
+        palette.surface.withOpacity(isDark ? 0.78 : 0.96);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: borderColor),
+        color: backgroundColor,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  decoration: BoxDecoration(
+                    color: palette.primary.withOpacity(isDark ? 0.22 : 0.14),
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  padding: const EdgeInsets.all(12),
+                  child: Icon(data.icon, color: palette.primary, size: 28),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        data.title,
+                        style: theme.textTheme.titleMedium
+                            ?.copyWith(fontWeight: FontWeight.w600),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        data.body,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: palette.secondaryText,
+                          height: 1.45,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            if (data.children.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              ...data.children,
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AverageSpeedStateData {
+  const _AverageSpeedStateData({
+    required this.color,
+    required this.label,
+  });
+
+  final Color color;
+  final String label;
+}
+
+class _AverageSpeedVisual extends StatelessWidget {
+  const _AverageSpeedVisual({
+    required this.goodLabel,
+    required this.warningLabel,
+    required this.overLabel,
+  });
+
+  final String goodLabel;
+  final String warningLabel;
+  final String overLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final states = <_AverageSpeedStateData>[
+      _AverageSpeedStateData(color: Colors.green, label: goodLabel),
+      _AverageSpeedStateData(color: Colors.amber, label: warningLabel),
+      _AverageSpeedStateData(color: Colors.redAccent, label: overLabel),
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final bool horizontal = constraints.maxWidth >= 520;
+        if (horizontal) {
+          return Row(
+            children: [
+              for (int i = 0; i < states.length; i++) ...[
+                Expanded(child: _AverageSpeedStateTile(data: states[i])),
+                if (i < states.length - 1) const SizedBox(width: 12),
+              ],
+            ],
+          );
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (int i = 0; i < states.length; i++) ...[
+              _AverageSpeedStateTile(data: states[i]),
+              if (i < states.length - 1) const SizedBox(height: 12),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _AverageSpeedStateTile extends StatelessWidget {
+  const _AverageSpeedStateTile({required this.data});
+
+  final _AverageSpeedStateData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(18),
+        gradient: LinearGradient(
+          colors: [
+            data.color.withOpacity(0.85),
+            data.color.withOpacity(0.6),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(Icons.speed, color: Colors.white.withOpacity(0.95), size: 24),
+            const SizedBox(height: 12),
+            Text(
+              data.label,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: Colors.white,
+                height: 1.4,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _VoiceTimelineStepData {
+  const _VoiceTimelineStepData({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+}
+
+class _VoiceTimelineVisual extends StatelessWidget {
+  const _VoiceTimelineVisual({required this.steps});
+
+  final List<_VoiceTimelineStepData> steps;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = AppColors.of(context);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final bool horizontal = constraints.maxWidth >= 560;
+        if (horizontal) {
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              for (int i = 0; i < steps.length; i++) ...[
+                Expanded(child: _VoiceTimelineStep(data: steps[i])),
+                if (i < steps.length - 1)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 32),
+                    child: SizedBox(
+                      width: 32,
+                      child: Divider(
+                        color: palette.divider.withOpacity(0.6),
+                        thickness: 2,
+                      ),
+                    ),
+                  ),
+              ],
+            ],
+          );
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (int i = 0; i < steps.length; i++) ...[
+              _VoiceTimelineStep(data: steps[i]),
+              if (i < steps.length - 1)
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Container(
+                    width: 2,
+                    height: 24,
+                    margin:
+                        const EdgeInsets.symmetric(vertical: 8, horizontal: 28),
+                    color: palette.divider.withOpacity(0.6),
+                  ),
+                ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _VoiceTimelineStep extends StatelessWidget {
+  const _VoiceTimelineStep({required this.data});
+
+  final _VoiceTimelineStepData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = AppColors.of(context);
+    final bool isDark = theme.brightness == Brightness.dark;
+
+    final Color bubbleColor =
+        palette.primary.withOpacity(isDark ? 0.22 : 0.12);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            color: bubbleColor,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          padding: const EdgeInsets.all(14),
+          child: Icon(data.icon, color: palette.primary, size: 26),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          data.title,
+          style: theme.textTheme.titleSmall
+              ?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          data.description,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: palette.secondaryText,
+            height: 1.4,
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- add localized copy that explains average-speed color changes and voice guidance cues
- extend the map intro overlay with new instructional cards, color visuals, and a voice timeline

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690781cb0534832dbb6c44680c0abf17