### PR TITLE
Require forward heading when entering segments

### DIFF
--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -295,7 +295,10 @@ class _MapPageState extends State<MapPage>
     final firstFix = LatLng(pos.latitude, pos.longitude);
     _userLatLng = firstFix;
     _center = firstFix;
-    final segEvent = _segmentTracker.handleLocationUpdate(current: firstFix);
+    final segEvent = _segmentTracker.handleLocationUpdate(
+      current: firstFix,
+      headingDegrees: _userHeading,
+    );
     _applySegmentEvent(segEvent);
     _nextCameraCheckAt = _segmentsService.calculateNextCameraCheck(
       position: firstFix,
@@ -507,7 +510,10 @@ class _MapPageState extends State<MapPage>
       now: now,
       nextCameraCheckAt: _nextCameraCheckAt,
     )) {
-      final segEvent = _segmentTracker.handleLocationUpdate(current: next);
+      final segEvent = _segmentTracker.handleLocationUpdate(
+        current: next,
+        headingDegrees: _userHeading,
+      );
       _applySegmentEvent(segEvent, now: now);
       _nextCameraCheckAt = _segmentsService.calculateNextCameraCheck(
         position: next,

--- a/lib/features/segments/domain/tracking/geometry_extensions.dart
+++ b/lib/features/segments/domain/tracking/geometry_extensions.dart
@@ -183,6 +183,26 @@ extension _SegmentTrackerGeometry on SegmentTracker {
     final double diff = (normalizedA - normalizedB).abs() % 360.0;
     return diff > 180.0 ? 360.0 - diff : diff;
   }
+
+  double? _segmentHeadingAtStart(List<GeoPoint> path) {
+    if (path.length < 2) {
+      return null;
+    }
+
+    for (int i = 0; i < path.length - 1; i++) {
+      final GeoPoint from = path[i];
+      final GeoPoint to = path[i + 1];
+      final double segmentLength = _distanceBetween(from, to);
+      if (!segmentLength.isFinite) {
+        continue;
+      }
+      if (segmentLength >= _minimumHeadingSegmentLengthMeters) {
+        return _bearingBetweenPoints(from, to);
+      }
+    }
+
+    return _bearingBetweenPoints(path.first, path.last);
+  }
 }
 
 /// Captures the result of projecting a point onto a polyline.


### PR DESCRIPTION
## Summary
- pass the user's heading into the segment tracker when processing location updates
- reject start geofence entries whose heading is more than 90° off the segment's forward bearing
- derive segment entry bearings from geometry with a minimum-length guard to avoid degenerate paths

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6909114affd0832dbda0dc989901e0f9