### PR TITLE
Delay Bulgarian upcoming cue after segment exit

### DIFF
--- a/lib/features/map/services/segment_ui_service.dart
+++ b/lib/features/map/services/segment_ui_service.dart
@@ -27,6 +27,10 @@ class SegmentUiService {
     required AppLocalizations localizations,
     required UpcomingSegmentCueService cueService,
   }) {
+    if (event.endedSegment) {
+      cueService.notifySegmentExit();
+    }
+
     final Iterable<SegmentDebugPath> paths = event.debugData.candidatePaths;
     if (paths.isEmpty) {
       cueService.reset();


### PR DESCRIPTION
## Summary
- suppress the Bulgarian upcoming segment voice cue immediately after exiting a monitored segment to avoid overlapping prompts
- record segment exits so the cue can resume once the exit announcement finishes
- ensure Bulgarian detection accepts extended locale codes while keeping the reset logic aligned

## Testing
- Not run (Flutter CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_6909140d7858832d8980998c5498d271