### PR TITLE
Prevent repeated Bulgarian approaching segment cue

### DIFF
--- a/lib/features/map/services/upcoming_segment_cue_service.dart
+++ b/lib/features/map/services/upcoming_segment_cue_service.dart
@@ -17,6 +17,7 @@ class UpcomingSegmentCueService {
   bool _hasPlayed = false;
   bool _useBulgarianVoice = false;
   DateTime? _lastSegmentExitAt;
+  String? _recentlyExitedSegmentId;
 
   static const Duration _segmentExitVoiceHold = Duration(seconds: 5);
   GuidanceAudioPolicy _audioPolicy = const GuidanceAudioPolicy(
@@ -50,8 +51,9 @@ class UpcomingSegmentCueService {
     _useBulgarianVoice = useBulgarian;
   }
 
-  void notifySegmentExit() {
+  void notifySegmentExit({String? segmentId}) {
     _lastSegmentExitAt = DateTime.now();
+    _recentlyExitedSegmentId = segmentId;
   }
 
   void updateCue(SegmentDebugPath upcoming) {
@@ -65,6 +67,13 @@ class UpcomingSegmentCueService {
 
     if (distance >= 500) {
       _hasPlayed = false;
+      if (_recentlyExitedSegmentId == segmentId) {
+        _recentlyExitedSegmentId = null;
+      }
+      return;
+    }
+
+    if (_recentlyExitedSegmentId == segmentId) {
       return;
     }
 
@@ -97,6 +106,7 @@ class UpcomingSegmentCueService {
     _segmentId = null;
     _hasPlayed = false;
     _lastSegmentExitAt = null;
+    _recentlyExitedSegmentId = null;
   }
 
   Future<void> dispose() => _player.dispose();


### PR DESCRIPTION
## Summary
- remember the previously active segment id so exit cues can flag the completed segment
- suppress upcoming segment voice prompts for recently exited segments until the driver is clear
- reset recent segment exit tracking when cues are cleared

## Testing
- not run (dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690a4f4f70a0832db27e20614fbf6f38