### PR TITLE
Skip approaching cue when already inside start geofence

### DIFF
--- a/lib/features/map/services/segment_ui_service.dart
+++ b/lib/features/map/services/segment_ui_service.dart
@@ -65,6 +65,9 @@ class SegmentUiService {
 
     SegmentDebugPath? upcoming;
     for (final path in paths) {
+      if (path.startHit) {
+        continue;
+      }
       final double startDist = path.startDistanceMeters;
       if (!startDist.isFinite) continue;
       if (startDist <= 500) {


### PR DESCRIPTION
## Summary
- ignore candidate segments whose start geofence is already active when picking an upcoming cue
- prevents the Bulgarian "approaching segment" voice line from playing immediately after exiting a segment

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690a5c4a61d4832dab25ebad5040a51f