### PR TITLE
Throttle Bulgarian upcoming cue after exits

### DIFF
--- a/lib/features/map/services/segment_ui_service.dart
+++ b/lib/features/map/services/segment_ui_service.dart
@@ -65,6 +65,9 @@ class SegmentUiService {
 
     SegmentDebugPath? upcoming;
     for (final path in paths) {
+      if (path.startHit) {
+        continue;
+      }
       final double startDist = path.startDistanceMeters;
       if (!startDist.isFinite) continue;
       if (startDist <= 500) {

--- a/lib/features/map/services/upcoming_segment_cue_service.dart
+++ b/lib/features/map/services/upcoming_segment_cue_service.dart
@@ -4,6 +4,7 @@ import 'package:audioplayers/audioplayers.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/guidance_audio_controller.dart';
 import 'package:toll_cam_finder/features/segments/domain/tracking/segment_tracker.dart';
+import 'package:toll_cam_finder/shared/audio/bulgarian_voice_cooldown.dart';
 import 'package:toll_cam_finder/shared/audio/navigation_audio_context.dart';
 
 class UpcomingSegmentCueService {
@@ -71,9 +72,10 @@ class UpcomingSegmentCueService {
     final bool canPlayVoice =
         _useBulgarianVoice ? _audioPolicy.allowSpeech : _audioPolicy.allowAlertTones;
     if (_useBulgarianVoice &&
-        _lastSegmentExitAt != null &&
-        DateTime.now().difference(_lastSegmentExitAt!) <
-            _segmentExitVoiceHold) {
+        (BulgarianVoiceCooldown.isExitVoiceCoolingDown(_segmentExitVoiceHold) ||
+            (_lastSegmentExitAt != null &&
+                DateTime.now().difference(_lastSegmentExitAt!) <
+                    _segmentExitVoiceHold))) {
       return;
     }
 

--- a/lib/features/segments/domain/tracking/segment_guidance_controller.dart
+++ b/lib/features/segments/domain/tracking/segment_guidance_controller.dart
@@ -8,6 +8,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:toll_cam_finder/core/constants.dart';
 import 'package:toll_cam_finder/features/map/domain/controllers/guidance_audio_controller.dart';
 import 'package:toll_cam_finder/features/segments/domain/tracking/segment_tracker.dart';
+import 'package:toll_cam_finder/shared/audio/bulgarian_voice_cooldown.dart';
 import 'package:toll_cam_finder/shared/audio/navigation_audio_context.dart';
 
 class SegmentGuidanceUiModel {
@@ -856,6 +857,10 @@ class SegmentGuidanceController {
       announcement.averageKph,
       bulgarian: false,
     );
+
+    if (_useBulgarianVoice) {
+      BulgarianVoiceCooldown.markExitVoicePlayed();
+    }
 
     await _announceLocalizedSpeech(
       englishMessage:

--- a/lib/shared/audio/bulgarian_voice_cooldown.dart
+++ b/lib/shared/audio/bulgarian_voice_cooldown.dart
@@ -1,0 +1,17 @@
+class BulgarianVoiceCooldown {
+  BulgarianVoiceCooldown._();
+
+  static DateTime? _lastExitVoiceAt;
+
+  static void markExitVoicePlayed() {
+    _lastExitVoiceAt = DateTime.now();
+  }
+
+  static bool isExitVoiceCoolingDown(Duration hold) {
+    final DateTime? last = _lastExitVoiceAt;
+    if (last == null) {
+      return false;
+    }
+    return DateTime.now().difference(last) < hold;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared cooldown helper that remembers when the Bulgarian exit prompt was last spoken
- mark the cooldown when the segment exit voice line plays in the guidance controller
- consult the cooldown in the upcoming segment cue service so the Bulgarian "approaching segment" prompt is skipped immediately after an exit

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690a5c4a61d4832dab25ebad5040a51f