### PR TITLE
Prevent Bulgarian upcoming cue immediately after exit

### DIFF
--- a/lib/features/map/services/segment_ui_service.dart
+++ b/lib/features/map/services/segment_ui_service.dart
@@ -4,6 +4,8 @@ import 'package:toll_cam_finder/features/segments/domain/tracking/segment_tracke
 import 'upcoming_segment_cue_service.dart';
 
 class SegmentUiService {
+  bool _hadActiveSegment = false;
+
   SegmentDebugPath? resolveActiveSegmentPath(
     Iterable<SegmentDebugPath> paths,
     SegmentTrackerEvent event,
@@ -29,6 +31,15 @@ class SegmentUiService {
   }) {
     if (event.endedSegment) {
       cueService.notifySegmentExit();
+    }
+
+    if (event.activeSegmentId == null) {
+      if (_hadActiveSegment && !event.endedSegment) {
+        cueService.notifySegmentExit();
+      }
+      _hadActiveSegment = false;
+    } else {
+      _hadActiveSegment = true;
     }
 
     final Iterable<SegmentDebugPath> paths = event.debugData.candidatePaths;


### PR DESCRIPTION
## Summary
- track whether a segment was previously active in the segment UI service
- notify the upcoming segment cue of exits even when the tracker stops reporting a segment id

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690a5fb5d218832da48efa1b6a7e6867